### PR TITLE
docs(fern): enable PostHog analytics in docs.yml

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -7,6 +7,10 @@ instances:
       repo: airweave
       branch: main
 title: Airweave
+analytics:
+  posthog:
+    api-key: "phc_pRMEx1bwjdogqrCL4xpfEoEwXds7eONicNSWhX45M8M"
+    endpoint: "https://eu.i.posthog.com" 
 layout:
   searchbar-placement: header
   page-width: full


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enable PostHog analytics for the docs by adding PostHog config (API key and EU endpoint) to fern/docs.yml. This starts collecting usage metrics across the docs site.

<!-- End of auto-generated description by cubic. -->

