### PR TITLE
fix(monke): sync timeouts and text2vec token limits

### DIFF
--- a/monke/configs/gmail.yaml
+++ b/monke/configs/gmail.yaml
@@ -8,8 +8,7 @@ connector:
   auth_fields: {}
     # access_token: "${GMAIL_ACCESS_TOKEN}"
   config_fields:
-    openai_model: "gpt-4.1-mini"
-    # post_create_sleep_seconds: 7  # Optional: wait N seconds after creation before first sync
+    post_create_sleep_seconds: 10  # Wait 10 seconds for Gmail API to propagate emails
 
 test_flow:
   steps:


### PR DESCRIPTION
FIXED
1. **Sync Timeouts**: Jobs stuck `in_progress` 
2. **ReadTimeout Errors**: embedding failures from oversized texts  
3. **Token Limit Bottleneck**: LLM-generated tests (330-1839 tokens) exceed 250-token safety limit


TODO:
1. Upgrade embedding model to handle larger token limits (OpenAI embeddings)
2. Remove 250-token restriction once model capacity allows