### PR TITLE
fix(logging): add organization name to all ctx logs

### DIFF
--- a/backend/airweave/platform/sync/factory.py
+++ b/backend/airweave/platform/sync/factory.py
@@ -156,6 +156,7 @@ class SyncFactory:
                 "organization_id": str(ctx.organization.id),
                 "source_connection_id": str(source_connection_data["connection_id"]),
                 "collection_readable_id": str(collection.readable_id),
+                "organization_name": ctx.organization.name,
             },
         )
 

--- a/backend/airweave/platform/temporal/activities.py
+++ b/backend/airweave/platform/temporal/activities.py
@@ -233,20 +233,21 @@ async def update_sync_job_status_activity(
     from airweave.core.shared_models import SyncJobStatus
     from airweave.core.sync_job_service import sync_job_service
 
-    # Reconstruct ApiContext with a new logger
-    logger = LoggerConfigurator.configure_logger(
-        "airweave.temporal.activity",
-        dimensions={
-            "sync_job_id": sync_job_id,
-            "organization_id": ctx_dict["organization_id"],
-        },
-    )
-
     # Reconstruct user if present
     user = schemas.User(**ctx_dict["user"]) if ctx_dict.get("user") else None
 
     # Reconstruct organization from the dictionary
     organization = schemas.Organization(**ctx_dict["organization"])
+
+    # Reconstruct ApiContext with a new logger
+    logger = LoggerConfigurator.configure_logger(
+        "airweave.temporal.activity",
+        dimensions={
+            "sync_job_id": sync_job_id,
+            "organization_id": str(organization.id),
+            "organization_name": organization.name,
+        },
+    )
 
     ctx = ApiContext(
         request_id=ctx_dict["request_id"],


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added organization name to all context logs to improve traceability across sync workflows. 

- **Bug Fixes**
 - Ensured the organization name is present in logging dimensions for sync context creation and sync job status updates.

<!-- End of auto-generated description by cubic. -->

