### PR TITLE
fix: add state secret

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -53,6 +53,7 @@ jobs:
           POSTGRES_PASSWORD: "postgres"
           OPENAI_API_KEY: "sk-docs"
           LOCAL_DEVELOPMENT: "true"
+          STATE_SECRET: "dummy-state-secret-key-1234567890-abcdefghijklmn"
 
       - name: Verify OpenAPI spec generation
         run: |


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add STATE_SECRET to the Fern docs GitHub Actions workflow environment. This fixes failures caused by the missing secret during OpenAPI spec verification and local dev startup.

<!-- End of auto-generated description by cubic. -->

