### PR TITLE
feat(mcp): set up continuous deployment for MCP

### DIFF
--- a/.github/workflows/publish-sdks-and-mcp.yml
+++ b/.github/workflows/publish-sdks-and-mcp.yml
@@ -1,4 +1,4 @@
-name: Fern SDK Generation
+name: Publish SDKs and MCP
 
 on:
   release:
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "SDK version to release"
+        description: "Version to release (e.g., v0.5.8)"
         required: true
         type: string
 
 jobs:
-  generate-sdks:
+  generate-sdks-and-mcp:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -67,6 +67,30 @@ jobs:
           cd fern
           VERSION=${{ github.event.release.tag_name || github.event.inputs.version }}
           fern generate --group public --version $VERSION --log-level debug
+
+      - name: Update MCP package version
+        run: |
+          cd mcp
+          VERSION=${{ github.event.release.tag_name || github.event.inputs.version }}
+          # Remove 'v' prefix if present
+          VERSION=${VERSION#v}
+          npm version $VERSION --no-git-tag-version
+          echo "Updated MCP package to version $VERSION"
+
+      - name: Build MCP package
+        run: |
+          cd mcp
+          npm install
+          npm run build
+
+      - name: Publish MCP to npm
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd mcp
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          npm publish --access public
+          echo "Published airweave-mcp-search to npm"
 
       - name: Trigger Docs Generation
         uses: actions/github-script@v6

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -14,35 +14,6 @@ An MCP (Model Context Protocol) server that provides comprehensive search capabi
 - 🧪 **Comprehensive Testing**: Full test suite with LLM testing strategy
 - 🏗️ **Simple Architecture**: Clean, maintainable code structure without over-engineering
 
-## Version History
-
-### v2.1.0 - Advanced Search Features
-
-🚀 **New advanced search capabilities:**
-
-- **Advanced Parameters**: Added `score_threshold`, `search_method`, `expansion_strategy`, `enable_reranking`, `enable_query_interpretation`
-- **Smart Endpoint Selection**: Automatically uses POST endpoint for advanced features, GET for basic search
-- **Enhanced AI Integration**: Better parameter extraction from natural language queries
-- **Comprehensive Testing**: Full test suite including LLM simulation tests
-
-### v2.0.0 - Enhanced Search Parameters
-
-⚠️ **Major version update with breaking changes:**
-
-- **Parameter Structure**: The search tool now uses an object-based parameter structure instead of positional arguments
-- **New Parameters**: Added `limit`, `offset`, and `recency_bias` parameters
-- **Enhanced Validation**: Improved parameter validation with detailed error messages
-- **Version Bump**: Updated from v1.0.7 to v2.0.0
-
-**Migration Guide:**
-```typescript
-// Old format (v1.0.7)
-search("customer feedback", "raw")
-
-// New format (v2.0.0+)
-search({ query: "customer feedback", response_type: "raw" })
-```
-
 ## Quick Start
 
 ### Installation from npm
@@ -153,43 +124,43 @@ Searches within the configured Airweave collection with full parameter control.
 search({ query: "customer feedback about pricing" })
 
 // Search with AI completion
-search({ 
-  query: "billing issues", 
-  response_type: "completion" 
+search({
+  query: "billing issues",
+  response_type: "completion"
 })
 
 // Paginated search
-search({ 
-  query: "API documentation", 
-  limit: 10, 
-  offset: 20 
+search({
+  query: "API documentation",
+  limit: 10,
+  offset: 20
 })
 
 // Recent results with recency bias
-search({ 
-  query: "customer complaints", 
-  recency_bias: 0.8 
+search({
+  query: "customer complaints",
+  recency_bias: 0.8
 })
 
 // Advanced search with high-quality results
-search({ 
-  query: "customer complaints", 
+search({
+  query: "customer complaints",
   score_threshold: 0.8,
   search_method: "neural",
   enable_reranking: true
 })
 
 // Fast keyword search without expansion
-search({ 
-  query: "API documentation", 
+search({
+  query: "API documentation",
   search_method: "keyword",
   expansion_strategy: "no_expansion",
   enable_reranking: false
 })
 
 // Full parameter search
-search({ 
-  query: "support tickets", 
+search({
+  query: "support tickets",
   response_type: "completion",
   limit: 5,
   offset: 0,

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airweave-mcp-search",
-  "version": "2.1.0",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airweave-mcp-search",
-      "version": "2.1.0",
+      "version": "0.5.7",
       "license": "MIT",
       "dependencies": {
         "@airweave/sdk": "^0.5.4",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airweave-mcp-search",
-  "version": "2.1.0",
+  "version": "0.5.7",
   "description": "MCP server for searching Airweave collections",
   "type": "module",
   "main": "build/index.js",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Set up continuous deployment for the MCP package. Releases (or manual runs) now auto-publish airweave-mcp-search to npm; the MCP README was cleaned up.

- **New Features**
  - Extended workflow to publish MCP to npm alongside SDK generation.
  - Auto-sets MCP version from the release tag (strips leading v), then installs, builds, and publishes with NPM_TOKEN.
  - Standardized MCP versioning to match repo releases (e.g., 0.5.7).

- **Migration**
  - Create releases with tags like vX.Y.Z, or run the workflow manually with a version input.
  - Ensure NPM_TOKEN is set in repo secrets.
  - No changes required for consumers.

<!-- End of auto-generated description by cubic. -->

