### PR TITLE
feat(monke): support multiple LLM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,29 +65,13 @@ That's it! Access the dashboard at http://localhost:8080
 
 <!-- START_APP_GRID -->
 
-<div style="display: flex; flex-wrap: wrap; justify-content: center; gap: 12px; padding: 8px;">
-  <img src="frontend/src/components/icons/apps/asana.svg" alt="Asana" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/bitbucket.svg" alt="Bitbucket" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/confluence.svg" alt="Confluence" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/dropbox.svg" alt="Dropbox" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/github.svg" alt="Github" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/gmail.svg" alt="Gmail" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/google_calendar.svg" alt="Google Calendar" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/google_drive.svg" alt="Google Drive" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/hubspot.svg" alt="Hubspot" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/jira.svg" alt="Jira" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/linear.svg" alt="Linear" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/monday.svg" alt="Monday" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/notion.svg" alt="Notion" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/onedrive.svg" alt="Onedrive" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/outlook_calendar.svg" alt="Outlook Calendar" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/outlook_mail.svg" alt="Outlook Mail" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/postgresql.svg" alt="Postgresql" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/slack.svg" alt="Slack" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/stripe.svg" alt="Stripe" width="40" height="40" />
-  <img src="frontend/src/components/icons/apps/todoist.svg" alt="Todoist" width="40" height="40" />
-</div>
-
+<p align="center">
+  <div style="display: inline-block; text-align: center; padding: 4px;">
+    <img src="frontend/src/components/icons/apps/asana.svg" alt="Asana" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/bitbucket.svg" alt="Bitbucket" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/confluence.svg" alt="Confluence" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/dropbox.svg" alt="Dropbox" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/github.svg" alt="Github" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/gmail.svg" alt="Gmail" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/google_calendar.svg" alt="Google Calendar" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/google_drive.svg" alt="Google Drive" width="40" height="40" style="margin: 4px; padding: 2px;" />
+    <img src="frontend/src/components/icons/apps/hubspot.svg" alt="Hubspot" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/jira.svg" alt="Jira" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/linear.svg" alt="Linear" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/monday.svg" alt="Monday" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/notion.svg" alt="Notion" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/onedrive.svg" alt="Onedrive" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/outlook_calendar.svg" alt="Outlook Calendar" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/outlook_mail.svg" alt="Outlook Mail" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/postgresql.svg" alt="Postgresql" width="40" height="40" style="margin: 4px; padding: 2px;" />
+    <img src="frontend/src/components/icons/apps/slack.svg" alt="Slack" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/stripe.svg" alt="Stripe" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/todoist.svg" alt="Todoist" width="40" height="40" style="margin: 4px; padding: 2px;" />
+  </div>
+</p>
 
 <!-- END_APP_GRID -->
 

--- a/README.md
+++ b/README.md
@@ -65,13 +65,29 @@ That's it! Access the dashboard at http://localhost:8080
 
 <!-- START_APP_GRID -->
 
-<p align="center">
-  <div style="display: inline-block; text-align: center; padding: 4px;">
-    <img src="frontend/src/components/icons/apps/asana.svg" alt="Asana" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/bitbucket.svg" alt="Bitbucket" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/confluence.svg" alt="Confluence" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/dropbox.svg" alt="Dropbox" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/github.svg" alt="Github" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/gmail.svg" alt="Gmail" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/google_calendar.svg" alt="Google Calendar" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/google_drive.svg" alt="Google Drive" width="40" height="40" style="margin: 4px; padding: 2px;" />
-    <img src="frontend/src/components/icons/apps/hubspot.svg" alt="Hubspot" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/jira.svg" alt="Jira" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/linear.svg" alt="Linear" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/monday.svg" alt="Monday" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/notion.svg" alt="Notion" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/onedrive.svg" alt="Onedrive" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/outlook_calendar.svg" alt="Outlook Calendar" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/outlook_mail.svg" alt="Outlook Mail" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/postgresql.svg" alt="Postgresql" width="40" height="40" style="margin: 4px; padding: 2px;" />
-    <img src="frontend/src/components/icons/apps/slack.svg" alt="Slack" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/stripe.svg" alt="Stripe" width="40" height="40" style="margin: 4px; padding: 2px;" /><img src="frontend/src/components/icons/apps/todoist.svg" alt="Todoist" width="40" height="40" style="margin: 4px; padding: 2px;" />
-  </div>
-</p>
+<div style="display: flex; flex-wrap: wrap; justify-content: center; gap: 12px; padding: 8px;">
+  <img src="frontend/src/components/icons/apps/asana.svg" alt="Asana" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/bitbucket.svg" alt="Bitbucket" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/confluence.svg" alt="Confluence" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/dropbox.svg" alt="Dropbox" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/github.svg" alt="Github" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/gmail.svg" alt="Gmail" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/google_calendar.svg" alt="Google Calendar" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/google_drive.svg" alt="Google Drive" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/hubspot.svg" alt="Hubspot" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/jira.svg" alt="Jira" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/linear.svg" alt="Linear" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/monday.svg" alt="Monday" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/notion.svg" alt="Notion" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/onedrive.svg" alt="Onedrive" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/outlook_calendar.svg" alt="Outlook Calendar" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/outlook_mail.svg" alt="Outlook Mail" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/postgresql.svg" alt="Postgresql" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/slack.svg" alt="Slack" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/stripe.svg" alt="Stripe" width="40" height="40" />
+  <img src="frontend/src/components/icons/apps/todoist.svg" alt="Todoist" width="40" height="40" />
+</div>
+
 
 <!-- END_APP_GRID -->
 

--- a/monke/bongos/asana.py
+++ b/monke/bongos/asana.py
@@ -30,13 +30,13 @@ class AsanaBongo(BaseBongo):
 
         Args:
             credentials: Dict with at least "access_token" (Asana PAT)
