### PR TITLE
Performance increments

### DIFF
--- a/backend/airweave/platform/scheduler.py
+++ b/backend/airweave/platform/scheduler.py
@@ -47,7 +47,7 @@ class PlatformScheduler:
         """Initialize the scheduler."""
         self.running = False
         self.task: Optional[asyncio.Task] = None
-        self.check_interval = 1  # Check every 1 second
+        self.check_interval = 5 # Check every 5 seconds to reduce system load
 
     async def update_all_next_scheduled_runs(self):
         """Update all next_scheduled_run values for syncs with cron schedules.

--- a/backend/airweave/platform/sources/mysql.py
+++ b/backend/airweave/platform/sources/mysql.py
@@ -56,7 +56,7 @@ class MySQLSource(BaseSource):
     def __init__(self):
         """Initialize the MySQL source."""
         self.pool: Optional[aiomysql.Pool] = None
-        self.entity_classes: Dict[str, Type[PolymorphicEntity]] = {}
+        self.entity_classes: Dict[str, Type[PolymorphicEntity]] = dict()
 
     @classmethod
     async def create(cls, config: Dict[str, Any]) -> "MySQLSource":

--- a/backend/airweave/platform/sources/notion.py
+++ b/backend/airweave/platform/sources/notion.py
@@ -48,9 +48,9 @@ class NotionSource(BaseSource):
             current_time = asyncio.get_event_loop().time()
 
             # Remove old request times
-            self._request_times = [
-                t for t in self._request_times if current_time - t < self.RATE_LIMIT_PERIOD
-            ]
+            self._request_times = list(
+                filter(lambda t: current_time - t < self.RATE_LIMIT_PERIOD, self._request_times)
+            )
 
             if len(self._request_times) >= self.RATE_LIMIT_REQUESTS:
                 # Wait until enough time has passed

--- a/frontend/src/components/sync/SyncJobsTable.tsx
+++ b/frontend/src/components/sync/SyncJobsTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import {
   Table,
   TableBody,
@@ -25,13 +25,17 @@ interface SyncJobsTableProps {
   onJobSelect: (jobId: string) => void;
 }
 
-export const SyncJobsTable: React.FC<SyncJobsTableProps> = ({ 
-  syncId, 
+export const SyncJobsTable: React.FC<SyncJobsTableProps> = ({
+  syncId,
   onTotalRunsChange,
-  onJobSelect 
+  onJobSelect
 }) => {
   const [jobs, setJobs] = useState<SyncJob[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  const handleRowClick = useCallback((jobId: string) => {
+    onJobSelect(jobId);
+  }, [onJobSelect]);
 
   useEffect(() => {
     const fetchJobs = async () => {
@@ -54,10 +58,6 @@ export const SyncJobsTable: React.FC<SyncJobsTableProps> = ({
     return <div className="p-6">Loading jobs...</div>;
   }
 
-  const handleRowClick = (jobId: string) => {
-    onJobSelect(jobId);
-  };
-
   return (
     <div className="p-6">
       <div className="flex justify-between items-center mb-6">
@@ -79,8 +79,8 @@ export const SyncJobsTable: React.FC<SyncJobsTableProps> = ({
         </TableHeader>
         <TableBody>
           {jobs.map((job) => (
-            <TableRow 
-              key={job.id} 
+            <TableRow
+              key={job.id}
               onClick={() => handleRowClick(job.id)}
               className="cursor-pointer hover:bg-muted/50"
             >
@@ -88,22 +88,21 @@ export const SyncJobsTable: React.FC<SyncJobsTableProps> = ({
                 {format(new Date(job.created_at), "MMM d, yyyy HH:mm")}
               </TableCell>
               <TableCell>
-                {job.completed_at 
+                {job.completed_at
                   ? format(new Date(job.completed_at), "MMM d, yyyy HH:mm")
                   : '-'
                 }
               </TableCell>
               <TableCell>
                 <span
-                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                    job.status === "completed"
+                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${job.status === "completed"
                       ? "bg-green-100 text-green-800"
                       : job.status === "failed"
-                      ? "bg-red-100 text-red-800"
-                      : job.status === "running"
-                      ? "bg-blue-100 text-blue-800"
-                      : "bg-yellow-100 text-yellow-800"
-                  }`}
+                        ? "bg-red-100 text-red-800"
+                        : job.status === "running"
+                          ? "bg-blue-100 text-blue-800"
+                          : "bg-yellow-100 text-yellow-800"
+                    }`}
                 >
                   {job.status}
                 </span>

--- a/frontend/src/hooks/useSyncSubscription.ts
+++ b/frontend/src/hooks/useSyncSubscription.ts
@@ -15,13 +15,13 @@ export function useSyncSubscription(jobId?: string | null) {
     if (!jobId) return;
 
     const url = `http://localhost:8001/sync/job/${jobId}/subscribe`; // make sure to use the correct URL
-    const es = new EventSource(url);
+    const es = new EventSource(url, { withCredentials: true }); /* Add cleanup in useEffect return */
     eventSourceRef.current = es;
 
     es.onmessage = (event) => {
       try {
         const data: SyncUpdate = JSON.parse(event.data);
-        setUpdates((prev) => [...prev, data]);
+        setUpdates((prev) => prev.concat(data));
       } catch (err) {
         console.error("Failed to parse SSE data:", err);
       }

--- a/frontend/src/pages/ViewEditSync.tsx
+++ b/frontend/src/pages/ViewEditSync.tsx
@@ -94,21 +94,17 @@ const ViewEditSync = () => {
       const syncJobs: SyncJob[] = await jobsResponse.json();
 
       // Sort jobs by created_at date (newest first)
-      const sortedJobs = syncJobs.sort((a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      );
+      const sortedJobs = [...syncJobs].sort((a, b) => +new Date(b.created_at) - +new Date(a.created_at));
 
       // Set the most recent job as the last sync
       if (sortedJobs.length > 0) {
         setLastSync(sortedJobs[0]);
 
         // Calculate total runtime across all completed jobs
-        let totalTime = 0;
-        syncJobs.forEach(job => {
-          if (job.started_at && job.ended_at) {
-            totalTime += new Date(job.ended_at).getTime() - new Date(job.started_at).getTime();
-          }
-        });
+        const totalTime = syncJobs.reduce((acc, job) =>
+          acc + (job.started_at && job.ended_at ? +new Date(job.ended_at) - +new Date(job.started_at) : 0),
+          0
+        );
         setTotalRuntime(totalTime);
 
         // If the job is still running, set up a polling interval to check for updates
@@ -186,7 +182,7 @@ const ViewEditSync = () => {
             destination: {
               type: destination.integration_type?.toLowerCase() ?? 'Destination',
               name: destination.name ?? 'Native Airweave',
-              shortName: destination.short_name ?? ( destinationData.short_name === 'weaviate_native' ? 'Native' : 'unknown')
+              shortName: destination.short_name ?? (destinationData.short_name === 'weaviate_native' ? 'Native' : 'unknown')
             },
             userId: syncData.created_by_email,
             organizationId: syncData.organization_id,
@@ -673,9 +669,9 @@ const ViewEditSync = () => {
         )}
 
         {/* Second row: Sync DAG (full width) */}
-          <Card className="border rounded-lg overflow-hidden px-3 py-2">
-            <SyncDagEditor syncId={id || ''} />
-          </Card>
+        <Card className="border rounded-lg overflow-hidden px-3 py-2">
+          <SyncDagEditor syncId={id || ''} />
+        </Card>
 
         {/* Sync Jobs Table */}
         <div>


### PR DESCRIPTION
## Backend
- Changed scheduler check interval from 1s to 5s in `scheduler.py`
- Updated MySQL source initialization to use `dict()` constructor in `mysql.py`
- Modified rate limiting implementation to use `filter()` instead of list comprehension in `notion.py`

## Frontend
- Added `useCallback` hook for event handlers in [SyncJobsTable](cci:1://file:///home/ailove/airweave/frontend/src/components/sync/SyncJobsTable.tsx:27:0-118:2)
- Updated array sorting method in `ViewEditSync`
- Changed array manipulation from `forEach` to `reduce` in `ViewEditSync`
- Added `withCredentials` to EventSource in `useSyncSubscription`
- Changed state update method from spread operator to `concat` in `useSyncSubscription`