### PR TITLE
fix/SDK

### DIFF
--- a/backend/airweave/api/v1/endpoints/collections.py
+++ b/backend/airweave/api/v1/endpoints/collections.py
@@ -338,7 +338,7 @@ async def search_advanced(
 
 @router.post(
     "/{readable_id}/refresh_all",
-    response_model=list[schemas.SourceConnectionJob],
+    response_model=List[schemas.SourceConnectionJob],
     responses=create_job_list_response(["completed"], "Multiple sync jobs triggered"),
 )
 async def refresh_all_source_connections(
@@ -351,7 +351,7 @@ async def refresh_all_source_connections(
     guard_rail: GuardRailService = Depends(deps.get_guard_rail_service),
     background_tasks: BackgroundTasks,
     logger: ContextualLogger = Depends(deps.get_logger),
-) -> list[schemas.SourceConnectionJob]:
+) -> List[schemas.SourceConnectionJob]:
     """Trigger data synchronization for all source connections in the collection.
 
     The sync jobs run asynchronously in the background, so this endpoint

--- a/backend/airweave/api/v1/endpoints/collections.py
+++ b/backend/airweave/api/v1/endpoints/collections.py
@@ -35,7 +35,7 @@ router = TrailingSlashRouter()
         "Finance data collection",
     ),
 )
-async def list_collections(
+async def list(
     skip: int = Query(0, description="Number of collections to skip for pagination"),
     limit: int = Query(
         100, description="Maximum number of collections to return (1-1000)", le=1000, ge=1
@@ -55,7 +55,7 @@ async def list_collections(
 
 
 @router.post("/", response_model=schemas.Collection)
-async def create_collection(
+async def create(
     collection: schemas.CollectionCreate,
     db: AsyncSession = Depends(deps.get_db),
     ctx: ApiContext = Depends(deps.get_context),
@@ -79,7 +79,7 @@ async def create_collection(
 
 
 @router.get("/{readable_id}", response_model=schemas.Collection)
-async def get_collection(
+async def get(
     readable_id: str = Path(
         ...,
         description="The unique readable identifier of the collection (e.g., 'finance-data-ab123')",
@@ -95,7 +95,7 @@ async def get_collection(
 
 
 @router.put("/{readable_id}", response_model=schemas.Collection)
-async def update_collection(
+async def update(
     collection: schemas.CollectionUpdate,
     readable_id: str = Path(
         ..., description="The unique readable identifier of the collection to update"
@@ -116,7 +116,7 @@ async def update_collection(
 
 
 @router.delete("/{readable_id}", response_model=schemas.Collection)
-async def delete_collection(
+async def delete(
     readable_id: str = Path(
         ..., description="The unique readable identifier of the collection to delete"
     ),
@@ -158,7 +158,7 @@ async def delete_collection(
     response_model=schemas.SearchResponse,
     responses=create_search_response("raw_results", "Raw search results with metadata"),
 )
-async def search_collection(
+async def search(
     readable_id: str = Path(
         ..., description="The unique readable identifier of the collection to search"
     ),
@@ -257,7 +257,7 @@ async def search_collection(
     response_model=schemas.SearchResponse,
     responses=create_search_response("completion_response", "Search with AI-generated completion"),
 )
-async def search_collection_advanced(
+async def search_advanced(
     readable_id: str = Path(
         ..., description="The unique readable identifier of the collection to search"
     ),

--- a/backend/airweave/api/v1/endpoints/source_connections.py
+++ b/backend/airweave/api/v1/endpoints/source_connections.py
@@ -35,7 +35,7 @@ router = TrailingSlashRouter()
         ["engineering_docs"], "Multiple source connections across collections"
     ),
 )
-async def list_source_connections(
+async def list(
     *,
     db: AsyncSession = Depends(deps.get_db),
     collection: Optional[str] = Query(
@@ -69,7 +69,7 @@ async def list_source_connections(
 
 
 @router.get("/{source_connection_id}", response_model=schemas.SourceConnection)
-async def get_source_connection(
+async def get(
     *,
     db: AsyncSession = Depends(deps.get_db),
     source_connection_id: UUID = Path(
@@ -91,7 +91,7 @@ async def get_source_connection(
 
 
 @router.post("/", response_model=schemas.SourceConnection)
-async def create_source_connection(
+async def create(
     *,
     db: AsyncSession = Depends(deps.get_db),
     source_connection_in: schemas.SourceConnectionCreate = Body(...),
@@ -219,7 +219,7 @@ async def create_source_connection(
 
 
 @router.post("/internal/", response_model=schemas.SourceConnection)
-async def create_source_connection_with_credential(
+async def create_with_credential(
     *,
     db: AsyncSession = Depends(deps.get_db),
     source_connection_in: schemas.SourceConnectionCreateWithCredential = Body(...),
@@ -534,7 +534,7 @@ async def _create_minute_level_schedule(
 
 
 @router.post("/continuous", response_model=schemas.SourceConnectionContinuousResponse)
-async def create_continuous_source_connection_BETA(
+async def create_continuous_BETA(
     *,
     db: AsyncSession = Depends(deps.get_db),
     source_connection_in: schemas.SourceConnectionCreateContinuous = Body(...),
@@ -769,7 +769,7 @@ async def create_continuous_source_connection_BETA(
 
 
 @router.put("/{source_connection_id}", response_model=schemas.SourceConnection)
-async def update_source_connection(
+async def update(
     *,
     db: AsyncSession = Depends(deps.get_db),
     source_connection_id: UUID = Path(
@@ -792,7 +792,7 @@ async def update_source_connection(
 
 
 @router.delete("/{source_connection_id}", response_model=schemas.SourceConnection)
-async def delete_source_connection(
+async def delete(
     *,
     db: AsyncSession = Depends(deps.get_db),
     source_connection_id: UUID = Path(
@@ -820,7 +820,7 @@ async def delete_source_connection(
     response_model=schemas.SourceConnectionJob,
     responses=create_single_job_response("completed", "Sync job successfully triggered"),
 )
-async def run_source_connection(
+async def run(
     *,
     db: AsyncSession = Depends(deps.get_db),
     source_connection_id: UUID = Path(
@@ -918,7 +918,7 @@ async def run_source_connection(
     response_model=List[schemas.SourceConnectionJob],
     responses=create_job_list_response(["completed"], "Complete sync job history"),
 )
-async def list_source_connection_jobs(
+async def list_jobs(
     *,
     db: AsyncSession = Depends(deps.get_db),
     source_connection_id: UUID = Path(
@@ -941,7 +941,7 @@ async def list_source_connection_jobs(
     response_model=schemas.SourceConnectionJob,
     responses=create_single_job_response("completed", "Detailed sync job information"),
 )
-async def get_source_connection_job(
+async def get_job(
     *,
     db: AsyncSession = Depends(deps.get_db),
     source_connection_id: UUID = Path(
@@ -962,7 +962,7 @@ async def get_source_connection_job(
     response_model=schemas.SourceConnectionJob,
     responses=create_single_job_response("cancelled", "Successfully cancelled sync job"),
 )
-async def cancel_source_connection_job(
+async def cancel_job(
     *,
     db: AsyncSession = Depends(deps.get_db),
     source_connection_id: UUID = Path(

--- a/backend/airweave/api/v1/endpoints/sources.py
+++ b/backend/airweave/api/v1/endpoints/sources.py
@@ -22,7 +22,7 @@ router = TrailingSlashRouter()
         "github", "Source details with authentication and configuration schemas"
     ),
 )
-async def read_source(
+async def read(
     *,
     db: AsyncSession = Depends(deps.get_db),
     short_name: str = Path(
@@ -102,7 +102,7 @@ async def read_source(
         ["github"], "List of all available data source connectors"
     ),
 )
-async def read_sources(
+async def list(
     *,
     db: AsyncSession = Depends(deps.get_db),
     ctx: ApiContext = Depends(deps.get_context),

--- a/backend/airweave/api/v1/endpoints/sources.py
+++ b/backend/airweave/api/v1/endpoints/sources.py
@@ -1,5 +1,7 @@
 """The API module that contains the endpoints for sources."""
 
+from typing import List
+
 from fastapi import Depends, HTTPException, Path
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -97,7 +99,7 @@ async def read(
 
 @router.get(
     "/list",
-    response_model=list[schemas.Source],
+    response_model=List[schemas.Source],
     responses=create_source_list_response(
         ["github"], "List of all available data source connectors"
     ),
@@ -106,7 +108,7 @@ async def list(
     *,
     db: AsyncSession = Depends(deps.get_db),
     ctx: ApiContext = Depends(deps.get_context),
-) -> list[schemas.Source]:
+) -> List[schemas.Source]:
     """List all available data source connectors.
 
     <br/><br/>


### PR DESCRIPTION
Shorter names of endpoint functions
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Shortened API endpoint function names to concise verbs to produce cleaner SDK method names. No routes, request/response schemas, or behavior changed.

- **Refactors**
  - Renamed handlers across collections, source_connections, and sources to short verbs (e.g., list, get, create, update, delete, search, search_advanced, run, list_jobs, get_job, cancel_job).
  - OpenAPI operationIds updated accordingly to align generated SDK method names.

- **Migration**
  - Regenerate the SDK and update client calls to new method names.
    - Examples: list_collections → list, create_source_connection → create, list_source_connection_jobs → list_jobs.

<!-- End of auto-generated description by cubic. -->