-            **kwargs: Optional configuration such as entity_count, openai_model,
+            **kwargs: Optional configuration such as entity_count, llm_model,
                 max_concurrency, rate_limit_delay
         """
         super().__init__(credentials)
         self.access_token: str = credentials["access_token"]
         self.entity_count: int = int(kwargs.get("entity_count", 5))
-        self.openai_model: str = kwargs.get("openai_model", "gpt-4o-mini")
+        self.llm_model = kwargs.get("llm_model", None)
         self.max_concurrency: int = int(kwargs.get("max_concurrency", 1))
         # Use rate_limit_delay_ms from config if provided, otherwise default to 500ms
         rate_limit_ms = int(kwargs.get("rate_limit_delay_ms", 500))
@@ -74,7 +74,7 @@ class AsanaBongo(BaseBongo):
                         await self._rate_limit()
                         token = str(uuid.uuid4())[:8]
                         self.logger.info(f"🔨 Generating content for task with token: {token}")
-                        title, notes, comments = await generate_asana_task(self.openai_model, token)
+                        title, notes, comments = await generate_asana_task(self.llm_model, token)
                         self.logger.info(f"📝 Generated task: '{title[:50]}...'")
 
                         # Create task
@@ -171,7 +171,7 @@ class AsanaBongo(BaseBongo):
             for i in range(count):
                 await self._rate_limit()
                 t = self._tasks[i]
-                title, notes, _ = await generate_asana_task(self.openai_model, t["token"])
+                title, notes, _ = await generate_asana_task(self.llm_model, t["token"])
                 resp = await client.put(
                     f"{self.API_BASE}/tasks/{t['id']}",
                     headers=self._headers(),

--- a/monke/bongos/bitbucket.py
+++ b/monke/bongos/bitbucket.py
@@ -35,7 +35,7 @@ class BitbucketBongo(BaseBongo):
         self.workspace = kwargs.get('workspace', self.username)  # Default to username
         self.repo_slug = kwargs.get('repo_slug', 'monke-test-repo')
         self.branch = kwargs.get('branch', 'main')
-        self.openai_model = kwargs.get('openai_model', 'gpt-5')
+        self.llm_model = kwargs.get('llm_model', None)
 
         # Test data tracking
         self.test_files = []
@@ -63,7 +63,7 @@ class BitbucketBongo(BaseBongo):
             token = str(uuid.uuid4())[:8]
 
             filename, content, file_type = await generate_bitbucket_artifact(
-                self.openai_model, token
+                self.llm_model, token
             )
             filepath = f"monke-test/{filename}-{token}.{file_type}"
 
@@ -106,7 +106,7 @@ class BitbucketBongo(BaseBongo):
 
                 # Generate new content with same token
                 _, content, _ = await generate_bitbucket_artifact(
-                    self.openai_model, token, is_update=True
+                    self.llm_model, token, is_update=True
                 )
 
                 # Update file

--- a/monke/bongos/confluence.py
+++ b/monke/bongos/confluence.py
@@ -31,7 +31,7 @@ class ConfluenceBongo(BaseBongo):
 
         # Configuration from kwargs
         self.entity_count = kwargs.get('entity_count', 10)
-        self.openai_model = kwargs.get('openai_model', 'gpt-5')
+        self.llm_model = kwargs.get('llm_model', None)
 
         # Test data tracking
         self.test_pages = []
@@ -63,7 +63,7 @@ class ConfluenceBongo(BaseBongo):
             # Short unique token used in title and content for verification
             token = str(uuid.uuid4())[:8]
 
-            title, content = await generate_confluence_artifact(self.openai_model, token)
+            title, content = await generate_confluence_artifact(self.llm_model, token)
 
             # Create page
             page_data = await self._create_test_page(
@@ -106,7 +106,7 @@ class ConfluenceBongo(BaseBongo):
 
                 # Generate new content with same token
                 title, content = await generate_confluence_artifact(
-                    self.openai_model, token, is_update=True
+                    self.llm_model, token, is_update=True
                 )
 
                 # Update page

--- a/monke/bongos/dropbox.py
+++ b/monke/bongos/dropbox.py
@@ -31,7 +31,7 @@ class DropboxBongo(BaseBongo):
         # Configuration from kwargs
         self.entity_count = kwargs.get('entity_count', 10)
         self.file_types = kwargs.get('file_types', ["markdown", "text", "json"])
-        self.openai_model = kwargs.get('openai_model', 'gpt-5')
+        self.llm_model = kwargs.get('llm_model', None)
 
         # Test data tracking
         self.test_files = []
@@ -60,7 +60,7 @@ class DropboxBongo(BaseBongo):
             # Short unique token used in filename and content for verification
             token = str(uuid.uuid4())[:8]
 
-            title, content = await generate_dropbox_artifact(file_type, self.openai_model, token)
+            title, content = await generate_dropbox_artifact(file_type, self.llm_model, token)
             filename = f"{title}-{token}.{self._get_file_extension(file_type)}"
             file_path = f"{self.test_folder_path}/{filename}"
 
@@ -103,7 +103,7 @@ class DropboxBongo(BaseBongo):
 
                 # Generate new content with same token
                 title, content = await generate_dropbox_artifact(
-                    file_type, self.openai_model, token, is_update=True
+                    file_type, self.llm_model, token, is_update=True
                 )
 
                 # Update file content

--- a/monke/bongos/github.py
+++ b/monke/bongos/github.py
@@ -33,7 +33,7 @@ class GitHubBongo(BaseBongo):
         # Configuration from kwargs
         self.entity_count = kwargs.get('entity_count', 10)
         self.file_types = kwargs.get('file_types', ["markdown", "python", "json"])
-        self.openai_model = kwargs.get('openai_model', 'gpt-5')
+        self.llm_model = kwargs.get('llm_model', None)
 
         # Test data tracking
         self.test_files = []
@@ -58,7 +58,7 @@ class GitHubBongo(BaseBongo):
             # Short unique token used in filename and body for verification
             token = str(uuid.uuid4())[:8]
 
-            title, content = await generate_github_artifact(file_type, self.openai_model, token)
+            title, content = await generate_github_artifact(file_type, self.llm_model, token)
             slug = slugify(title)[:40] or f"monke-{token}"
             filename = f"{slug}-{token}.{self._get_file_extension(file_type)}"
 
@@ -97,7 +97,7 @@ class GitHubBongo(BaseBongo):
                 file_type = file_info.get("file_type", "markdown")
                 token = file_info.get("token") or str(uuid.uuid4())[:8]
                 # Regenerate content with same token to indicate continuity
-                title, updated_content = await generate_github_artifact(file_type, self.openai_model, token)
+                title, updated_content = await generate_github_artifact(file_type, self.llm_model, token)
 
                 updated_file = await self._update_test_file(
                     file_info["path"],

--- a/monke/bongos/gmail.py
+++ b/monke/bongos/gmail.py
@@ -31,7 +31,7 @@ class GmailBongo(BaseBongo):
 
         # Configuration from kwargs
         self.entity_count = kwargs.get("entity_count", 10)
-        self.openai_model = kwargs.get("openai_model", "gpt-4.1")  # sensible default for JSON mode
+        self.llm_model = kwargs.get("llm_model", None)
         self.llm_max_concurrency = int(kwargs.get("llm_max_concurrency", 8))
 
         # Test data tracking
@@ -60,7 +60,7 @@ class GmailBongo(BaseBongo):
 
         async def gen_one(tok: str):
             async with sem:
-                subject, body = await generate_gmail_artifact(self.openai_model, tok)
+                subject, body = await generate_gmail_artifact(self.llm_model, tok)
                 return tok, subject, body
 
         gen_results = await asyncio.gather(*[gen_one(t) for t in tokens])
@@ -104,7 +104,7 @@ class GmailBongo(BaseBongo):
             token = email_info.get("token") or str(uuid.uuid4())[:8]
             async with sem:
                 subject, body = await generate_gmail_artifact(
-                    self.openai_model, token, is_update=True
+                    self.llm_model, token, is_update=True
                 )
                 return email_info, token, subject, body
 

--- a/monke/bongos/google_calendar.py
+++ b/monke/bongos/google_calendar.py
@@ -36,7 +36,7 @@ class GoogleCalendarBongo(BaseBongo):
 
         # Config from kwargs
         self.entity_count = kwargs.get("entity_count", 10)
-        self.openai_model = kwargs.get("openai_model", "gpt-5")
+        self.llm_model = kwargs.get("llm_model", None)
 
         # Test data tracking
         self.test_events: List[Dict[str, Any]] = []
@@ -77,7 +77,7 @@ class GoogleCalendarBongo(BaseBongo):
         for i in range(self.entity_count):
             token = str(uuid.uuid4())[:8]
             title, description, duration_hours = await generate_google_calendar_artifact(
-                self.openai_model, token
+                self.llm_model, token
             )
 
             start_time = datetime.now(timezone.utc) + timedelta(days=i + 1)
@@ -118,7 +118,7 @@ class GoogleCalendarBongo(BaseBongo):
         for event_info in self.test_events[: min(3, self.entity_count)]:
             token = event_info.get("token") or str(uuid.uuid4())[:8]
             title, description, _ = await generate_google_calendar_artifact(
-                self.openai_model, token, is_update=True
+                self.llm_model, token, is_update=True
             )
 
             await self._update_test_event(

--- a/monke/bongos/google_drive.py
+++ b/monke/bongos/google_drive.py
@@ -32,7 +32,7 @@ class GoogleDriveBongo(BaseBongo):
         # Configuration from kwargs
         self.entity_count = kwargs.get("entity_count", 10)
         self.file_types = kwargs.get("file_types", ["document", "spreadsheet", "pdf"])
-        self.openai_model = kwargs.get("openai_model", "gpt-5")
+        self.llm_model = kwargs.get("llm_model", None)
 
         # Test data tracking
         self.test_files = []
@@ -62,7 +62,7 @@ class GoogleDriveBongo(BaseBongo):
             token = str(uuid.uuid4())[:8]
 
             title, content, mime_type = await generate_google_drive_artifact(
-                file_type, self.openai_model, token
+                file_type, self.llm_model, token
             )
 
             filename = self._filename_with_extension(f"{title}-{token}", file_type)
@@ -112,7 +112,7 @@ class GoogleDriveBongo(BaseBongo):
 
                 # Generate new content with same token
                 title, content, mime_type = await generate_google_drive_artifact(
-                    file_type, self.openai_model, token, is_update=True
+                    file_type, self.llm_model, token, is_update=True
                 )
 
                 # Update file content

--- a/monke/bongos/hubspot.py
+++ b/monke/bongos/hubspot.py
@@ -18,7 +18,7 @@ class HubSpotBongo(BaseBongo):
         super().__init__(credentials)
         self.access_token: str = credentials["access_token"]
         self.entity_count: int = int(kwargs.get("entity_count", 3))
-        self.openai_model: str = kwargs.get("openai_model", "gpt-4.1")
+        self.llm_model = kwargs.get("llm_model", None)
         self.rate_limit_delay = float(kwargs.get("rate_limit_delay_ms", 800)) / 1000.0
         self.logger = get_logger("hubspot_bongo")
         self._contacts: List[Dict[str, Any]] = []
@@ -31,7 +31,7 @@ class HubSpotBongo(BaseBongo):
             for _ in range(self.entity_count):
                 await self._pace()
                 token = str(uuid.uuid4())[:8]
-                c = await generate_hubspot_contact(self.openai_model, token)
+                c = await generate_hubspot_contact(self.llm_model, token)
                 payload = {
                     "properties": {
                         "email": c.email,

--- a/monke/bongos/jira.py
+++ b/monke/bongos/jira.py
@@ -31,7 +31,7 @@ class JiraBongo(BaseBongo):
 
         # Configuration from kwargs
         self.entity_count = kwargs.get('entity_count', 10)
-        self.openai_model = kwargs.get('openai_model', 'gpt-5')
+        self.llm_model = kwargs.get("llm_model", None)
 
         # Test data tracking
         self.test_issues = []
@@ -63,7 +63,7 @@ class JiraBongo(BaseBongo):
             # Short unique token used in summary and description for verification
             token = str(uuid.uuid4())[:8]
 
-            summary, description, issue_type = await generate_jira_artifact(self.openai_model, token)
+            summary, description, issue_type = await generate_jira_artifact(self.llm_model, token)
 
             # Create issue
             issue_data = await self._create_test_issue(
@@ -108,7 +108,7 @@ class JiraBongo(BaseBongo):
 
                 # Generate new content with same token
                 summary, description, _ = await generate_jira_artifact(
-                    self.openai_model, token, is_update=True
+                    self.llm_model, token, is_update=True
                 )
 
                 # Update issue

--- a/monke/bongos/linear.py
+++ b/monke/bongos/linear.py
@@ -16,7 +16,7 @@ class LinearBongo(BaseBongo):
         super().__init__(credentials)
         self.access_token: str = credentials["access_token"]  # Personal API key or OAuth token
         self.entity_count: int = int(kwargs.get("entity_count", 3))
-        self.openai_model: str = kwargs.get("openai_model", "gpt-4.1-mini")
+        self.llm_model = kwargs.get("llm_model", None)
         self.rate_limit_delay = float(kwargs.get("rate_limit_delay_ms", 500)) / 1000.0
         self.logger = get_logger("linear_bongo")
         self._issues: List[Dict[str, Any]] = []
@@ -30,7 +30,7 @@ class LinearBongo(BaseBongo):
             for _ in range(self.entity_count):
                 await self._pace()
                 token = str(uuid.uuid4())[:8]
-                data = await generate_linear_issue(self.openai_model, token)
+                data = await generate_linear_issue(self.llm_model, token)
                 q = """
                 mutation IssueCreate($input: IssueCreateInput!) {
                   issueCreate(input: $input) {

--- a/monke/bongos/monday.py
+++ b/monke/bongos/monday.py
@@ -16,7 +16,7 @@ class MondayBongo(BaseBongo):
         super().__init__(credentials)
         self.access_token: str = credentials["access_token"]
         self.entity_count: int = int(kwargs.get("entity_count", 3))
-        self.openai_model: str = kwargs.get("openai_model", "gpt-4.1-mini")
+        self.llm_model = kwargs.get("llm_model", None)
         self.rate_limit_delay = float(kwargs.get("rate_limit_delay_ms", 500)) / 1000.0
         self.logger = get_logger("monday_bongo")
         self._items: List[Dict[str, Any]] = []
@@ -42,7 +42,7 @@ class MondayBongo(BaseBongo):
             for _ in range(self.entity_count):
                 await self._pace()
                 token = uuid.uuid4().hex[:8]
-                item = await generate_monday_item(self.openai_model, token)
+                item = await generate_monday_item(self.llm_model, token)
                 created = await self._gql(
                     client,
                     """

--- a/monke/bongos/notion.py
+++ b/monke/bongos/notion.py
@@ -26,7 +26,7 @@ class NotionBongo(BaseBongo):
         super().__init__(credentials)
         self.access_token: str = credentials["access_token"]
         self.entity_count: int = int(kwargs.get("entity_count", 5))
-        self.openai_model: str = kwargs.get("openai_model", "gpt-4o-mini")
+        self.llm_model = kwargs.get("llm_model", None)
 
         # Rate limiting: ~3 requests per second
         rate_limit_ms = int(kwargs.get("rate_limit_delay_ms", 334))
@@ -138,7 +138,7 @@ class NotionBongo(BaseBongo):
             token = str(uuid.uuid4())[:8]
 
             # Generate page content
-            title, content_blocks = await generate_notion_page(self.openai_model, token)
+            title, content_blocks = await generate_notion_page(self.llm_model, token)
             # Embed token in title to make it reliably searchable downstream
             title_with_token = f"{token} {title}"
 
@@ -188,7 +188,7 @@ class NotionBongo(BaseBongo):
 
             # Generate new content
             title, content_blocks = await generate_notion_page(
-                self.openai_model,
+                self.llm_model,
                 token,
                 update=True
             )

--- a/monke/bongos/outlook_calendar.py
+++ b/monke/bongos/outlook_calendar.py
@@ -16,7 +16,7 @@ class OutlookCalendarBongo(BaseBongo):
         super().__init__(credentials)
         self.access_token: str = credentials["access_token"]
         self.entity_count: int = int(kwargs.get("entity_count", 3))
-        self.openai_model: str = kwargs.get("openai_model", "gpt-4.1")
+        self.llm_model = kwargs.get("llm_model", None)
         self.rate_limit_delay = float(kwargs.get("rate_limit_delay_ms", 500)) / 1000.0
         self.logger = get_logger("outlook_calendar_bongo")
         self._events: List[Dict[str, Any]] = []
@@ -29,7 +29,7 @@ class OutlookCalendarBongo(BaseBongo):
             for _ in range(self.entity_count):
                 await self._pace()
                 token = uuid.uuid4().hex[:8]
-                ev = await generate_outlook_event(self.openai_model, token)
+                ev = await generate_outlook_event(self.llm_model, token)
                 payload = {
                     "subject": ev.subject,
                     "body": {"contentType": "HTML", "content": ev.body_html},

--- a/monke/bongos/outlook_mail.py
+++ b/monke/bongos/outlook_mail.py
@@ -16,7 +16,7 @@ class OutlookMailBongo(BaseBongo):
         super().__init__(credentials)
         self.access_token: str = credentials["access_token"]
         self.entity_count: int = int(kwargs.get("entity_count", 3))
-        self.openai_model: str = kwargs.get("openai_model", "gpt-4.1-mini")
+        self.llm_model = kwargs.get("llm_model", None)
         self.rate_limit_delay = float(kwargs.get("rate_limit_delay_ms", 500)) / 1000.0
         self.logger = get_logger("outlook_mail_bongo")
         self._messages: List[Dict[str, Any]] = []
@@ -29,7 +29,7 @@ class OutlookMailBongo(BaseBongo):
             for _ in range(self.entity_count):
                 await self._pace()
                 token = uuid.uuid4().hex[:8]
-                msg = await generate_outlook_message(self.openai_model, token)
+                msg = await generate_outlook_message(self.llm_model, token)
                 payload = {
                     "subject": msg.subject,
                     "body": {"contentType": "HTML", "content": msg.body_html},

--- a/monke/bongos/stripe.py
+++ b/monke/bongos/stripe.py
@@ -30,7 +30,7 @@ class StripeBongo(BaseBongo):
 
         # Configuration from kwargs
         self.entity_count = kwargs.get('entity_count', 10)
-        self.openai_model = kwargs.get('openai_model', 'gpt-5')
+        self.llm_model = kwargs.get("llm_model", None)
 
         # Test data tracking
         self.test_customers = []
@@ -54,7 +54,7 @@ class StripeBongo(BaseBongo):
             # Short unique token used in name and metadata for verification
             token = str(uuid.uuid4())[:8]
 
-            name, email, description = await generate_stripe_artifact(self.openai_model, token)
+            name, email, description = await generate_stripe_artifact(self.llm_model, token)
 
             # Create customer
             customer_data = await self._create_test_customer(
@@ -98,7 +98,7 @@ class StripeBongo(BaseBongo):
 
                 # Generate new content with same token
                 name, email, description = await generate_stripe_artifact(
-                    self.openai_model, token, is_update=True
+                    self.llm_model, token, is_update=True
                 )
 
                 # Update customer

--- a/monke/bongos/todoist.py
+++ b/monke/bongos/todoist.py
@@ -30,7 +30,7 @@ class TodoistBongo(BaseBongo):
 
         # Configuration from kwargs
         self.entity_count = kwargs.get('entity_count', 10)
-        self.openai_model = kwargs.get('openai_model', 'gpt-5')
+        self.llm_model = kwargs.get("llm_model", None)
 
         # Test data tracking
         self.test_tasks = []
@@ -58,7 +58,7 @@ class TodoistBongo(BaseBongo):
             # Short unique token used in content for verification
             token = str(uuid.uuid4())[:8]
 
-            content, description, priority = await generate_todoist_artifact(self.openai_model, token)
+            content, description, priority = await generate_todoist_artifact(self.llm_model, token)
 
             # Create task
             task_data = await self._create_test_task(
@@ -102,7 +102,7 @@ class TodoistBongo(BaseBongo):
 
                 # Generate new content with same token
                 content, description, priority = await generate_todoist_artifact(
-                    self.openai_model, token, is_update=True
+                    self.llm_model, token, is_update=True
                 )
 
                 # Update task

--- a/monke/client/llm.py
+++ b/monke/client/llm.py
@@ -1,49 +1,131 @@
-"""Lightweight OpenAI client (Async + Structured Outputs)."""
+"""Multi-provider LLM client (Async + Structured Outputs)."""
 
 from __future__ import annotations
 
 import os
 import re
-from typing import Optional, Type
+from typing import Optional, Type, Any
 
-from openai import AsyncOpenAI
 from pydantic import BaseModel, ValidationError
 
 from monke.utils.logging import get_logger
 
 
+class ProviderType:
+    """LLM providers."""
+
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    MISTRAL = "mistral"
+
+
 class LLMClient:
     """
-    Async wrapper around OpenAI's Responses API.
+    Multi-provider async LLM client.
 
-    - Uses AsyncOpenAI (official async SDK client)
-    - Structured Outputs via `responses.parse`: pass a Pydantic model and get a parsed instance back
-    - Falls back to JSON Schema response_format (strict) if `parse()` isn't available
+    - Supports OpenAI, Anthropic, and Mistral APIs
+    - Structured Outputs via provider-specific implementations
+    - Provider detection based on available environment variables
+    - Priority: OpenAI > Anthropic > Mistral
     """
 
     def __init__(self, model_override: Optional[str] = None):
-        if not os.getenv("OPENAI_API_KEY"):
-            raise RuntimeError("OPENAI_API_KEY is required in environment")
-
-        base_url = os.getenv("OPENAI_BASE_URL")
-        self.client = AsyncOpenAI(base_url=base_url) if base_url else AsyncOpenAI()
-        # Default to gpt-4.1 unless overridden via arg or env
-        self.model = model_override or os.getenv("OPENAI_MODEL", "gpt-4.1")
         self.logger = get_logger("llm_client")
 
-    async def generate_text(self, instruction: str) -> str:
-        """Simple text generation using the Responses API."""
-        resp = await self.client.responses.create(
-            model=self.model,
-            instructions="You generate fresh, varied test data.",
-            input=instruction,
-            temperature=0.8,
-        )
-        return getattr(resp, "output_text", "") or ""
+        self.provider = self._detect_provider()
+        self.client = self._initialize_client()
 
-    async def generate_structured(self, schema: Type[BaseModel], instruction: str) -> BaseModel:
+        self.model = self._get_model(model_override)
+
+    def _detect_provider(self) -> str:
+        """Detect which provider to use based on available API keys."""
+        if os.getenv("OPENAI_API_KEY"):
+            return ProviderType.OPENAI
+        elif os.getenv("ANTHROPIC_API_KEY"):
+            return ProviderType.ANTHROPIC
+        elif os.getenv("MISTRAL_API_KEY"):
+            return ProviderType.MISTRAL
+        else:
+            raise RuntimeError(
+                "No API key found. Please set one of: OPENAI_API_KEY, ANTHROPIC_API_KEY, or MISTRAL_API_KEY"
+            )
+
+    def _initialize_client(self) -> Any:
+        """Initialize the client based on detected provider."""
+        if self.provider == ProviderType.OPENAI:
+            try:
+                from openai import AsyncOpenAI
+            except ImportError:
+                raise RuntimeError(
+                    "OpenAI package not installed. Run: pip install openai>=1.40.0"
+                )
+            base_url = os.getenv("OPENAI_BASE_URL")
+            return AsyncOpenAI(base_url=base_url) if base_url else AsyncOpenAI()
+
+        elif self.provider == ProviderType.ANTHROPIC:
+            try:
+                from anthropic import AsyncAnthropic
+            except ImportError:
+                raise RuntimeError(
+                    "Anthropic package not installed. Run: pip install anthropic"
+                )
+            return AsyncAnthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+
+        elif self.provider == ProviderType.MISTRAL:
+            try:
+                from mistralai.async_client import MistralAsyncClient
+            except ImportError:
+                raise RuntimeError(
+                    "Mistral package not installed. Run: pip install mistralai"
+                )
+            return MistralAsyncClient(api_key=os.getenv("MISTRAL_API_KEY"))
+
+        else:
+            raise RuntimeError(f"Unsupported provider: {self.provider}")
+
+    def _get_model(self, model_override: Optional[str]) -> str:
+        """Get the model name with provider-specific defaults."""
+        if model_override:
+            return model_override
+
+        env_model = (
+            os.getenv("OPENAI_MODEL")
+            or os.getenv("ANTHROPIC_MODEL")
+            or os.getenv("MISTRAL_MODEL")
+        )
+        if env_model:
+            return env_model
+
+        # Provider-specific defaults
+        if self.provider == ProviderType.OPENAI:
+            return "gpt-4.1"
+        elif self.provider == ProviderType.ANTHROPIC:
+            return "claude-3-5-sonnet-20241022"
+        elif self.provider == ProviderType.MISTRAL:
+            return "mistral-large-latest"
+        else:
+            return "gpt-4.1"  # fallback
+
+    async def generate_structured(
+        self, schema: Type[BaseModel], instruction: str
+    ) -> BaseModel:
+        """Generate structured output that matches the given Pydantic schema."""
+        if self.provider == ProviderType.OPENAI:
+            return await self._generate_structured_openai(schema, instruction)
+        elif self.provider == ProviderType.ANTHROPIC:
+            return await self._generate_structured_anthropic(schema, instruction)
+        elif self.provider == ProviderType.MISTRAL:
+            return await self._generate_structured_mistral(schema, instruction)
+        else:
+            raise RuntimeError(
+                f"Structured generation not implemented for provider: {self.provider}"
+            )
+
+    async def _generate_structured_openai(
+        self, schema: Type[BaseModel], instruction: str
+    ) -> BaseModel:
         """
-        Generate an object that matches the given Pydantic schema using Structured Outputs.
+        OpenAI structured generation using Structured Outputs.
 
         Primary path: `responses.parse(...)` with `text_format=schema` (Pydantic class).
         Fallback:     `responses.create(...)` with response_format=json_schema + strict, then Pydantic-validate.
@@ -52,48 +134,147 @@ class LLMClient:
         try:
             resp = await self.client.responses.parse(
                 model=self.model,
-                input=instruction,  # you can also pass a list of role/content items if you prefer
+                input=instruction,
                 instructions="Return only a single object that conforms to the provided schema.",
-                text_format=schema,  # <- Pydantic class; SDK converts to JSON Schema and parses output
+                text_format=schema,
                 temperature=0.7,
             )
             parsed = getattr(resp, "output_parsed", None)
             if parsed is not None:
-                return parsed  # already a Pydantic instance
-            # If for some reason parsed is None, fall through to the defensive fallback below.
+                return parsed
             self.logger.warning(
                 "Structured parse returned no parsed object; attempting JSON Schema fallback."
             )
         except Exception as e:
-            # Common causes: older SDK version, transient parsing issues, or unsupported model.
-            self.logger.exception("Structured parse failed; attempting JSON Schema fallback: %s", e)
+            self.logger.exception(
+                "Structured parse failed; attempting JSON Schema fallback: %s", e
+            )
 
         # --- Defensive fallback: strict JSON Schema response_format ---
-        # Convert the Pydantic model to a JSON Schema and enforce strict adherence server-side.
-        rf = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": schema.__name__,
-                "schema": schema.model_json_schema(),
-                "strict": True,
-            },
+        return await self._fallback_json_parsing(schema, instruction, "openai")
+
+    async def _generate_structured_anthropic(
+        self, schema: Type[BaseModel], instruction: str
+    ) -> BaseModel:
+        """Anthropic structured generation using tool calling."""
+        tool_definition = {
+            "name": f"create_{schema.__name__.lower()}",
+            "description": f"Create a {schema.__name__} object",
+            "input_schema": schema.model_json_schema(),
         }
 
-        resp2 = await self.client.responses.create(
+        message = await self.client.messages.create(
             model=self.model,
-            input=instruction,
-            instructions="Return ONLY a single JSON object that matches the schema. No prose.",
-            response_format=rf,
+            max_tokens=4000,
             temperature=0.7,
+            system="You are a helpful assistant that creates structured data objects.",
+            messages=[{"role": "user", "content": instruction}],
+            tools=[tool_definition],
+            tool_choice={"type": "tool", "name": tool_definition["name"]},
         )
 
-        raw = getattr(resp2, "output_text", "") or ""
-        # Validate the raw JSON text with Pydantic. If the model wrapped it, extract the first JSON object.
+        for content in message.content:
+            if content.type == "tool_use":
+                return schema.model_validate(content.input)
+
+        # Fallback to JSON parsing if no tool use
+        return await self._fallback_json_parsing(schema, instruction, "anthropic")
+
+    async def _generate_structured_mistral(
+        self, schema: Type[BaseModel], instruction: str
+    ) -> BaseModel:
+        """Mistral structured generation using function calling."""
+        function_definition = {
+            "name": f"create_{schema.__name__.lower()}",
+            "description": f"Create a {schema.__name__} object",
+            "parameters": schema.model_json_schema(),
+        }
+
+        response = await self.client.chat(
+            model=self.model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant that creates structured data objects.",
+                },
+                {"role": "user", "content": instruction},
+            ],
+            tools=[{"type": "function", "function": function_definition}],
+            tool_choice="any",
+            temperature=0.7,
+            max_tokens=4000,
+        )
+
+        message = response.choices[0].message
+        if message.tool_calls:
+            import json
+
+            function_args = json.loads(message.tool_calls[0].function.arguments)
+            return schema.model_validate(function_args)
+
+        # Fallback to JSON parsing if no tool calls
+        return await self._fallback_json_parsing(schema, instruction, "mistral")
+
+    async def _fallback_json_parsing(
+        self, schema: Type[BaseModel], instruction: str, provider: str
+    ) -> BaseModel:
+        """Unified JSON parsing fallback for providers without native structured output."""
+        json_instruction = f"{instruction}\n\nReturn only valid JSON matching this schema:\n{schema.model_json_schema()}"
+
+        if provider == "openai":
+            rf = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": schema.__name__,
+                    "schema": schema.model_json_schema(),
+                    "strict": True,
+                },
+            }
+            resp = await self.client.responses.create(
+                model=self.model,
+                input=json_instruction,
+                response_format=rf,
+                temperature=0.7,
+            )
+            raw = getattr(resp, "output_text", "") or ""
+
+        elif provider == "anthropic":
+            message = await self.client.messages.create(
+                model=self.model,
+                max_tokens=4000,
+                temperature=0.7,
+                system="Return only valid JSON. No explanations.",
+                messages=[{"role": "user", "content": json_instruction}],
+            )
+            raw = message.content[0].text if message.content else ""
+
+        elif provider == "mistral":
+            response = await self.client.chat(
+                model=self.model,
+                temperature=0.7,
+                max_tokens=4000,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "Return only valid JSON. No explanations.",
+                    },
+                    {"role": "user", "content": json_instruction},
+                ],
+            )
+            raw = response.choices[0].message.content if response.choices else ""
+
+        else:
+            raise RuntimeError(f"Unknown provider for fallback: {provider}")
+
+        return self._parse_json_response(schema, raw)
+
+    def _parse_json_response(self, schema: Type[BaseModel], raw: str) -> BaseModel:
+        """Parse JSON response text into Pydantic model."""
         try:
             return schema.model_validate_json(raw)
         except ValidationError:
