### PR TITLE
Fix AttributeError in LocalText2Vec by Declaring Key Model Fields

### DIFF
--- a/backend/airweave/platform/embedding_models/local_text2vec.py
+++ b/backend/airweave/platform/embedding_models/local_text2vec.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 import httpx
 
+from pydantic import Field
 from airweave.core.config import settings
 from airweave.core.logging import ContextualLogger
 from airweave.platform.decorators import embedding_model
@@ -21,8 +22,19 @@ from ._base import BaseEmbeddingModel
 class LocalText2Vec(BaseEmbeddingModel):
     """Local text2vec model configuration for embedding."""
 
-    def __init__(self, logger: ContextualLogger):
-        """Initialize the local text2vec model."""
+    # Configuration parameters as class attributes
+    vector_dimensions: int = 384  # MiniLM-L6-v2 default dimensions
+    model_name: str = "local-text2vec-transformers"
+    enabled: bool = True
+    inference_url: str = Field(default="", description="URL of the inference API") # Updated during initialization
+
+    def __init__(
+        self,
+        logger: Optional[ContextualLogger] = None,
+        **data  # Pass through to BaseEmbeddingModel/Pydantic, if relevant
+    ):
+        # Always call parent __init__ (esp. with Pydantic models!)
+        super().__init__(**data)
         self.logger = logger
 
     def model_post_init(self, __context) -> None:


### PR DESCRIPTION
**Problem**
Runtime errors (AttributeError) were raised because important fields like inference_url and vector_dimensions were not present on LocalText2Vec instances, due to being undeclared in the class.

**Solution**
Explicitly declare all necessary config/model parameters as class attributes with type hints.

Call the superclass constructor with any extra data to support Pydantic or other base models.

**Impact**
Completely fixes runtime AttributeError.

