### PR TITLE
Feat/restore test branch

### DIFF
--- a/backend/tests/unit/platform/sync/test_service.py
+++ b/backend/tests/unit/platform/sync/test_service.py
@@ -89,7 +89,7 @@ class TestSyncServiceRun:
         mock_sync_result = MagicMock(spec=schemas.Sync)
 
         # Mock get_db_context
-        with patch("airweave.platform.sync.service.get_db_context") as mock_get_db_context:
+        with patch("airweave.core.sync_service.get_db_context") as mock_get_db_context:
             mock_get_db_context.return_value = mock_db_context
 
             # Mock SyncContextFactory.create
@@ -99,7 +99,7 @@ class TestSyncServiceRun:
                 mock_create_context.return_value = mock_sync_context
 
                 # Mock sync_orchestrator.run
-                with patch("airweave.platform.sync.service.sync_orchestrator.run") as mock_run:
+                with patch("airweave.core.sync_service.sync_orchestrator.run") as mock_run:
                     mock_run.return_value = mock_sync_result
 
                     # Act
@@ -129,17 +129,17 @@ class TestSyncServiceRun:
         test_error = Exception("Test error")
 
         # Mock get_db_context
-        with patch("airweave.platform.sync.service.get_db_context") as mock_get_db_context:
+        with patch("airweave.core.sync_service.get_db_context") as mock_get_db_context:
             mock_get_db_context.return_value = mock_db_context
 
             # Mock SyncContextFactory.create to raise an exception
             with patch(
-                "airweave.platform.sync.service.SyncContextFactory.create"
+                "airweave.core.sync_service.SyncContextFactory.create"
             ) as mock_create_context:
                 mock_create_context.side_effect = test_error
 
                 # Mock logger.error
-                with patch("airweave.platform.sync.service.logger.error") as mock_logger_error:
+                with patch("airweave.core.sync_service.logger.error") as mock_logger_error:
                     # Act & Assert
                     service = SyncService()
                     with pytest.raises(Exception) as excinfo:

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -13,7 +13,8 @@ else
   echo "Auth disabled (no credentials or ENABLE_AUTH not set to true)"
 fi
 
-# Create runtime config with environment variables
+# Create config.js with runtime environment variables
+echo "Generating runtime config with API_URL=${API_URL:-/api}"
 cat > /app/dist/config.js << EOF
 window.ENV = {
   API_URL: "${API_URL:-/api}",
@@ -22,9 +23,17 @@ window.ENV = {
   AUTH0_CLIENT_ID: "${AUTH0_CLIENT_ID:-}",
   AUTH0_AUDIENCE: "${AUTH0_AUDIENCE:-}"
 };
+console.log("Runtime config loaded:", window.ENV);
 EOF
 
-echo "Configuration generated successfully"
+# Make sure config.js is loaded before any other scripts
+# First, backup the original index.html
+cp /app/dist/index.html /app/dist/index.html.bak
+
+# Insert config.js in the <head> section to ensure it loads first
+sed -i 's|</head>|  <script src="/config.js"></script>\n  </head>|' /app/dist/index.html
+
+echo "Runtime config injected successfully. API_URL set to: ${API_URL:-/api}"
 
 # Run the command
 exec serve -s /app/dist -l 8080 --no-clipboard --no-port-switching


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a Docker service manager for end-to-end OAuth sync tests and improved frontend runtime config injection.

- **Testing**
  - End-to-end OAuth sync tests now start and stop Docker containers automatically.
  - Added port checks and cleanup to avoid conflicts.

- **Frontend**
  - Runtime config is now injected into index.html before other scripts.
  - Added logging for loaded config and improved config file generation.

<!-- End of auto-generated description by mrge. -->

