### PR TITLE
feat: unify search analytics tracking across regular and streaming search

### DIFF
--- a/backend/airweave/analytics/__init__.py
+++ b/backend/airweave/analytics/__init__.py
@@ -1,7 +1,7 @@
 """Analytics module for PostHog integration."""
 
 from .decorators.api import track_api_endpoint
-from .decorators.search import track_search_operation
+from .decorators.search import track_search_operation, track_streaming_search_initiation
 from .events.business_events import business_events
 from .service import analytics
 
@@ -10,4 +10,5 @@ __all__ = [
     "business_events",
     "track_api_endpoint",
     "track_search_operation",
+    "track_streaming_search_initiation",
 ]

--- a/backend/airweave/analytics/decorators/__init__.py
+++ b/backend/airweave/analytics/decorators/__init__.py
@@ -1,9 +1,10 @@
 """Decorators for analytics tracking."""
 
 from .api import track_api_endpoint
-from .search import track_search_operation
+from .search import track_search_operation, track_streaming_search_initiation
 
 __all__ = [
     "track_api_endpoint",
     "track_search_operation",
+    "track_streaming_search_initiation",
 ]

--- a/backend/airweave/analytics/decorators/search.py
+++ b/backend/airweave/analytics/decorators/search.py
@@ -4,7 +4,11 @@ import time
 from functools import wraps
 from typing import Any, Callable, TypeVar
 
-from airweave.analytics.service import analytics
+from airweave.analytics.search_analytics import (
+    build_search_error_properties,
+    build_search_properties,
+    track_search_event,
+)
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -32,57 +36,6 @@ def _extract_search_context(args, kwargs):
     return ctx, query, collection_slug
 
 
-def _build_success_properties(ctx, query, collection_slug, result, duration_ms):
-    """Build properties for successful search analytics."""
-    properties = {
-        "query_length": len(query),
-        "collection_slug": collection_slug,
-        "duration_ms": duration_ms,
-        "results_count": len(result.results) if hasattr(result, "results") else 0,
-        "response_type": result.response_type.value
-        if hasattr(result, "response_type") and hasattr(result.response_type, "value")
-        else None,
-        "status": result.status.value
-        if hasattr(result, "status") and hasattr(result.status, "value")
-        else "success",
-        "organization_name": getattr(ctx.organization, "name", "unknown"),
-    }
-
-    # Add search-specific metrics
-    if hasattr(result, "results") and result.results:
-        scores = [r.get("score", 0) for r in result.results if isinstance(r, dict)]
-        if scores:
-            properties.update(
-                {
-                    "avg_score": sum(scores) / len(scores),
-                    "max_score": max(scores),
-                    "min_score": min(scores),
-                }
-            )
-
-    return properties
-
-
-def _build_error_properties(query, collection_slug, duration_ms, error):
-    """Build properties for search error analytics."""
-    return {
-        "query_length": len(query) if query else 0,
-        "collection_slug": collection_slug,
-        "duration_ms": duration_ms,
-        "error": type(error).__name__,
-    }
-
-
-def _track_search_analytics(ctx, properties, event_name):
-    """Track search analytics event."""
-    analytics.track_event(
-        event_name=event_name,
-        distinct_id=str(ctx.user.id) if ctx.user else f"api_key_{ctx.organization.id}",
-        properties=properties,
-        groups={"organization": str(ctx.organization.id)},
-    )
-
-
 def track_search_operation():
     """Decorator to track search operations with query analysis."""
 
@@ -97,20 +50,72 @@ def track_search_operation():
 
                 if ctx and query:
                     duration_ms = (time.monotonic() - start_time) * 1000
