### PR TITLE
feat(redis): Use Redis PubSub

### DIFF
--- a/backend/airweave/core/config.py
+++ b/backend/airweave/core/config.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
         RUN_ALEMBIC_MIGRATIONS (bool): Whether to run the alembic migrations.
         RUN_DB_SYNC (bool): Whether to run the system sync to process sources,
             destinations, and entity types.
+        REDIS_HOST (str): The Redis server hostname.
+        REDIS_PORT (int): The Redis server port.
+        REDIS_PASSWORD (Optional[str]): The Redis password (if authentication is enabled).
+        REDIS_DB (int): The Redis database number.
         QDRANT_HOST (str): The Qdrant host.
         QDRANT_PORT (int): The Qdrant port.
         TEXT2VEC_INFERENCE_URL (str): The URL for text2vec-transformers inference service.
@@ -76,6 +80,12 @@ class Settings(BaseSettings):
 
     RUN_ALEMBIC_MIGRATIONS: bool = False
     RUN_DB_SYNC: bool = True
+
+    # Redis configuration
+    REDIS_HOST: str = "localhost"
+    REDIS_PORT: int = 6379
+    REDIS_PASSWORD: Optional[str] = None
+    REDIS_DB: int = 0
 
     QDRANT_HOST: Optional[str] = None
     QDRANT_PORT: Optional[int] = None

--- a/backend/airweave/core/redis_client.py
+++ b/backend/airweave/core/redis_client.py
@@ -1,0 +1,79 @@
+"""Redis client for Airweave."""
+
+import redis.asyncio as redis
+
+from airweave.core.config import settings
+from airweave.core.logging import logger
+
+
+class RedisClient:
+    """Redis client singleton for pubsub operations."""
+
+    def __init__(self):
+        """Initialize the Redis client."""
+        self.client = self._create_client()
+
+    def _create_client(self) -> redis.Redis:
+        """Create and configure the Redis client.
+
+        Returns:
+            redis.Redis: Configured Redis client instance.
+        """
+        return redis.Redis(
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            decode_responses=True,
+            socket_keepalive=True,
+            socket_keepalive_options={},
+            health_check_interval=30,
+            max_connections=50,
+        )
+
+    async def publish(self, channel: str, message: str) -> int:
+        """Publish a message to a channel.
+
+        Args:
+            channel: Channel name to publish to.
+            message: Message to publish (should be JSON string).
+
+        Returns:
+            int: Number of subscribers that received the message.
+        """
+        try:
+            return await self.client.publish(channel, message)
+        except Exception as e:
+            logger.warning(f"Redis publish failed for channel '{channel}': {e}")
+            return 0
+
+    async def subscribe(self, channel: str) -> redis.client.PubSub:
+        """Subscribe to a channel.
+
+        Args:
+            channel: Channel name to subscribe to.
+
+        Returns:
+            redis.client.PubSub: PubSub instance for listening to messages.
+        """
+        pubsub = self.client.pubsub()
+        await pubsub.subscribe(channel)
+        return pubsub
+
+    async def ping(self) -> bool:
+        """Test Redis connection.
+
+        Returns:
+            bool: True if connected, False otherwise.
+        """
+        try:
+            await self.client.ping()
+            return True
+        except Exception:
+            return False
+
+    async def close(self) -> None:
+        """Close Redis connection gracefully."""
+        await self.client.close()
+
+
+# Global singleton instance
+redis_client = RedisClient()

--- a/backend/airweave/core/sync_service.py
+++ b/backend/airweave/core/sync_service.py
@@ -1,7 +1,7 @@
 """Service for data synchronization."""
 
 from datetime import datetime
-from typing import AsyncGenerator, List, Optional, Union
+from typing import List, Optional, Union
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -15,7 +15,6 @@ from airweave.core.sync_job_service import sync_job_service
 from airweave.db.session import get_db_context
 from airweave.db.unit_of_work import UnitOfWork
 from airweave.platform.sync.factory import SyncFactory
-from airweave.platform.sync.pubsub import sync_pubsub
 
 
 class SyncService:
@@ -456,31 +455,6 @@ class SyncService:
             db=db, id=sync_id, current_user=current_user, with_connections=True
         )
         return updated_sync
-
-    async def subscribe_to_sync_job(
-        self,
-        job_id: UUID,
-    ) -> AsyncGenerator[str, None]:
-        """Subscribe to a sync job's progress.
-
-        Args:
-        ----
-            job_id (UUID): The ID of the job to subscribe to.
-
-        Returns:
-        -------
-            AsyncGenerator[str, None]: The event stream.
-
-        Raises:
-        ------
-            HTTPException: If the job is not found or completed.
-        """
-        queue = await sync_pubsub.subscribe(job_id)
-
-        if not queue:
-            raise HTTPException(status_code=404, detail="Sync job not found or completed")
-
-        return queue
 
 
 sync_service = SyncService()


### PR DESCRIPTION
Replace the in-memory pubsub with Redis pubsub. 
Then we can allow multiple nodes to share the pubsub.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the in-memory pubsub system with Redis PubSub to allow sync job updates to be shared across multiple nodes.

- **Dependencies**
  - Added Redis configuration and a new async Redis client.
  - Updated sync job pubsub logic to use Redis channels for publishing and subscribing.

<!-- End of auto-generated description by cubic. -->

