### PR TITLE
Fix SQLAlchemy MissingGreenlet error during app startup

### DIFF
--- a/backend/airweave/db/init_db.py
+++ b/backend/airweave/db/init_db.py
@@ -3,12 +3,15 @@
 import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.util.concurrency import greenlet_spawn
 
 from airweave import crud, schemas
 from airweave.core.config import settings
 from airweave.db.init_db_native import init_db_with_native_connections
 
-
+async def init_db_with_greenlet(db: AsyncSession):
+    await greenlet_spawn(init_db, db)
+    
 async def init_db(db: AsyncSession) -> None:
     """Initialize the database with the first organization and superuser.
 

--- a/backend/airweave/main.py
+++ b/backend/airweave/main.py
@@ -26,7 +26,7 @@ from airweave.api.v1.api import api_router
 from airweave.core.config import settings
 from airweave.core.exceptions import NotFoundException, PermissionException
 from airweave.core.logging import logger
-from airweave.db.init_db import init_db
+from airweave.db.init_db import init_db, init_db_with_greenlet
 from airweave.db.session import AsyncSessionLocal
 from airweave.platform.db_sync import sync_platform_components
 from airweave.platform.entities._base import ensure_file_entity_models
@@ -45,7 +45,7 @@ async def lifespan(app: FastAPI):
             # Ensure all FileEntity subclasses have their parent and chunk models created
             ensure_file_entity_models()
             await sync_platform_components("airweave/platform", db)
-        await init_db(db)
+        await init_db_with_greenlet(db)
 
     # Start the sync scheduler
     await platform_scheduler.start()


### PR DESCRIPTION
Wrapped `init_db` in `greenlet_spawn` within the FastAPI lifespan context to ensure proper async SQLAlchemy context during initialization. This prevents MissingGreenlet errors caused by I/O attempts outside the required greenlet context during startup.

Fixes #265