-                    properties = _build_success_properties(
-                        ctx, query, collection_slug, result, duration_ms
+
+                    # Extract response type and status from result
+                    response_type = None
+                    if hasattr(result, "response_type") and hasattr(result.response_type, "value"):
+                        response_type = result.response_type.value
+
+                    status = "success"
+                    if hasattr(result, "status") and hasattr(result.status, "value"):
+                        status = result.status.value
+
+                    # Build properties using shared utility
+                    properties = build_search_properties(
+                        ctx=ctx,
+                        query=query,
+                        collection_slug=collection_slug,
+                        duration_ms=duration_ms,
+                        search_type="regular",
+                        results=result.results if hasattr(result, "results") else None,
+                        response_type=response_type,
+                        status=status,
                     )
-                    _track_search_analytics(ctx, properties, "search_query")
+
+                    track_search_event(ctx, properties, "search_query")
 
                 return result
 
             except Exception as e:
                 if ctx and query:
                     duration_ms = (time.monotonic() - start_time) * 1000
-                    properties = _build_error_properties(query, collection_slug, duration_ms, e)
-                    _track_search_analytics(ctx, properties, "search_query_error")
+                    properties = build_search_error_properties(
+                        query, collection_slug, duration_ms, e, search_type="regular"
+                    )
+                    track_search_event(ctx, properties, "search_query_error")
 
                 raise
+
+        return wrapper
+
+    return decorator
+
+
+def track_streaming_search_initiation():
+    """Decorator to track streaming search initiation.
+
+    This decorator only tracks when a streaming search is initiated.
+    The actual search completion is tracked by the SearchExecutor
+    when it emits the 'done' event.
+    """
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            ctx, query, collection_slug = _extract_search_context(args, kwargs)
+
+            # Track stream initiation
+            if ctx and query:
+                properties = build_search_properties(
+                    ctx=ctx,
+                    query=query,
+                    collection_slug=collection_slug,
+                    duration_ms=0,  # No duration for initiation
+                    search_type="streaming",
+                )
+                track_search_event(ctx, properties, "search_stream_start")
+
+            return await func(*args, **kwargs)
 
         return wrapper
 

--- a/backend/airweave/analytics/search_analytics.py
+++ b/backend/airweave/analytics/search_analytics.py
@@ -1,0 +1,99 @@
+"""Shared analytics utilities for search operations."""
+
+from typing import Any, Dict, Optional
+
+from airweave.analytics.service import analytics
+from airweave.api.context import ApiContext
+
+
+def build_search_properties(
+    ctx: ApiContext,
+    query: str,
+    collection_slug: str,
+    duration_ms: float,
+    search_type: str = "regular",
+    results: Optional[list] = None,
+    response_type: Optional[str] = None,
+    status: str = "success",
+) -> Dict[str, Any]:
+    """Build unified analytics properties for search operations.
+
+    Args:
+        ctx: API context with user and organization info
+        query: Search query text
+        collection_slug: Collection identifier
+        duration_ms: Search duration in milliseconds
+        search_type: Type of search ("regular" or "streaming")
+        results: Search results list (optional)
+        response_type: Response type (optional)
+        status: Search status (default: "success")
+
+    Returns:
+        Dictionary of analytics properties
+    """
+    properties = {
+        "query_length": len(query),
+        "collection_slug": collection_slug,
+        "duration_ms": duration_ms,
+        "search_type": search_type,
+        "organization_name": getattr(ctx.organization, "name", "unknown"),
+        "status": status,
+    }
+
+    # Add response type if provided
+    if response_type:
+        properties["response_type"] = response_type
+
+    # Add results count if results are provided
+    if results:
+        properties["results_count"] = len(results)
+
+    return properties
+
+
+def build_search_error_properties(
+    query: str,
+    collection_slug: str,
+    duration_ms: float,
+    error: Exception,
+    search_type: str = "regular",
+) -> Dict[str, Any]:
+    """Build analytics properties for search errors.
+
+    Args:
+        query: Search query text
+        collection_slug: Collection identifier
+        duration_ms: Search duration in milliseconds
+        error: The exception that occurred
+        search_type: Type of search ("regular" or "streaming")
+
+    Returns:
+        Dictionary of analytics properties
+    """
+    return {
+        "query_length": len(query) if query else 0,
+        "collection_slug": collection_slug,
+        "duration_ms": duration_ms,
+        "search_type": search_type,
+        "error": type(error).__name__,
+    }
+
+
+def track_search_event(
+    ctx: ApiContext,
+    properties: Dict[str, Any],
+    event_name: str,
+) -> None:
+    """Track a search analytics event.
+
+    Args:
+        ctx: API context with user and organization info
+        properties: Analytics properties dictionary
+        event_name: Name of the event to track
+    """
+    analytics.track_event(
+        event_name=event_name,
+        distinct_id=str(ctx.user.id) if ctx.user else f"api_key_{ctx.organization.id}",
+        properties=properties,
+        groups={"organization": str(ctx.organization.id)},
+    )

--- a/backend/airweave/api/v1/endpoints/collections.py
+++ b/backend/airweave/api/v1/endpoints/collections.py
@@ -10,7 +10,11 @@ from qdrant_client.http.models import Filter as QdrantFilter
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave import crud, schemas
-from airweave.analytics import business_events, track_api_endpoint, track_search_operation
+from airweave.analytics import (
+    business_events,
+    track_api_endpoint,
+    track_search_operation,
+)
 from airweave.api import deps
 from airweave.api.context import ApiContext
 from airweave.api.examples import (
@@ -492,7 +496,6 @@ async def get_filter_schema() -> Dict[str, Any]:
 
 
 @router.post("/{readable_id}/search/stream")
-@track_api_endpoint("stream_search")
 async def stream_search_collection_advanced(  # noqa: C901 - streaming orchestration is acceptable
     readable_id: str = Path(
         ..., description="The unique readable identifier of the collection to search"
@@ -517,6 +520,19 @@ async def stream_search_collection_advanced(  # noqa: C901 - streaming orchestra
 
     # Ensure the organization is allowed to perform queries
     await guard_rail.is_allowed(ActionType.QUERIES)
+
+    # Track stream initiation after permission check
+    from airweave.analytics.search_analytics import build_search_properties, track_search_event
+
+    if ctx and search_request.query:
+        properties = build_search_properties(
+            ctx=ctx,
+            query=search_request.query,
+            collection_slug=readable_id,
+            duration_ms=0,  # No duration for initiation
+            search_type="streaming",
+        )
+        track_search_event(ctx, properties, "search_stream_start")
 
     # Subscribe to the search:<request_id> channel
     pubsub = await core_pubsub.subscribe("search", request_id)


### PR DESCRIPTION
We had inconsistent analytics tracking between our search endpoints:

- **Regular search endpoints** (GET/POST `/search`): Used `@track_search_operation()` ✅
- **Streaming search endpoint** (POST `/search/stream`): Used `@track_api_endpoint("stream_search")` ❌

This caused several issues:
1. **Inaccurate metrics**: `@track_search_operation()` on streaming recorded near-zero duration and zero results
2. **Incorrect timing**: `@track_api_endpoint()` measured endpoint creation time, not actual search execution
3. **Fragmented analytics**: Search data was split across different events in PostHog
4. **Code duplication**: Similar analytics logic scattered across multiple files

## Solution

### 1. **Created Unified Analytics Architecture**
- **New decorator**: `@track_streaming_search_initiation()` for streaming search start tracking
- **Enhanced SearchExecutor**: Added analytics tracking when search completes (both regular and streaming)
- **Shared utilities**: Created `search_analytics.py` to consolidate duplicate analytics logic

### 2. **Unified Analytics Events**
- **`search_stream_start`**: Fired when streaming search is initiated
- **`search_query`**: Fired when any search completes (regular or streaming) with unified properties:
  - `search_type`: "regular" or "streaming"
  - `duration_ms`: Actual search execution time
  - `results_count`: Number of results returned
  - `query_length`, `collection_slug`, `organization_name`

## Verification (PostHog)
<img width="716" height="364" alt="Screenshot 2025-09-11 at 17 38 52" src="https://github.com/user-attachments/assets/ef550d6d-2cbd-4bc8-aeaa-354c34221a85" />
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Unifies analytics for regular and streaming search. Fixes incorrect timing and fragmented events so PostHog shows consistent, reliable search metrics.

- **Bug Fixes**
  - Streaming now records actual execution time at search completion.
  - All searches emit a single event: search_query with unified props (search_type, duration_ms, query_length, collection_slug, organization_name, response_type/status when present).
  - Streaming start is tracked via search_stream_start to capture initiation.

- **Refactors**
  - Added analytics/search_analytics.py for shared property builders and event tracking.
  - New decorator track_streaming_search_initiation; applied to POST /{readable_id}/search/stream.
  - track_search_operation now uses shared utilities; analytics exports updated.

<!-- End of auto-generated description by cubic. -->

