### PR TITLE
fix(test): SSE also sends heartbeat messages

### DIFF
--- a/backend/tests/e2e/smoke/test_public_api.py
+++ b/backend/tests/e2e/smoke/test_public_api.py
@@ -1022,6 +1022,10 @@ def test_sync_job_pubsub(api_url: str, job_id: str, headers: dict, timeout: int 
 
     # Verify message structure
     for msg in messages_received:
+        # Skip non-progress messages (connected, heartbeat, etc.)
+        if msg.get("type") in ["connected", "heartbeat", "error"]:
+            continue
+
         required_fields = [
             "inserted",
             "updated",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the SSE test to skip heartbeat, connected, and error messages when checking message structure. This prevents test failures from non-progress messages.

<!-- End of auto-generated description by cubic. -->