+            # Try to extract JSON from response
             m = re.search(r"\{[\s\S]*\}", raw)
             if not m:
-                # Nothing JSON-like to validate
-                raise
+                raise ValueError(f"No valid JSON found in response: {raw}")
             return schema.model_validate_json(m.group(0))

--- a/monke/configs/asana.yaml
+++ b/monke/configs/asana.yaml
@@ -6,7 +6,7 @@ connector:
   type: asana
   auth_fields: {}  # Will be resolved by credentials_resolver (either from env or provider)
   config_fields:
-    openai_model: "gpt-4.1-mini"  # Model for content generation
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     rate_limit_delay_ms: 1000  # Increased delay between API calls for Asana
     # post_create_sleep_seconds: 15
 

--- a/monke/configs/bitbucket.yaml
+++ b/monke/configs/bitbucket.yaml
@@ -8,8 +8,8 @@ connector:
   auth_fields: {}
     # username: "${BITBUCKET_USERNAME}"
     # app_password: "${BITBUCKET_APP_PASSWORD}"
-  config_fields:
-    openai_model: "gpt-4.1-mini"
+  config_fields: {}
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     # post_create_sleep_seconds: 7  # Optional: wait N seconds after creation before first sync
 
 test_flow:

--- a/monke/configs/confluence.yaml
+++ b/monke/configs/confluence.yaml
@@ -9,7 +9,7 @@ connector:
     access_token: "${CONFLUENCE_ACCESS_TOKEN}"
   config_fields:
     cloud_id: "${CONFLUENCE_CLOUD_ID}"  # Optional, will be auto-discovered if not provided
