### PR TITLE
feat: enable PostHog analytics by default with hosted vs self-hosted user tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,11 +53,6 @@ APP_FULL_URL=
 QDRANT_FULL_URL=
 ADDITIONAL_CORS_ORIGINS=
 
-# Posthog Configuration
-POSTHOG_API_KEY=
-POSTHOG_HOST=https://app.posthog.com
-ANALYTICS_ENABLED=false
-
 # Other Settings
 PROJECT_NAME=Airweave
 LOG_LEVEL=INFO

--- a/backend/airweave/core/config.py
+++ b/backend/airweave/core/config.py
@@ -136,8 +136,10 @@ class Settings(BaseSettings):
     RESEND_FROM_EMAIL: Optional[str] = None
 
     # PostHog Analytics Configuration
-    POSTHOG_API_KEY: Optional[str] = None
-    POSTHOG_HOST: str = "https://app.posthog.com"
+    # Public API key for open source and hosted platform
+    POSTHOG_API_KEY: str = "phc_Ytp26UB3WwGCdjHTpDBI9HQg2ZA38ITMDKI6fE6EPGS"
+    POSTHOG_HOST: str = "https://eu.i.posthog.com"
+    # Analytics enabled by default unless in local environment
     ANALYTICS_ENABLED: bool = True
 
     # Sync configuration


### PR DESCRIPTION
Configures PostHog analytics to work out-of-the-box for both hosted platform and self-hosted deployments, with automatic user segmentation between the two deployment types.

### **Changes Made**

#### **Configuration Updates**
- **Set public PostHog API key** (`phc_Ytp26UB3WwGCdjHTpDBI9HQg2ZA38ITMDKI6fE6EPGS`) as default
- **Configure EU PostHog host** (`https://eu.i.posthog.com`) 
- **Remove environment variable dependency** - analytics work without `POSTHOG_API_KEY` env var
- **Enable analytics by default** unless in local environment

#### **Analytics Service Enhancements**
- **Add deployment type detection** to distinguish hosted vs self-hosted users
- **Add deployment identifier** for unique tracking per deployment
- **Enhance all events** with deployment context fields

### **New Analytics Fields**
Every analytics event now automatically includes:

**Primary Distinction:**
- `deployment_type`: `"hosted"` (app.airweave.ai) vs `"self_hosted"` (other deployments)
- `is_hosted_platform`: boolean flag for easy filtering
- `deployment_id`: unique identifier per deployment

**Supporting Context:**
- `environment`: deployment environment (`prd`, `local`, `dev`, `test`)
- `api_url`: full API URL for deployment identification
- `app_url`: full app URL for deployment identification
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable PostHog analytics by default for both hosted and self-hosted deployments, with automatic deployment context added to all events. Uses a public EU PostHog key and host so analytics work out of the box; disabled only in local.

- New Features
  - Default PostHog config: public API key and EU host; no env vars required.
  - Enabled by default except in local.
  - Auto-detect deployment type (hosted vs self_hosted) and add is_hosted_platform.
  - Add deployment_id plus common context (environment, api_url, app_url) to identify, event, and group calls.

- Migration
  - Hosted: no action needed.
  - Self-hosted: analytics are now on by default. Set ANALYTICS_ENABLED=false to opt out.
  - Optional: override POSTHOG_API_KEY and POSTHOG_HOST to use your own PostHog project.

<!-- End of auto-generated description by cubic. -->

