### PR TITLE
feat(psql): increase batch size and timeout

### DIFF
--- a/backend/airweave/platform/sources/postgresql.py
+++ b/backend/airweave/platform/sources/postgresql.py
@@ -229,8 +229,8 @@ class PostgreSQLSource(BaseSource):
                     user=self.config["user"],
                     password=self.config["password"],
                     database=self.config["database"],
-                    timeout=60.0,  # Connection timeout (1 minute)
-                    command_timeout=300.0,  # Command timeout (5 minutes for slow queries)
+                    timeout=90.0,  # Connection timeout (1.5 minutes)
+                    command_timeout=900.0,  # Command timeout (15 minutes for slow queries)
                 )
             except asyncpg.InvalidPasswordError as e:
                 raise ValueError("Invalid database credentials") from e
@@ -718,7 +718,7 @@ class PostgreSQLSource(BaseSource):
         self._log_sync_type(table_key, cursor_field, last_cursor_value)
 
         # Process table in batches
-        BATCH_SIZE = 1000
+        BATCH_SIZE = 10000
         offset = 0
 
         while True:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Increase PostgreSQL sync throughput and reliability for large tables by raising batch size and timeouts. This reduces timeouts on slow queries and speeds up ingestion.

- **Performance**
  - Batch size increased from 1,000 to 10,000 rows.
  - Connection timeout raised from 60s to 90s.
  - Command timeout raised from 5m to 15m.

<!-- End of auto-generated description by cubic. -->