-    openai_model: "gpt-5"
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     # post_create_sleep_seconds: 7  # Optional: wait N seconds after creation before first sync
 
 test_flow:

--- a/monke/configs/dropbox.yaml
+++ b/monke/configs/dropbox.yaml
@@ -7,8 +7,8 @@ connector:
   type: "dropbox"
   auth_fields:
     access_token: "${DROPBOX_ACCESS_TOKEN}"
-  config_fields:
-    openai_model: "gpt-5"
+  config_fields: {}
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     # post_create_sleep_seconds: 7  # Optional: wait N seconds after creation before first sync
 
 test_flow:

--- a/monke/configs/github.yaml
+++ b/monke/configs/github.yaml
@@ -10,7 +10,7 @@ connector:
     repo_name: "${GITHUB_REPO_NAME}"
   config_fields:
     branch: "main"
-    openai_model: "gpt-5"
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     post_create_sleep_seconds: 15
 
 test_flow:

--- a/monke/configs/gmail.yaml
+++ b/monke/configs/gmail.yaml
@@ -7,8 +7,8 @@ connector:
   type: "gmail"
   auth_fields: {}
     # access_token: "${GMAIL_ACCESS_TOKEN}"
-  config_fields:
-    openai_model: "gpt-4.1-mini"
+  config_fields: {}
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     # post_create_sleep_seconds: 7  # Optional: wait N seconds after creation before first sync
 
 test_flow:

