### PR TITLE
fix: dropbox integration

### DIFF
--- a/backend/airweave/platform/entities/dropbox.py
+++ b/backend/airweave/platform/entities/dropbox.py
@@ -1,53 +1,148 @@
 """Dropbox entity schemas."""
 
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from pydantic import Field
 
-from airweave.platform.entities._base import ChunkEntity
+from airweave.platform.entities._base import ChunkEntity, FileEntity
 
 
 class DropboxAccountEntity(ChunkEntity):
-    """Schema for Dropbox account-level entities (e.g., user or team info).
+    """Schema for Dropbox account-level entities based on the Dropbox API.
 
-    For MVP purposes, store minimal fields such as account ID, display name, and email.
+    REQUIRED fields from ChunkEntity (must be provided):
+    - entity_id: ID of the entity this represents in the source
+    - breadcrumbs: List of breadcrumbs for this entity (empty for top-level accounts)
+
+    OPTIONAL fields from ChunkEntity (automatically populated if available):
+    - Other inherited fields from ChunkEntity
     """
 
-    display_name: str
-    account_id: str
-    email: Optional[str] = None
-    profile_photo_url: Optional[str] = None
-    is_team: bool = False  # Flag to indicate if this relates to a Dropbox Business/Team
+    # Core identification fields
+    account_id: str = Field(..., description="The user's unique Dropbox ID")
+
+    # Name information
+    name: str = Field(..., description="Name for display representing the user's Dropbox account")
+    abbreviated_name: Optional[str] = Field(
+        None, description="Abbreviated form of the person's name (typically initials)"
+    )
+    familiar_name: Optional[str] = Field(
+        None, description="Locale-dependent name (usually given name in US)"
+    )
+    given_name: Optional[str] = Field(None, description="Also known as first name")
+    surname: Optional[str] = Field(None, description="Also known as last name or family name")
+
+    # Account status and details
+    email: Optional[str] = Field(None, description="The user's email address")
+    email_verified: bool = Field(
+        False, description="Whether the user has verified their email address"
+    )
+    disabled: bool = Field(False, description="Whether the user has been disabled")
+
+    # Account type and relationships
+    account_type: Optional[str] = Field(
+        None, description="Type of account (basic, pro, business, etc.)"
+    )
+    is_teammate: bool = Field(
+        False, description="Whether this user is a teammate of the current user"
+    )
+    is_paired: bool = Field(
+        False, description="Whether the user has both personal and work accounts linked"
+    )
+    team_member_id: Optional[str] = Field(
+        None, description="The user's unique team member ID (if part of a team)"
+    )
+
+    # Regional and language settings
+    locale: Optional[str] = Field(
+        None, description="The language that the user specified (IETF language tag)"
+    )
+    country: Optional[str] = Field(
+        None, description="The user's two-letter country code (ISO 3166-1)"
+    )
+
+    # URLs and external references
+    profile_photo_url: Optional[str] = Field(None, description="URL for the profile photo")
+    referral_link: Optional[str] = Field(None, description="The user's referral link")
+
+    # Quota information
+    space_used: Optional[int] = Field(None, description="The user's total space usage in bytes")
+    space_allocated: Optional[int] = Field(
+        None, description="The user's total space allocation in bytes"
+    )
+
+    # Team information
+    team_info: Optional[Dict] = Field(
+        None, description="Information about the team if user is a member"
+    )
+
+    # Root information
+    root_info: Optional[Dict] = Field(
+        None, description="Information about the user's root namespace"
+    )
 
 
 class DropboxFolderEntity(ChunkEntity):
-    """Schema for Dropbox folder entities.
+    """Schema for Dropbox folder entities matching the Dropbox API.
 
-    Mirrors folder metadata (like path, IDs, etc.).
+    REQUIRED fields from ChunkEntity (must be provided):
+    - entity_id: ID of the entity this represents in the source
+    - breadcrumbs: List of breadcrumbs for this entity
+
+    OPTIONAL fields from ChunkEntity (automatically populated if available):
+    - Other inherited fields from ChunkEntity
     """
 
