### PR TITLE
chore: upgrade to `4.25.6`

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -6,7 +6,7 @@ groups:
   public:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.25.5
+        version: 4.25.6
         output:
           location: pypi
           package-name: airweave-sdk


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Upgraded the fern-python-sdk generator version from 4.25.5 to 4.25.6 in the configuration file.

<!-- End of auto-generated description by cubic. -->