--- a/monke/configs/google_calendar.yaml
+++ b/monke/configs/google_calendar.yaml
@@ -7,8 +7,8 @@ connector:
   type: "google_calendar"
   auth_fields: {}
     # access_token: "${GOOGLE_CALENDAR_ACCESS_TOKEN}"
-  config_fields:
-    openai_model: "gpt-4.1-mini"
+  config_fields: {}
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     # post_create_sleep_seconds: 7  # Optional: wait N seconds after creation before first sync
 
 test_flow:

--- a/monke/configs/google_drive.yaml
+++ b/monke/configs/google_drive.yaml
@@ -7,8 +7,8 @@ connector:
   type: "google_drive"
   auth_fields: {}
     # access_token: "${GOOGLE_DRIVE_ACCESS_TOKEN}"
-  config_fields:
-    openai_model: "gpt-4.1"
+  config_fields: {}
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     # post_create_sleep_seconds: 7  # Optional: wait N seconds after creation before first sync
 
 test_flow:

--- a/monke/configs/hubspot.yaml
+++ b/monke/configs/hubspot.yaml
@@ -5,7 +5,7 @@ connector:
   type: "hubspot"
   auth_fields: {}   # resolved by credentials_resolver (expects access_token)
   config_fields:
-    openai_model: "gpt-4.1"
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     rate_limit_delay_ms: 800
 test_flow:
   steps: [create, sync, verify, update, sync, verify, partial_delete, sync, verify_partial_deletion, verify_remaining_entities, complete_delete, sync, verify_complete_deletion]

