### PR TITLE
Removed unnecessary ``` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ client.collections.create_collection(
 npm install @airweave/sdk
 # or
 yarn add @airweave/sdk
-```
 
 ```typescript
 import { AirweaveSDKClient, AirweaveSDKEnvironment } from "@airweave/sdk";


### PR DESCRIPTION
The extra ``` was disrupting the formatting of the TypeScript code.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed an extra code block marker from README.md to fix TypeScript code formatting.

<!-- End of auto-generated description by cubic. -->

