### PR TITLE
fix(backend): pydantic error for non exisiting file entity field

### DIFF
--- a/backend/airweave/platform/sources/asana.py
+++ b/backend/airweave/platform/sources/asana.py
@@ -457,7 +457,6 @@ class AsanaSource(BaseSource):
                 name=attachment_detail.get("name"),
                 mime_type=attachment_detail.get("mime_type"),
                 size=attachment_detail.get("size"),
-                total_size=attachment_detail.get("size"),  # Set total_size from API response
                 download_url=attachment_detail.get("download_url"),
                 created_at=attachment_detail.get("created_at"),
                 modified_at=attachment_detail.get("modified_at"),
@@ -469,6 +468,8 @@ class AsanaSource(BaseSource):
                 view_url=attachment_detail.get("view_url"),
                 permanent=attachment_detail.get("permanent", False),
             )
+
+            file_entity.airweave_system_metadata.total_size = attachment_detail.get("size")
 
             # Different headers based on URL type
             headers = None

--- a/backend/airweave/platform/sources/gmail.py
+++ b/backend/airweave/platform/sources/gmail.py
@@ -532,12 +532,13 @@ class GmailSource(BaseSource):
                         name=filename,
                         mime_type=mime_type,
                         size=size,
-                        total_size=size,
                         download_url=dummy_download_url,  # Required by FileEntity
                         message_id=message_id,
                         attachment_id=attachment_id,
                         thread_id=thread_id,
                     )
+
+                    file_entity.airweave_system_metadata.total_size = size
 
                     # Get base64 data
                     base64_data = attachment_data.get("data", "")

--- a/backend/airweave/platform/sources/onedrive.py
+++ b/backend/airweave/platform/sources/onedrive.py
@@ -325,7 +325,7 @@ class OneDriveSource(BaseSource):
         )
 
         # Add additional properties for file processing
-        entity.total_size = item.get("size", 0)
+        entity.airweave_system_metadata.total_size = item.get("size", 0)
 
         return entity
 

--- a/backend/airweave/platform/transformers/web_fetcher.py
+++ b/backend/airweave/platform/transformers/web_fetcher.py
@@ -616,7 +616,7 @@ def _create_web_file_entity(
     enhanced_metadata: dict,
 ) -> WebFileEntity:
     """Create WebFileEntity with optimized field copying."""
-    return WebFileEntity(
+    entity = WebFileEntity(
         entity_id=web_entity.entity_id,
         file_id=f"web_{web_entity.entity_id}",
         name=f"{title}.md",
@@ -627,7 +627,6 @@ def _create_web_file_entity(
         local_path=temp_file_path,
         file_uuid=file_uuid,
         checksum=checksum,
-        total_size=file_size,
         # Copy BaseEntity fields
         breadcrumbs=web_entity.breadcrumbs,
         parent_entity_id=web_entity.parent_entity_id,
@@ -641,6 +640,9 @@ def _create_web_file_entity(
         # Enhanced metadata
         metadata=enhanced_metadata,
     )
+
+    entity.airweave_system_metadata.total_size = file_size
+    return entity
 
 
 async def _store_file_entity(


### PR DESCRIPTION
Noticed a fatal error when syncing OneDrive (no document was processed) due to an error thrown by Pydantic because of a field that was moved and not migrated correctly. Error was introduced in https://github.com/airweave-ai/airweave/commit/829aa65035519c5b61447ebfdb2a2ed674301b24 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a Pydantic validation error by writing file size to airweave_system_metadata.total_size instead of the removed total_size field. Restores OneDrive sync and aligns all sources with the current FileEntity schema.

- **Bug Fixes**
  - Updated Asana, Gmail, OneDrive, and Web Fetcher to set entity.airweave_system_metadata.total_size.
  - Removed deprecated total_size constructor args and assignments.
  - Prevents fatal crash where OneDrive sync processed no documents.

<!-- End of auto-generated description by cubic. -->

