### PR TITLE
feat/query-interpretation-databases

### DIFF
--- a/backend/airweave/core/pg_field_catalog_service.py
+++ b/backend/airweave/core/pg_field_catalog_service.py
@@ -1,0 +1,87 @@
+"""Service for maintaining PostgreSQL field catalog per source connection."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from airweave.core.logging import ContextualLogger
+from airweave.models.pg_field_catalog import PgFieldCatalogColumn, PgFieldCatalogTable
+
+
+async def overwrite_catalog(
+    db: AsyncSession,
+    organization_id: UUID,
+    source_connection_id: UUID,
+    snapshot: List[Dict[str, Any]],
+    logger: ContextualLogger | None = None,
+) -> None:
+    """Overwrite the catalog for a given source connection with a fresh snapshot.
+
+    Args:
+        db: Async SQLAlchemy session
+        organization_id: Tenant organization ID
+        source_connection_id: The source connection that owns this catalog
+        snapshot: List of table snapshots with columns/keys, produced by the source
+        logger: Optional logger
+    """
+    if logger:
+        logger.info(
+            "Refreshing Postgres field catalog (tables=%d) for source_connection=%s",
+            len(snapshot),
+            str(source_connection_id),
+        )
+
+    # Delete existing tables for this scope (cascade will remove columns)
+    existing_ids = await db.scalars(
+        select(PgFieldCatalogTable.id).where(
+            PgFieldCatalogTable.organization_id == organization_id,
+            PgFieldCatalogTable.source_connection_id == str(source_connection_id),
+        )
+    )
+    ids = list(existing_ids)
+    if ids:
+        await db.execute(delete(PgFieldCatalogTable).where(PgFieldCatalogTable.id.in_(ids)))
+        await db.flush()
+
+    # Insert new snapshot
+    for table in snapshot:
+        table_row = PgFieldCatalogTable(
+            organization_id=organization_id,
+            source_connection_id=str(source_connection_id),
+            schema_name=table["schema_name"],
+            table_name=table["table_name"],
+            recency_column=table.get("recency_column"),
+            primary_keys=table.get("primary_keys"),
+            foreign_keys=table.get("foreign_keys"),
+        )
+        db.add(table_row)
+        await db.flush()  # ensure table_row.id is available
+
+        for col in table.get("columns", []):
+            db.add(
+                PgFieldCatalogColumn(
+                    organization_id=organization_id,
+                    table_id=str(table_row.id),
+                    column_name=col["column_name"],
+                    data_type=col.get("data_type"),
+                    udt_name=col.get("udt_name"),
+                    is_nullable=bool(col.get("is_nullable", True)),
+                    default_value=col.get("default_value"),
+                    ordinal_position=col.get("ordinal_position"),
+                    is_primary_key=bool(col.get("is_primary_key", False)),
+                    is_foreign_key=bool(col.get("is_foreign_key", False)),
+                    ref_schema=col.get("ref_schema"),
+                    ref_table=col.get("ref_table"),
+                    ref_column=col.get("ref_column"),
+                    enum_values=col.get("enum_values"),
+                    is_filterable=bool(col.get("is_filterable", True)),
+                )
+            )
+
+    await db.flush()
+    if logger:
+        logger.info("Postgres field catalog refresh complete")

--- a/backend/airweave/core/pg_field_catalog_service.py
+++ b/backend/airweave/core/pg_field_catalog_service.py
@@ -39,7 +39,7 @@ async def overwrite_catalog(
     existing_ids = await db.scalars(
         select(PgFieldCatalogTable.id).where(
             PgFieldCatalogTable.organization_id == organization_id,
-            PgFieldCatalogTable.source_connection_id == str(source_connection_id),
+            PgFieldCatalogTable.source_connection_id == source_connection_id,
         )
     )
     ids = list(existing_ids)
@@ -51,7 +51,7 @@ async def overwrite_catalog(
     for table in snapshot:
         table_row = PgFieldCatalogTable(
             organization_id=organization_id,
-            source_connection_id=str(source_connection_id),
+            source_connection_id=source_connection_id,
             schema_name=table["schema_name"],
             table_name=table["table_name"],
             recency_column=table.get("recency_column"),
@@ -65,7 +65,7 @@ async def overwrite_catalog(
             db.add(
                 PgFieldCatalogColumn(
                     organization_id=organization_id,
-                    table_id=str(table_row.id),
+                    table_id=table_row.id,
                     column_name=col["column_name"],
                     data_type=col.get("data_type"),
                     udt_name=col.get("udt_name"),

--- a/backend/airweave/models/pg_field_catalog.py
+++ b/backend/airweave/models/pg_field_catalog.py
@@ -1,6 +1,6 @@
 """Models for per-source-connection PostgreSQL field catalog."""
 
-from sqlalchemy import JSON, Boolean, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import JSON, UUID, Boolean, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from airweave.models._base import OrganizationBase
@@ -16,8 +16,8 @@ class PgFieldCatalogTable(OrganizationBase):
     __tablename__ = "pg_field_catalog_table"
 
     # Link back to the source connection that owns this schema snapshot
-    source_connection_id: Mapped[str] = mapped_column(
-        ForeignKey("source_connection.id", ondelete="CASCADE"), nullable=False
+    source_connection_id: Mapped[UUID] = mapped_column(
+        UUID, ForeignKey("source_connection.id", ondelete="CASCADE"), nullable=False
     )
 
     schema_name: Mapped[str] = mapped_column(String, nullable=False)
@@ -56,8 +56,8 @@ class PgFieldCatalogColumn(OrganizationBase):
 
     __tablename__ = "pg_field_catalog_column"
 
-    table_id: Mapped[str] = mapped_column(
-        ForeignKey("pg_field_catalog_table.id", ondelete="CASCADE"), nullable=False
+    table_id: Mapped[UUID] = mapped_column(
+        UUID, ForeignKey("pg_field_catalog_table.id", ondelete="CASCADE"), nullable=False
     )
 
     column_name: Mapped[str] = mapped_column(String, nullable=False)

--- a/backend/airweave/models/pg_field_catalog.py
+++ b/backend/airweave/models/pg_field_catalog.py
@@ -1,0 +1,93 @@
+"""Models for per-source-connection PostgreSQL field catalog."""
+
+from sqlalchemy import JSON, Boolean, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from airweave.models._base import OrganizationBase
+
+
+class PgFieldCatalogTable(OrganizationBase):
+    """Catalog of PostgreSQL tables for a specific source connection.
+
+    Rows are scoped by organization and `source_connection_id` to maintain
+    multi-tenant isolation. We keep a single row per (source_connection, schema, table).
+    """
+
+    __tablename__ = "pg_field_catalog_table"
+
+    # Link back to the source connection that owns this schema snapshot
+    source_connection_id: Mapped[str] = mapped_column(
+        ForeignKey("source_connection.id", ondelete="CASCADE"), nullable=False
+    )
+
+    schema_name: Mapped[str] = mapped_column(String, nullable=False)
+    table_name: Mapped[str] = mapped_column(String, nullable=False)
+
+    # Optional: name of the column selected to act as recency cursor for this table
+    recency_column: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    # Primary key columns for convenience (duplicated from columns for easy lookup)
+    primary_keys: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+
+    # Foreign keys as a list of objects: {column, ref_schema, ref_table, ref_column}
+    foreign_keys: Mapped[list[dict] | None] = mapped_column(JSON, nullable=True)
+
+    # Relationship to columns
+    columns: Mapped[list["PgFieldCatalogColumn"]] = relationship(
+        "PgFieldCatalogColumn",
+        back_populates="table",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "organization_id",
+            "source_connection_id",
+            "schema_name",
+            "table_name",
+            name="uq_pg_field_catalog_table_scope",
+        ),
+    )
+
+
+class PgFieldCatalogColumn(OrganizationBase):
+    """Catalog of columns belonging to a `PgFieldCatalogTable`."""
+
+    __tablename__ = "pg_field_catalog_column"
+
+    table_id: Mapped[str] = mapped_column(
+        ForeignKey("pg_field_catalog_table.id", ondelete="CASCADE"), nullable=False
+    )
+
+    column_name: Mapped[str] = mapped_column(String, nullable=False)
+
+    # information_schema types
+    data_type: Mapped[str | None] = mapped_column(String, nullable=True)
+    udt_name: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    is_nullable: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    default_value: Mapped[str | None] = mapped_column(String, nullable=True)
+    ordinal_position: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Flags / relationships
+    is_primary_key: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    is_foreign_key: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    ref_schema: Mapped[str | None] = mapped_column(String, nullable=True)
+    ref_table: Mapped[str | None] = mapped_column(String, nullable=True)
+    ref_column: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    # For enums (USER-DEFINED types), keep the value set if available
+    enum_values: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+
+    # Heuristic flag for UI/LLM to prefer columns for filtering
+    is_filterable: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    # Relationship back to table
+    table: Mapped[PgFieldCatalogTable] = relationship(
+        PgFieldCatalogTable, back_populates="columns", lazy="noload"
+    )
+
+    __table_args__ = (
+        UniqueConstraint("table_id", "column_name", name="uq_pg_field_catalog_column_name"),
+    )

--- a/backend/airweave/platform/sources/_base.py
+++ b/backend/airweave/platform/sources/_base.py
@@ -20,6 +20,9 @@ class BaseSource:
         """Initialize the base source."""
         self._logger: Optional[Any] = None  # Store contextual logger as instance variable
         self._token_manager: Optional[Any] = None  # Store token manager for OAuth sources
+        # Optional sync identifiers for multi-tenant scoped helpers
+        self._organization_id: Optional[str] = None
+        self._source_connection_id: Optional[str] = None
 
     @property
     def logger(self):
@@ -32,6 +35,15 @@ class BaseSource:
     def set_logger(self, logger) -> None:
         """Set a contextual logger for this source."""
         self._logger = logger
+
+    def set_sync_identifiers(self, organization_id: str, source_connection_id: str) -> None:
+        """Set sync-scoped identifiers for this source instance.
+
+        These identifiers can be used by sources to persist auxiliary metadata
+        (e.g., schema catalogs) scoped to the current tenant/connection.
+        """
+        self._organization_id = organization_id
+        self._source_connection_id = source_connection_id
 
     @property
     def token_manager(self):

--- a/backend/airweave/platform/sync/factory.py
+++ b/backend/airweave/platform/sync/factory.py
@@ -339,6 +339,19 @@ class SyncFactory:
         if hasattr(source, "set_logger"):
             source.set_logger(logger)
 
+        # Step 4.1: Pass sync identifiers to the source for scoped helpers
+        try:
+            organization_id = ctx.organization.id
+            source_connection_obj = source_connection_data.get("source_connection_obj")
+            if hasattr(source, "set_sync_identifiers") and source_connection_obj:
+                source.set_sync_identifiers(
+                    organization_id=str(organization_id),
+                    source_connection_id=str(source_connection_obj.id),
+                )
+        except Exception:
+            # Non-fatal: older sources may ignore this
+            pass
+
         # Step 5: Setup token manager if needed
         # The _setup_token_manager method will check if this source needs a token manager
         # based on whether its auth config inherits from OAuth2AuthConfig

--- a/backend/airweave/platform/sync/factory.py
+++ b/backend/airweave/platform/sync/factory.py
@@ -350,7 +350,7 @@ class SyncFactory:
                 )
         except Exception:
             # Non-fatal: older sources may ignore this
-            logger.debug("Skipping set_sync_identifiers due to exception; source may not support it")
+            pass
 
         # Step 5: Setup token manager if needed
         # The _setup_token_manager method will check if this source needs a token manager

--- a/backend/airweave/platform/sync/factory.py
+++ b/backend/airweave/platform/sync/factory.py
@@ -350,7 +350,7 @@ class SyncFactory:
                 )
         except Exception:
             # Non-fatal: older sources may ignore this
-            pass
+            logger.debug("Skipping set_sync_identifiers due to exception; source may not support it")
 
         # Step 5: Setup token manager if needed
         # The _setup_token_manager method will check if this source needs a token manager

--- a/backend/alembic/versions/0765a96ad189_merge_heads_for_pg_field_catalog.py
+++ b/backend/alembic/versions/0765a96ad189_merge_heads_for_pg_field_catalog.py
@@ -1,0 +1,24 @@
+"""merge heads for pg_field_catalog
+
+Revision ID: 0765a96ad189
+Revises: 25e5ed7e5b9f, 4f2c1a7a9b10
+Create Date: 2025-08-27 14:31:23.909286
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0765a96ad189'
+down_revision = ('25e5ed7e5b9f', '4f2c1a7a9b10')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/backend/alembic/versions/4f2c1a7a9b10_add_pg_field_catalog_tables.py
+++ b/backend/alembic/versions/4f2c1a7a9b10_add_pg_field_catalog_tables.py
@@ -19,11 +19,11 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "pg_field_catalog_table",
-        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("id", sa.UUID(), nullable=False),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("modified_at", sa.DateTime(), nullable=False),
-        sa.Column("organization_id", sa.Uuid(), nullable=False),
-        sa.Column("source_connection_id", sa.Uuid(), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("source_connection_id", sa.UUID(), nullable=False),
         sa.Column("schema_name", sa.String(), nullable=False),
         sa.Column("table_name", sa.String(), nullable=False),
         sa.Column("recency_column", sa.String(), nullable=True),
@@ -43,11 +43,11 @@ def upgrade() -> None:
 
     op.create_table(
         "pg_field_catalog_column",
-        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("id", sa.UUID(), nullable=False),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("modified_at", sa.DateTime(), nullable=False),
-        sa.Column("organization_id", sa.Uuid(), nullable=False),
-        sa.Column("table_id", sa.Uuid(), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("table_id", sa.UUID(), nullable=False),
         sa.Column("column_name", sa.String(), nullable=False),
         sa.Column("data_type", sa.String(), nullable=True),
         sa.Column("udt_name", sa.String(), nullable=True),

--- a/backend/alembic/versions/4f2c1a7a9b10_add_pg_field_catalog_tables.py
+++ b/backend/alembic/versions/4f2c1a7a9b10_add_pg_field_catalog_tables.py
@@ -1,0 +1,73 @@
+"""add pg field catalog tables
+
+Revision ID: 4f2c1a7a9b10
+Revises: 1ab50fcb59fb
+Create Date: 2025-08-27 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "4f2c1a7a9b10"
+down_revision = "1ab50fcb59fb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pg_field_catalog_table",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("modified_at", sa.DateTime(), nullable=False),
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("source_connection_id", sa.Uuid(), nullable=False),
+        sa.Column("schema_name", sa.String(), nullable=False),
+        sa.Column("table_name", sa.String(), nullable=False),
+        sa.Column("recency_column", sa.String(), nullable=True),
+        sa.Column("primary_keys", sa.JSON(), nullable=True),
+        sa.Column("foreign_keys", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["source_connection_id"], ["source_connection.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "organization_id",
+            "source_connection_id",
+            "schema_name",
+            "table_name",
+            name="uq_pg_field_catalog_table_scope",
+        ),
+    )
+
+    op.create_table(
+        "pg_field_catalog_column",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("modified_at", sa.DateTime(), nullable=False),
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("table_id", sa.Uuid(), nullable=False),
+        sa.Column("column_name", sa.String(), nullable=False),
+        sa.Column("data_type", sa.String(), nullable=True),
+        sa.Column("udt_name", sa.String(), nullable=True),
+        sa.Column("is_nullable", sa.Boolean(), nullable=False, server_default=sa.text("TRUE")),
+        sa.Column("default_value", sa.String(), nullable=True),
+        sa.Column("ordinal_position", sa.Integer(), nullable=True),
+        sa.Column("is_primary_key", sa.Boolean(), nullable=False, server_default=sa.text("FALSE")),
+        sa.Column("is_foreign_key", sa.Boolean(), nullable=False, server_default=sa.text("FALSE")),
+        sa.Column("ref_schema", sa.String(), nullable=True),
+        sa.Column("ref_table", sa.String(), nullable=True),
+        sa.Column("ref_column", sa.String(), nullable=True),
+        sa.Column("enum_values", sa.JSON(), nullable=True),
+        sa.Column("is_filterable", sa.Boolean(), nullable=False, server_default=sa.text("TRUE")),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["table_id"], ["pg_field_catalog_table.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("table_id", "column_name", name="uq_pg_field_catalog_column_name"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("pg_field_catalog_column")
+    op.drop_table("pg_field_catalog_table")


### PR DESCRIPTION
store database table structures at sync time in airweave system database and retrieve it at query time for interpretation
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a per-connection PostgreSQL field catalog saved during sync and used at query time to enrich query interpretation with real table/column metadata. This enables table.column filters, improves source_name handling, and keeps sync resilient.

- **New Features**
  - Persist PostgreSQL schema snapshots (tables, columns, PK/FK, enum values) per source connection via new catalog models and service; captured pre-stream in the Postgres source (best-effort).
  - Query interpretation loads the catalog to expose PostgreSQL fields, supports table.column keys, maps them to payload paths, and auto-scopes filters by table_name.
  - More robust source_name validation: accepts namespaced key, normalizes to lowercase short_names, and de-duplicates.
  - Base sources can receive organization_id/source_connection_id; sync factory now passes these to scope catalog writes.

- **Migration**
  - Run Alembic migrations (adds pg_field_catalog_table and pg_field_catalog_column, plus merge head).
  - No config changes. Catalog data is populated on the next PostgreSQL sync.

<!-- End of auto-generated description by cubic. -->

