### PR TITLE
feat: enable setting payment method types in Stripe checkout via Stripe Dashboard

### DIFF
--- a/backend/airweave/integrations/stripe_client.py
+++ b/backend/airweave/integrations/stripe_client.py
@@ -140,7 +140,6 @@ class StripeClient:
 
             session_params = {
                 "customer": customer_id,
-                "payment_method_types": ["card"],
                 "line_items": [
                     {
                         "price": price_id,


### PR DESCRIPTION
Remove hard-coded payment_method_types restriction to allow Dashboard-configured payment methods like iDEAL and PayPal.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the Stripe payment method type restriction so Dashboard-configured payment options like iDEAL and PayPal can be used in checkout.

<!-- End of auto-generated description by cubic. -->

