### PR TITLE
fix(postgresql): not found polymorphicEntity at runtime

### DIFF
--- a/backend/airweave/platform/sync/router.py
+++ b/backend/airweave/platform/sync/router.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave import crud
-from airweave.platform.entities._base import BaseEntity
+from airweave.platform.entities._base import BaseEntity, PolymorphicEntity
 from airweave.platform.locator import resource_locator
 from airweave.schemas.dag import DagNode, NodeType, SyncDag
 
@@ -92,6 +92,11 @@ class SyncDAGRouter:
         # First try direct lookup
         if entity_type in self.entity_map:
             return self.entity_map[entity_type]
+
+        # If entity is a subclass of PolymorphicEntity return placeholder
+        if hasattr(entity_type, "__mro__") and issubclass(entity_type, PolymorphicEntity):
+            RESERVED_TABLE_ENTITY_ID = UUID("11111111-1111-1111-1111-111111111111")
+            return RESERVED_TABLE_ENTITY_ID
 
         # For dynamically created classes, try to find by name pattern and module
         entity_name = entity_type.__name__


### PR DESCRIPTION
Subclass of polymorphicEntity gets placeholder definition_id so that it can be processed (without being transformed)

### Only tested: loading chat table with PostgreSQL source.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where subclasses of PolymorphicEntity could not be processed at runtime by assigning them a placeholder definition_id.

- **Bug Fixes**
  - Subclasses of PolymorphicEntity now receive a reserved definition_id, allowing them to be processed without transformation.
  - Improved table processing logic in the PostgreSQL source for better error handling and batch processing.

<!-- End of auto-generated description by mrge. -->

