### PR TITLE
Fix/decryption error invalid api key

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-airweave}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-airweave1234!}
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-airweave}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-airweave1234!}
     ports:
-      - "5433:5432"
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
fx: Handle invalid API keys gracefully in read_api_keys endpoint

Previously, when encountering invalid/corrupted API keys, the endpoint would fail to return any keys. This fix improves error handling by:
- Skipping invalid keys instead of failing
- Returning an empty list when all keys are invalid
- Adding better logging for debugging invalid keys
- now if you reload the page there will be no error ,u can see all the keys

**Before**
![Screenshot 2025-05-31 at 5 07 49 PM](https://github.com/user-attachments/assets/85ba407d-45bc-43d4-955c-1f54b8408672)
***After the fix***
![Screenshot 2025-05-31 at 5 08 42 PM](https://github.com/user-attachments/assets/a953dd92-17fa-4b84-99f1-229828e53a58)


Fixes #682 