### PR TITLE
Fix(image_converter): useable in case of either of the conversion tools or none

### DIFF
--- a/backend/airweave/platform/file_handling/conversion/converters/img_converter.py
+++ b/backend/airweave/platform/file_handling/conversion/converters/img_converter.py
@@ -313,6 +313,6 @@ class AsyncImageConverter(DocumentConverter):
 
         # Get response from LLM (default to vision model)
         response = await self.openai_client.chat.completions.create(
-            model="gpt-4-vision", messages=messages, max_tokens=300
+            model="gpt-4-turbo", messages=messages, max_tokens=300
         )
         return response.choices[0].message.content

--- a/backend/airweave/platform/file_handling/conversion/converters/img_converter.py
+++ b/backend/airweave/platform/file_handling/conversion/converters/img_converter.py
@@ -173,7 +173,6 @@ class AsyncImageConverter(DocumentConverter):
             Formatted metadata content
         """
         if not self.exiftool_available:
-            logger.info(f"Exiftool not available, skipping metadata extraction for {local_path}")
             return ""
 
         md_content = ""

--- a/backend/airweave/platform/file_handling/conversion/converters/img_converter.py
+++ b/backend/airweave/platform/file_handling/conversion/converters/img_converter.py
@@ -313,6 +313,6 @@ class AsyncImageConverter(DocumentConverter):
 
         # Get response from LLM (default to vision model)
         response = await self.openai_client.chat.completions.create(
-            model="gpt-4-vision-preview", messages=messages, max_tokens=300
+            model="gpt-4-vision", messages=messages, max_tokens=300
         )
         return response.choices[0].message.content

--- a/backend/airweave/platform/sources/_base.py
+++ b/backend/airweave/platform/sources/_base.py
@@ -60,7 +60,7 @@ class BaseSource:
             logger.error(f"No access token provided for file {file_entity.name}")
             raise ValueError(f"No access token available for processing file {file_entity.name}")
 
-        logger.info(f"Processing file entity: {file_entity.name} from URL: {url}")
+        logger.info(f"Processing file entity: {file_entity.name}")
 
         try:
             # Create stream (pass token as before)

--- a/backend/airweave/platform/sync/orchestrator.py
+++ b/backend/airweave/platform/sync/orchestrator.py
@@ -293,7 +293,8 @@ class EntityProcessor:
     ) -> None:
         """Handle INSERT action."""
         if len(processed_entities) == 0:
-            raise ValueError("No processed entities to persist")
+            logger.info("No processed entities to insert")
+            return
 
         # Prepare entities with parent reference
         for processed_entity in processed_entities:
@@ -332,7 +333,9 @@ class EntityProcessor:
     ) -> None:
         """Handle UPDATE action."""
         if len(processed_entities) == 0:
-            raise ValueError("No processed entities to persist")
+            # TODO: keep track of skipped entities that could not be processed
+            logger.info("No processed entities to update")
+            return
 
         # Prepare entities with parent reference
         for processed_entity in processed_entities:

--- a/backend/airweave/platform/transformers/default_file_chunker.py
+++ b/backend/airweave/platform/transformers/default_file_chunker.py
@@ -83,7 +83,7 @@ async def file_chunker(file: FileEntity) -> list[ParentEntity | ChunkEntity]:
 
     if not file.local_path:
         logger.error(f"File {file.name} has no local path")
-        return
+        return []
 
     try:
         # Convert file to markdown
@@ -91,7 +91,7 @@ async def file_chunker(file: FileEntity) -> list[ParentEntity | ChunkEntity]:
 
         if not result or not result.text_content:
             logger.warning(f"No content extracted from file {file.name}")
-            return
+            return []
 
         # Max token size for embedding models (e.g. OpenAI's text-embedding-ada-002)
         max_chunk_size = 8191


### PR DESCRIPTION
Test completed successfully in these scenarios:
- with only mistral api key
- with only openai api key
- with only exiftools globally installed
- without anything
<!-- This is an auto-generated description by mrge. -->
---


## Summary by mrge
Improved image conversion to work with any available method: Mistral OCR, OpenAI image description, or exiftool metadata. If none are available, image conversion is skipped without errors.

- **Bug Fixes**
  - Fixed image conversion to use OpenAI if Mistral is missing, or exiftool if both are missing.
  - Updated logging and error handling to avoid crashes when no conversion method is available.
  - File chunker and orchestrator now handle empty results gracefully instead of raising errors.

<!-- End of auto-generated description by mrge. -->