--- a/monke/configs/jira.yaml
+++ b/monke/configs/jira.yaml
@@ -9,7 +9,7 @@ connector:
     # access_token: "${JIRA_ACCESS_TOKEN}"
   config_fields:
     cloud_id: "${JIRA_CLOUD_ID}"  # Optional, will be auto-discovered if not provided
-    openai_model: "gpt-4.1-mini"
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     # post_create_sleep_seconds: 7  # Optional: wait N seconds after creation before first sync
 
 test_flow:

--- a/monke/configs/linear.yaml
+++ b/monke/configs/linear.yaml
@@ -5,7 +5,7 @@ connector:
   type: "linear"
   auth_fields: {}   # expects access_token = Linear personal API key or OAuth token
   config_fields:
-    openai_model: "gpt-4.1-mini"
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     rate_limit_delay_ms: 500
 test_flow:
   steps: [create, sync, verify, update, sync, verify, partial_delete, sync, verify_partial_deletion, verify_remaining_entities, complete_delete, sync, verify_complete_deletion]

--- a/monke/configs/monday.yaml
+++ b/monke/configs/monday.yaml
@@ -5,7 +5,7 @@ connector:
   type: "monday"
   auth_fields: {}   # expects access_token (personal token or OAuth)
   config_fields:
-    openai_model: "gpt-4.1-mini"
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     rate_limit_delay_ms: 500
 test_flow:
   steps: [create, sync, verify, update, sync, verify, partial_delete, sync, verify_partial_deletion, verify_remaining_entities, complete_delete, sync, verify_complete_deletion]

