### PR TITLE
Fix broken import: missing parenthesis and remove unused imports

### DIFF
--- a/backend/airweave/platform/auth_providers/composio.py
+++ b/backend/airweave/platform/auth_providers/composio.py
@@ -8,8 +8,7 @@ from fastapi import HTTPException
 from airweave.core.credential_sanitizer import (
     safe_log_credentials,
     sanitize_credentials_dict,
-
-from airweave.platform.auth.schemas import AuthType
+)
 from airweave.platform.auth_providers._base import BaseAuthProvider
 from airweave.platform.decorators import auth_provider
 

--- a/backend/airweave/platform/auth_providers/pipedream.py
+++ b/backend/airweave/platform/auth_providers/pipedream.py
@@ -7,7 +7,6 @@ import httpx
 from fastapi import HTTPException
 
 from airweave.core.credential_sanitizer import safe_log_credentials
-from airweave.platform.auth.schemas import AuthType
 from airweave.platform.auth_providers._base import BaseAuthProvider
 from airweave.platform.decorators import auth_provider
 


### PR DESCRIPTION
See title.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a missing closing parenthesis in composio auth provider imports to prevent a SyntaxError on import. Removed unused AuthType imports from composio.py and pipedream.py.

<!-- End of auto-generated description by cubic. -->

