### PR TITLE
Removed examples from the openapi spec that broke ts codegen

### DIFF
--- a/fern/definition/openapi-overrides.yml
+++ b/fern/definition/openapi-overrides.yml
@@ -1,0 +1,6 @@
+components:
+  schemas:
+    SourceConnectionCreate:
+      examples: null
+    SourceConnectionUpdate:
+      examples: null

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -1,6 +1,6 @@
 api:
-  specs:
-    - openapi: ./definition/openapi.json
+  path: ./definition/openapi.json
+  overrides: ./definition/openapi-overrides.yml
 
 groups:
   public:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed problematic examples from the OpenAPI spec to fix TypeScript SDK code generation errors.

- **Bug Fixes**
 - Set examples for SourceConnectionCreate and SourceConnectionUpdate schemas to null using an override file.
 - Updated generator config to apply the override.

<!-- End of auto-generated description by cubic. -->

