### PR TITLE
Fix invalid dashboard route redirect by adding path constants

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ import { NotFound } from '@/pages/NotFound';
 import { AuthGuard } from '@/components/AuthGuard';
 import Login from '@/pages/Login';
 import Callback from '@/pages/Callback';
-import { protectedPaths, publicPaths } from './constants/paths';
+import { protectedPaths, publicPaths } from '@/constants/paths';
 
 function App() {
   // Initialize collections event listeners when the app loads

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { NotFound } from '@/pages/NotFound';
 import { AuthGuard } from '@/components/AuthGuard';
 import Login from '@/pages/Login';
 import Callback from '@/pages/Callback';
+import { protectedPaths, publicPaths } from './constants/paths';
 
 function App() {
   // Initialize collections event listeners when the app loads
@@ -26,19 +27,19 @@ function App() {
     <ThemeProvider defaultTheme="dark" storageKey="airweave-ui-theme">
       <Routes>
         {/* Public routes */}
-        <Route path="/login" element={<Login />} />
-        <Route path="/callback" element={<Callback />} />
+        <Route path={publicPaths.login} element={<Login />} />
+        <Route path={publicPaths.callback} element={<Callback />} />
 
         {/* Protected routes */}
         <Route element={<AuthGuard><DashboardLayout /></AuthGuard>}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/collections" element={<CollectionsView />} />
-          <Route path="/collections/:readable_id" element={<CollectionDetailView />} />
-          <Route path="/api-keys" />
-          <Route path="/chat" element={<Chat />} />
-          <Route path="/chat/:id" element={<Chat />} />
-          <Route path="/white-label" element={<WhiteLabel />} />
-          <Route path="/white-label/:tab" element={<WhiteLabel />} />
+          <Route path={protectedPaths.dashboard} element={<Dashboard />} />
+          <Route path={protectedPaths.collections} element={<CollectionsView />} />
+          <Route path={protectedPaths.collectionDetail} element={<CollectionDetailView />} />
+          <Route path={protectedPaths.apiKeys} />
+          <Route path={protectedPaths.chat} element={<Chat />} />
+          <Route path={protectedPaths.chatDetail} element={<Chat />} />
+          <Route path={protectedPaths.whiteLabel} element={<WhiteLabel />} />
+          <Route path={protectedPaths.whiteLabelTab} element={<WhiteLabel />} />
         </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/frontend/src/constants/paths.ts
+++ b/frontend/src/constants/paths.ts
@@ -1,0 +1,15 @@
+export const protectedPaths = {
+    dashboard: "/",
+    collections: "/collections",
+    collectionDetail: "/collections/:readable_id",
+    apiKeys: "/api-keys",
+    chat: "/chat",
+    chatDetail: "/chat/:id",
+    whiteLabel: "/white-label",
+    whiteLabelTab: "/white-label/:tab",
+}
+
+export const publicPaths = {
+    login: "/login",
+    callback: "/callback",
+}

--- a/frontend/src/pages/CollectionDetailView.tsx
+++ b/frontend/src/pages/CollectionDetailView.tsx
@@ -25,6 +25,7 @@ import SourceConnectionDetailView from "@/components/collection/SourceConnection
 import { emitCollectionEvent, COLLECTION_DELETED } from "@/lib/events";
 import { QueryToolAndLiveDoc } from '@/components/collection/QueryToolAndLiveDoc';
 import { ConnectFlow } from '@/components/shared';
+import { protectedPaths } from "@/constants/paths";
 
 // DeleteCollectionDialog component
 interface DeleteCollectionDialogProps {
@@ -360,7 +361,7 @@ const Collections = () => {
                     description: "Collection deleted successfully"
                 });
                 // Navigate back to dashboard after successful deletion
-                navigate("/dashboard");
+                navigate(protectedPaths.dashboard);
             } else {
                 const errorText = await response.text();
                 throw new Error(`Failed to delete collection: ${errorText}`);
@@ -462,7 +463,7 @@ const Collections = () => {
                     <div>{error}</div>
                 </Alert>
                 <div className="mt-4">
-                    <Button onClick={() => navigate("/dashboard")}>
+                    <Button onClick={() => navigate(protectedPaths.dashboard)}>
                         Return to Dashboard
                     </Button>
                 </div>


### PR DESCRIPTION
## Context
The issue is described in the https://github.com/airweave-ai/airweave/issues/196

## Changes
- [x] Added route paths constants for better center point of reference for all the pathnames.
- [x] Replaced all the routes in the `App.tsx` with the new path constants.
- [x] Replace all the hard coded dashboard navigation with the dashboard path constant.

## Test
Checkout to the branch follow the steps
* Create a new collection
* Once created, delete the collection.

Previously it would redirect to a `404` path `/dashboard` but now it won't.