-    folder_id: str
-    name: str
-    path_lower: Optional[str] = None
-    path_display: Optional[str] = None
-    shared_folder_id: Optional[str] = None
-    is_team_folder: bool = False
+    # REQUIRED Core identification fields
+    folder_id: str = Field(..., description="Unique identifier for the folder")
+    name: str = Field(..., description="The name of the folder (last path component)")
+
+    # OPTIONAL Path information
+    path_lower: Optional[str] = Field(None, description="Lowercase full path starting with slash")
+    path_display: Optional[str] = Field(None, description="Display path with proper casing")
+
+    # OPTIONAL Complete sharing info object
+    sharing_info: Optional[Dict] = Field(None, description="Sharing information for the folder")
+
+    # OPTIONAL Key sharing fields extracted for convenience (from sharing_info)
+    read_only: bool = Field(False, description="Whether the folder is read-only")
+    traverse_only: bool = Field(False, description="Whether the folder can only be traversed")
+    no_access: bool = Field(False, description="Whether the folder cannot be accessed")
+
+    # OPTIONAL Custom properties/tags
+    property_groups: Optional[List[Dict]] = Field(None, description="Custom properties and tags")
 
 
-class DropboxFileEntity(ChunkEntity):
-    """Schema for Dropbox file entities.
+class DropboxFileEntity(FileEntity):
+    """Schema for Dropbox file entities matching the Dropbox API.
 
-    Includes core file metadata like file ID, path, size, timestamps.
+    REQUIRED fields from FileEntity (must be provided):
+    - file_id: ID of the file in the source system
+    - name: Name of the file
+    - download_url: URL to download the file
+
+    OPTIONAL fields from FileEntity (automatically populated if available):
+    - Other inherited fields from ChunkEntity
     """
 
-    file_id: str
-    name: str
-    path_lower: Optional[str] = None
-    path_display: Optional[str] = None
-    rev: Optional[str] = None
-    client_modified: Optional[datetime] = None
-    server_modified: Optional[datetime] = None
-    size: Optional[int] = None
-    is_downloadable: bool = True
-    sharing_info: Optional[Dict] = Field(default_factory=dict)
+    # Dropbox-specific fields - ALL OPTIONAL
+    path_lower: Optional[str] = Field(None, description="Lowercase full path in Dropbox")
+    path_display: Optional[str] = Field(None, description="Display path with proper casing")
+    rev: Optional[str] = Field(None, description="Unique identifier for the file revision")
+    client_modified: Optional[datetime] = Field(
+        None, description="When file was modified by client"
+    )
+    server_modified: Optional[datetime] = Field(
+        None, description="When file was modified on server"
+    )
+    is_downloadable: bool = Field(True, description="Whether file can be downloaded directly")
+    content_hash: Optional[str] = Field(
+        None, description="Dropbox content hash for integrity checks"
+    )
+
+    # Additional optional fields
+    sharing_info: Optional[Dict] = Field(None, description="Sharing information for the file")
+    has_explicit_shared_members: Optional[bool] = Field(
+        None, description="Whether file has explicit shared members"
+    )

--- a/backend/airweave/platform/transformers/default_file_chunker.py
+++ b/backend/airweave/platform/transformers/default_file_chunker.py
@@ -60,6 +60,7 @@ async def file_chunker(file: FileEntity) -> list[ParentEntity | ChunkEntity]:
             chunk = FileChunkClass(
                 name=f"{file.name} - Chunk {i + 1}",
                 entity_id=file.entity_id,
+                sync_id=file.sync_id,
                 parent_entity_id=parent.entity_id,
                 parent_db_entity_id=parent.db_entity_id,
                 md_content=chunk,


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed Dropbox integration with improved file handling and search capabilities. The PR removes the 100-item limit from the base CRUD method, adds sync_id to FileChunk for Qdrant searchability, and completely rebuilds the Dropbox integration with proper file entity support.

**Improvements**
- Enhanced Dropbox API integration with proper pagination, error handling, and file downloading
- Updated entity schemas to match Dropbox API structure for better data consistency
- Added retry logic with exponential backoff for API requests

<!-- End of auto-generated description by mrge. -->

Changes:
- Disable 100 limit from get_all crud_base method
- Dropbox integration
- Add sync_id to FileChunk so it is searchable in qdrant