--- a/monke/configs/notion.yaml
+++ b/monke/configs/notion.yaml
@@ -5,8 +5,8 @@ connector:
   name: Notion
   type: notion
   auth_fields: {}  # Resolved by credentials_resolver
-  config_fields:
-    openai_model: "gpt-4.1-mini"
+  config_fields: {}
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
   rate_limit_delay_ms: 334  # ~3 requests per second
   # post_create_sleep_seconds: 15
 

--- a/monke/configs/outlook_calendar.yaml
+++ b/monke/configs/outlook_calendar.yaml
@@ -5,7 +5,7 @@ connector:
   type: "outlook_calendar"
   auth_fields: {}   # expects access_token (Graph)
   config_fields:
-    openai_model: "gpt-4.1"
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     rate_limit_delay_ms: 500
 test_flow:
   steps: [create, sync, verify, update, sync, verify, partial_delete, sync, verify_partial_deletion, verify_remaining_entities, complete_delete, sync, verify_complete_deletion]

--- a/monke/configs/outlook_mail.yaml
+++ b/monke/configs/outlook_mail.yaml
@@ -5,7 +5,7 @@ connector:
   type: "outlook_mail"
   auth_fields: {}   # expects access_token (Graph)
   config_fields:
-    openai_model: "gpt-4.1-mini"
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     rate_limit_delay_ms: 500
 test_flow:
   steps: [create, sync, verify, update, sync, verify, partial_delete, sync, verify_partial_deletion, verify_remaining_entities, complete_delete, sync, verify_complete_deletion]

--- a/monke/configs/stripe.yaml
+++ b/monke/configs/stripe.yaml
@@ -6,8 +6,8 @@ connector:
   name: "stripe_test"
   type: "stripe"
   auth_fields: {}
-  config_fields:
-    openai_model: "gpt-5"
+  config_fields: {}
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
 
 test_flow:
   steps:

--- a/monke/configs/todoist.yaml
+++ b/monke/configs/todoist.yaml
@@ -7,7 +7,7 @@ connector:
   type: "todoist"
   auth_fields: {}
   config_fields:
-    openai_model: "gpt-5"
+    # llm_model: "model-name"  # Optional: override LLM model (otherwise uses env.test detection)
     post_create_sleep_seconds: 15
 
 test_flow:

--- a/monke/generation/asana.py
+++ b/monke/generation/asana.py
@@ -53,7 +53,7 @@ async def generate_asana_task(model: str, token: str) -> Tuple[str, str, List[st
     Returns:
         Tuple of (title, notes, comments)
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     instruction = (
         "Generate a realistic Asana task for a software development project. "

--- a/monke/generation/bitbucket.py
+++ b/monke/generation/bitbucket.py
@@ -13,7 +13,7 @@ async def generate_bitbucket_artifact(
 
     Returns (filename, content, file_type). The token must be embedded in the output by instruction.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     if is_update:
         instruction = (

--- a/monke/generation/confluence.py
+++ b/monke/generation/confluence.py
@@ -13,7 +13,7 @@ async def generate_confluence_artifact(
 
     Returns (title, content). The token must be embedded in the output by instruction.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     if is_update:
         instruction = (

--- a/monke/generation/dropbox.py
+++ b/monke/generation/dropbox.py
@@ -55,7 +55,7 @@ async def generate_dropbox_artifact(
 
     Returns (title, content). The token must be embedded in the output by instruction.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     instructions = {
         "markdown": (

--- a/monke/generation/github.py
+++ b/monke/generation/github.py
@@ -44,7 +44,7 @@ async def generate_github_artifact(file_type: str, model: str, token: str) -> Tu
 
     Returns (title, body). The token must be embedded in the output by instruction.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     instructions = {
         "markdown": (

--- a/monke/generation/gmail.py
+++ b/monke/generation/gmail.py
@@ -13,7 +13,7 @@ async def generate_gmail_artifact(
     Returns (subject, body). The literal token must appear in the body.
     Uses JSON mode (response_format: json_object) under the hood.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     if is_update:
         instruction = (

--- a/monke/generation/google_calendar.py
+++ b/monke/generation/google_calendar.py
@@ -13,7 +13,7 @@ async def generate_google_calendar_artifact(
 
     Returns (title, description, duration_hours). The token must be embedded in the output by instruction.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     if is_update:
         instruction = (

--- a/monke/generation/google_drive.py
+++ b/monke/generation/google_drive.py
@@ -71,7 +71,7 @@ async def generate_google_drive_artifact(
 
     Returns (title, content, mime_type). The token must be embedded in the output by instruction.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     instructions = {
         "document": (

--- a/monke/generation/hubspot.py
+++ b/monke/generation/hubspot.py
@@ -7,7 +7,7 @@ async def generate_hubspot_contact(model: str, token: str) -> HubSpotContact:
     Generate a realistic CRM contact. The email MUST contain the token (e.g., token@monke.test)
     so we can reliably verify later via search.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
     instruction = (
         "Generate a realistic CRM contact for a B2B SaaS context. "
         f"The literal token '{token}' MUST be embedded in the email local-part (e.g., '{token}@example.test') "

--- a/monke/generation/jira.py
+++ b/monke/generation/jira.py
@@ -13,7 +13,7 @@ async def generate_jira_artifact(
 
     Returns (summary, description, issue_type). The token must be embedded in the output by instruction.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     if is_update:
         instruction = (

--- a/monke/generation/linear.py
+++ b/monke/generation/linear.py
@@ -7,7 +7,7 @@ async def generate_linear_issue(model: str, token: str) -> LinearIssue:
     Generate a realistic software/dev work item.
     Token MUST appear at the start of the title and inside the description/comments.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
     instruction = (
         "Create a realistic engineering issue for a modern web service. "
         f"Start the title with the literal token '{token}' and include it in the description and at least one comment. "

--- a/monke/generation/monday.py
+++ b/monke/generation/monday.py
@@ -3,7 +3,7 @@ from monke.generation.schemas.monday import MondayItem
 
 
 async def generate_monday_item(model: str, token: str) -> MondayItem:
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
     instruction = (
         "Generate a realistic work item summary for a monday.com board. "
         f"Include the literal token '{token}' in the item name and note. "

--- a/monke/generation/notion.py
+++ b/monke/generation/notion.py
@@ -77,7 +77,7 @@ async def generate_notion_page(
     update: bool = False
 ) -> Tuple[str, List[Dict[str, Any]]]:
     """Generate page content for Notion testing using LLM."""
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     update_context = " (updated version)" if update else ""
 

--- a/monke/generation/outlook_mail.py
+++ b/monke/generation/outlook_mail.py
@@ -3,7 +3,7 @@ from monke.generation.schemas.outlook_mail import OutlookMessage
 
 
 async def generate_outlook_message(model: str, token: str) -> OutlookMessage:
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
     instruction = (
         "Generate a short, safe, non-sensitive email draft about an internal product update. "
         f"Include the literal token '{token}' in subject and body. Use example recipients @example.test"

--- a/monke/generation/stripe.py
+++ b/monke/generation/stripe.py
@@ -13,7 +13,7 @@ async def generate_stripe_artifact(
 
     Returns (name, email, description). The token must be embedded in the output by instruction.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     if is_update:
         instruction = (

--- a/monke/generation/todoist.py
+++ b/monke/generation/todoist.py
@@ -13,7 +13,7 @@ async def generate_todoist_artifact(
 
     Returns (content, description, priority). The token must be embedded in the output by instruction.
     """
-    llm = LLMClient(model_override=model)
+    llm = LLMClient(model_override=model if model else None)
 
     if is_update:
         instruction = (

--- a/monke/requirements.txt
+++ b/monke/requirements.txt
@@ -11,6 +11,8 @@ pyyaml>=6.0
 # Async support
 asyncio-mqtt>=0.16.0
 openai>=1.40.0
+anthropic>=0.34.0
+mistralai>=1.0.0
 uvicorn[standard]>=0.30.0
 websockets>=12.0
 airweave-sdk>=0.1.3


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add multi-provider LLM support (OpenAI, Anthropic, Mistral) and make generation model-agnostic across all connectors. Replaces openai_model with an optional llm_model and auto-detects the provider from environment variables.

- New Features
  - New LLMClient with provider detection via env keys (priority: OPENAI_API_KEY > ANTHROPIC_API_KEY > MISTRAL_API_KEY).
  - Structured outputs per provider: OpenAI structured parse, Anthropic tool use, Mistral function calling, with a unified JSON fallback.
  - All bongos and generation functions now use llm_model (or None to auto-detect). YAML configs updated to make model override optional.
  - Added dependencies: anthropic and mistralai.

- Migration
  - Update any custom configs: replace openai_model with llm_model or remove to rely on auto-detection.
  - Ensure one provider API key is set; optionally set OPENAI_MODEL/ANTHROPIC_MODEL/MISTRAL_MODEL.
  - Install new deps: pip install -r requirements.txt.

<!-- End of auto-generated description by cubic. -->

