### PR TITLE
feat(source connections): tighten source connection objects

### DIFF
--- a/backend/airweave/crud/crud_collection.py
+++ b/backend/airweave/crud/crud_collection.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from airweave import crud
 from airweave.api.context import ApiContext
 from airweave.core.exceptions import NotFoundException
-from airweave.core.shared_models import CollectionStatus, SourceConnectionStatus
+from airweave.core.shared_models import CollectionStatus
 from airweave.crud._base_organization import CRUDBaseOrganization
 from airweave.models.collection import Collection
 from airweave.schemas.collection import CollectionCreate, CollectionUpdate
@@ -40,16 +40,18 @@ class CRUDCollection(CRUDBaseOrganization[Collection, CollectionCreate, Collecti
         Returns:
             The computed ephemeral status
         """
-        # Get all source connections for this collection
-        source_connections = await crud.source_connection.get_for_collection(
-            db, readable_collection_id=collection.readable_id, ctx=ctx
+        # Get source connections with their stats to compute proper status
+        connections_with_stats = await crud.source_connection.get_multi_with_stats(
+            db, ctx=ctx, collection_id=collection.readable_id
         )
 
-        if not source_connections:
+        if not connections_with_stats:
             return CollectionStatus.NEEDS_SOURCE
 
         # Filter out pending shells to evaluate the status of active connections
-        active_connections = [sc for sc in source_connections if sc.is_authenticated]
+        active_connections = [
+            conn for conn in connections_with_stats if conn.get("is_authenticated", False)
+        ]
 
         # If there are no authenticated connections, it's effectively the same as needing a source
         if not active_connections:
@@ -59,14 +61,18 @@ class CRUDCollection(CRUDBaseOrganization[Collection, CollectionCreate, Collecti
         failing_count = 0
         in_progress_count = 0
 
-        for sc in active_connections:
-            if sc.status == SourceConnectionStatus.ERROR:
+        for conn in active_connections:
+            # Get last job status to compute connection status
+            last_job = conn.get("last_job", {})
+            last_job_status = last_job.get("status") if last_job else None
+
+            # Determine connection status based on last job
+            if last_job_status == "failed":
                 failing_count += 1
-            elif sc.status in [
-                SourceConnectionStatus.SYNCING,
-                SourceConnectionStatus.PENDING_SYNC,
-                SourceConnectionStatus.ACTIVE,
-            ]:
+            elif last_job_status == "running":
+                in_progress_count += 1
+            else:
+                # Active, completed, or no jobs yet
                 in_progress_count += 1
 
         # If any active connections are in progress, the collection is active

--- a/backend/airweave/crud/crud_source_connection.py
+++ b/backend/airweave/crud/crud_source_connection.py
@@ -73,8 +73,12 @@ class CRUDSourceConnection(
         collection_id: Optional[str] = None,
         skip: int = 0,
         limit: int = 100,
-    ) -> List[SourceConnection]:
-        """Get multiple source connections with aggregated stats."""
+    ) -> List[Dict[str, Any]]:
+        """Get source connections with all necessary stats in minimal queries.
+
+        Returns list of dictionaries with complete data for the list endpoint.
+        """
+        # 1. Get base source connections
         query = select(SourceConnection).where(
             SourceConnection.organization_id == ctx.organization.id
         )
@@ -82,19 +86,43 @@ class CRUDSourceConnection(
         if collection_id:
             query = query.where(SourceConnection.readable_collection_id == collection_id)
 
-        query = query.offset(skip).limit(limit)
-
+        query = query.offset(skip).limit(limit).order_by(SourceConnection.created_at.desc())
         result = await db.execute(query)
         source_connections = list(result.scalars().all())
 
-        if source_connections:
-            # Bulk fetch last sync job info
-            await self._attach_last_sync_info_bulk(db, source_connections)
+        if not source_connections:
+            return []
 
-            # Bulk fetch entity counts
-            # await self._attach_entity_counts_bulk(db, source_connections)
+        # 2. Bulk fetch all related data
+        # These queries can run independently
+        auth_methods = await self._fetch_auth_methods(db, source_connections)
+        last_jobs = await self._fetch_last_jobs(db, source_connections)
+        entity_counts = await self._fetch_entity_counts(db, source_connections)
 
-        return source_connections
+        # 3. Combine into response dictionaries
+        results = []
+        for sc in source_connections:
+            results.append(
+                {
+                    # Base fields
+                    "id": sc.id,
+                    "name": sc.name,
+                    "short_name": sc.short_name,
+                    "readable_collection_id": sc.readable_collection_id,
+                    "created_at": sc.created_at,
+                    "modified_at": sc.modified_at,
+                    "is_authenticated": sc.is_authenticated,
+                    "readable_auth_provider_id": sc.readable_auth_provider_id,
+                    "connection_init_session_id": sc.connection_init_session_id,
+                    "is_active": getattr(sc, "is_active", True),
+                    # Fetched data
+                    "authentication_method": auth_methods.get(sc.id),
+                    "last_job": last_jobs.get(sc.id),
+                    "entity_count": entity_counts.get(sc.id, 0),
+                }
+            )
+
+        return results
 
     async def _attach_last_sync_info_bulk(
         self,
@@ -170,37 +198,97 @@ class CRUDSourceConnection(
             else:
                 sc.status = SourceConnectionStatus.PENDING_SYNC
 
-    async def _attach_entity_counts_bulk(
-        self,
-        db: AsyncSession,
-        source_connections: List[SourceConnection],
-    ) -> None:
-        """Efficiently attach entity counts to multiple connections."""
-        sync_ids = [sc.sync_id for sc in source_connections if sc.sync_id]
-        if not sync_ids:
-            return
+    async def _fetch_auth_methods(
+        self, db: AsyncSession, source_conns: List[SourceConnection]
+    ) -> Dict[UUID, str]:
+        """Fetch authentication methods from credentials."""
+        from airweave.models.connection import Connection
+        from airweave.models.integration_credential import IntegrationCredential
 
-        # Get entity counts per sync
+        conn_ids = [sc.connection_id for sc in source_conns if sc.connection_id]
+        if not conn_ids:
+            return {}
+
         query = (
-            select(
-                SyncJob.sync_id,
-                func.sum(SyncJob.entities_inserted).label("total_entities_inserted"),
-                func.sum(SyncJob.entities_updated).label("total_entities_updated"),
-                func.sum(SyncJob.entities_deleted).label("total_entities_deleted"),
-                func.sum(SyncJob.entities_kept).label("total_entities_kept"),
-                func.sum(SyncJob.entities_skipped).label("total_entities_skipped"),
+            select(SourceConnection.id, IntegrationCredential.authentication_method)
+            .join(Connection, SourceConnection.connection_id == Connection.id)
+            .join(
+                IntegrationCredential,
+                Connection.integration_credential_id == IntegrationCredential.id,
             )
-            .where(SyncJob.sync_id.in_(sync_ids))
-            .group_by(SyncJob.sync_id)
+            .where(SourceConnection.id.in_([sc.id for sc in source_conns]))
         )
 
         result = await db.execute(query)
-        entity_counts = {row.sync_id: row.total_entities or 0 for row in result}
+        auth_methods = {}
 
-        # Attach to source connections
-        for sc in source_connections:
-            if sc.sync_id:
-                sc._entities_count = entity_counts.get(sc.sync_id, 0)
+        for row in result:
+            # Store the raw authentication method string
+            auth_methods[row[0]] = row[1]
+
+        # Also check for auth provider connections
+        for sc in source_conns:
+            if hasattr(sc, "readable_auth_provider_id") and sc.readable_auth_provider_id:
+                auth_methods[sc.id] = "auth_provider"
+
+        return auth_methods
+
+    async def _fetch_last_jobs(
+        self, db: AsyncSession, source_conns: List[SourceConnection]
+    ) -> Dict[UUID, Dict]:
+        """Fetch last sync job for each connection."""
+        sync_ids = [sc.sync_id for sc in source_conns if sc.sync_id]
+        if not sync_ids:
+            return {}
+
+        # Use window function to get latest job per sync
+        subq = (
+            select(
+                SyncJob.sync_id,
+                SyncJob.status,
+                SyncJob.completed_at,
+                func.row_number()
+                .over(partition_by=SyncJob.sync_id, order_by=SyncJob.created_at.desc())
+                .label("rn"),
+            )
+            .where(SyncJob.sync_id.in_(sync_ids))
+            .subquery()
+        )
+
+        query = select(subq).where(subq.c.rn == 1)
+        result = await db.execute(query)
+
+        # Map to source connection IDs
+        sync_to_sc = {sc.sync_id: sc.id for sc in source_conns if sc.sync_id}
+        return {
+            sync_to_sc[row.sync_id]: {"status": row.status, "completed_at": row.completed_at}
+            for row in result
+            if row.sync_id in sync_to_sc
+        }
+
+    async def _fetch_entity_counts(
+        self, db: AsyncSession, source_conns: List[SourceConnection]
+    ) -> Dict[UUID, int]:
+        """Fetch total entity counts from EntityCount table."""
+        from airweave.models.entity_count import EntityCount
+
+        sync_ids = [sc.sync_id for sc in source_conns if sc.sync_id]
+        if not sync_ids:
+            return {}
+
+        query = (
+            select(EntityCount.sync_id, func.sum(EntityCount.count).label("total"))
+            .where(EntityCount.sync_id.in_(sync_ids))
+            .group_by(EntityCount.sync_id)
+        )
+
+        result = await db.execute(query)
+
+        # Map to source connection IDs
+        sync_to_sc = {sc.sync_id: sc.id for sc in source_conns if sc.sync_id}
+        return {
+            sync_to_sc[row.sync_id]: row.total or 0 for row in result if row.sync_id in sync_to_sc
+        }
 
     async def get_by_query_and_org(
         self,
@@ -341,13 +429,15 @@ class CRUDSourceConnection(
         limit: int = 100,
     ) -> List[SourceConnection]:
         """Get all source connections for a collection."""
-        return await self.get_multi_with_stats(
-            db,
-            ctx=ctx,
-            collection_id=readable_collection_id,
-            skip=skip,
-            limit=limit,
+        query = select(SourceConnection).where(
+            and_(
+                SourceConnection.readable_collection_id == readable_collection_id,
+                SourceConnection.organization_id == ctx.organization.id,
+            )
         )
+        query = query.offset(skip).limit(limit).order_by(SourceConnection.created_at.desc())
+        result = await db.execute(query)
+        return list(result.scalars().all())
 
     async def get_by_sync_id(
         self,

--- a/backend/airweave/models/connection_init_session.py
+++ b/backend/airweave/models/connection_init_session.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from airweave.models._base import OrganizationBase
 
 if TYPE_CHECKING:
+    from airweave.models.redirect_session import RedirectSession
     from airweave.models.source_connection import SourceConnection
 
 
@@ -58,9 +59,16 @@ class ConnectionInitSession(OrganizationBase):
         ForeignKey("connection.id", ondelete="SET NULL"), nullable=True
     )
 
+    # Link to the redirect session for auth URL
+    redirect_session_id: Mapped[Optional[UUID]] = mapped_column(
+        ForeignKey("redirect_session.id", ondelete="SET NULL"), nullable=True
+    )
+
     source_connection: Mapped[Optional["SourceConnection"]] = relationship(
         back_populates="connection_init_session"
     )
+
+    redirect_session: Mapped[Optional["RedirectSession"]] = relationship("RedirectSession")
 
     @staticmethod
     def default_expires_at(minutes: int = 30) -> datetime:

--- a/backend/airweave/models/sync_job.py
+++ b/backend/airweave/models/sync_job.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
 from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String
-from sqlalchemy import Enum as SQLAlchemyEnum
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from airweave.core.shared_models import SyncJobStatus
@@ -24,9 +23,7 @@ class SyncJob(OrganizationBase, UserMixin):
     sync_id: Mapped[UUID] = mapped_column(
         ForeignKey("sync.id", ondelete="CASCADE", name="fk_sync_job_sync_id"), nullable=False
     )
-    status: Mapped[SyncJobStatus] = mapped_column(
-        SQLAlchemyEnum(SyncJobStatus), default=SyncJobStatus.PENDING
-    )
+    status: Mapped[str] = mapped_column(String(50), default=SyncJobStatus.PENDING.value)
     started_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     failed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)

--- a/backend/airweave/schemas/source_connection.py
+++ b/backend/airweave/schemas/source_connection.py
@@ -174,9 +174,9 @@ class SyncSummary(BaseModel):
 
 
 class SourceConnectionListItem(BaseModel):
-    """Minimal source connection for list views with computed fields."""
+    """Clean source connection for list views."""
 
-    # Direct database fields
+    # Core fields
     id: UUID
     name: str
     short_name: str
@@ -184,37 +184,39 @@ class SourceConnectionListItem(BaseModel):
     created_at: datetime
     modified_at: datetime
 
-    # Fields needed for computing auth_method and status
+    # Authentication
     is_authenticated: bool
-    readable_auth_provider_id: Optional[str] = None
-    connection_init_session_id: Optional[UUID] = None
-    is_active: bool = True  # Default to active if not provided
 
-    # Summary fields
-    last_sync: Optional[SyncSummary] = None
+    # Stats
     entity_count: int = 0
-    last_job_status: Optional[SyncJobStatus] = None  # For computing status
+
+    # Internal fields for computation (excluded from API response)
+    authentication_method: Optional[str] = Field(None, exclude=True)
+    is_active: bool = Field(True, exclude=True)
+    last_job_status: Optional[str] = Field(None, exclude=True)
 
     @computed_field  # type: ignore[misc]
     @property
     def auth_method(self) -> AuthenticationMethod:
-        """Compute authentication method from database fields."""
-        # Auth provider takes precedence
-        if self.readable_auth_provider_id:
-            return AuthenticationMethod.AUTH_PROVIDER
+        """Get authentication method from database value."""
+        if self.authentication_method:
+            # Map database string to enum
+            if self.authentication_method == "oauth_token":
+                return AuthenticationMethod.OAUTH_TOKEN
+            elif self.authentication_method == "oauth_browser":
+                return AuthenticationMethod.OAUTH_BROWSER
+            elif self.authentication_method == "oauth_byoc":
+                return AuthenticationMethod.OAUTH_BYOC
+            elif self.authentication_method == "direct":
+                return AuthenticationMethod.DIRECT
+            elif self.authentication_method == "auth_provider":
+                return AuthenticationMethod.AUTH_PROVIDER
 
-        # Check for pending OAuth
-        if self.connection_init_session_id and not self.is_authenticated:
-            return AuthenticationMethod.OAUTH_BROWSER
-
-        # TODO: Distinguish between DIRECT, OAUTH_TOKEN, and OAUTH_BYOC
-        # This would require additional fields from the database
-        # For now, default to direct if authenticated
+        # Default fallback based on authentication status
         if self.is_authenticated:
             return AuthenticationMethod.DIRECT
-
-        # Default to OAuth browser for unauthenticated
-        return AuthenticationMethod.OAUTH_BROWSER
+        else:
+            return AuthenticationMethod.OAUTH_BROWSER
 
     @computed_field  # type: ignore[misc]
     @property
@@ -229,9 +231,15 @@ class SourceConnectionListItem(BaseModel):
 
         # Check last job status if provided
         if self.last_job_status:
-            if self.last_job_status == SyncJobStatus.RUNNING:
+            # Handle both string and enum values
+            job_status = (
+                self.last_job_status
+                if isinstance(self.last_job_status, str)
+                else self.last_job_status.value
+            )
+            if job_status == "running":
                 return SourceConnectionStatus.SYNCING
-            elif self.last_job_status == SyncJobStatus.FAILED:
+            elif job_status == "failed":
                 return SourceConnectionStatus.ERROR
 
         return SourceConnectionStatus.ACTIVE
@@ -302,7 +310,6 @@ class EntitySummary(BaseModel):
 
     total_entities: int = 0
     by_type: Dict[str, EntityTypeStats] = Field(default_factory=dict)
-    last_updated: Optional[datetime] = None
 
 
 class SourceConnectionSimple(BaseModel):
@@ -314,9 +321,19 @@ class SourceConnectionSimple(BaseModel):
     short_name: str
     sync_id: Optional[UUID] = None
     readable_collection_id: str
-    status: SourceConnectionStatus
     created_at: datetime
     modified_at: datetime
+
+    # Fields needed for computing status
+    is_authenticated: bool = False
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def status(self) -> SourceConnectionStatus:
+        """Compute simple status based on authentication."""
+        if not self.is_authenticated:
+            return SourceConnectionStatus.PENDING_AUTH
+        return SourceConnectionStatus.ACTIVE
 
 
 class SourceConnection(BaseModel):

--- a/backend/alembic/versions/4ee815df1fed_add_redirect_session_id_fk_to_.py
+++ b/backend/alembic/versions/4ee815df1fed_add_redirect_session_id_fk_to_.py
@@ -1,0 +1,59 @@
+"""Add redirect_session_id FK to connection_init_session
+
+Revision ID: 4ee815df1fed
+Revises: a803b8e613be
+Create Date: 2025-09-22 18:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "4ee815df1fed"
+down_revision: Union[str, None] = "b1d1597dbcdb"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add the redirect_session_id column
+    op.add_column(
+        "connection_init_session",
+        sa.Column("redirect_session_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+
+    # Add foreign key constraint
+    op.create_foreign_key(
+        "fk_connection_init_session_redirect_session_id",
+        "connection_init_session",
+        "redirect_session",
+        ["redirect_session_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # Add index for better query performance
+    op.create_index(
+        "idx_connection_init_session_redirect_session_id",
+        "connection_init_session",
+        ["redirect_session_id"],
+    )
+
+
+def downgrade() -> None:
+    # Drop index
+    op.drop_index("idx_connection_init_session_redirect_session_id", "connection_init_session")
+
+    # Drop foreign key constraint
+    op.drop_constraint(
+        "fk_connection_init_session_redirect_session_id",
+        "connection_init_session",
+        type_="foreignkey",
+    )
+
+    # Drop the column
+    op.drop_column("connection_init_session", "redirect_session_id")

--- a/backend/alembic/versions/a803b8e613be_convert_syncjobstatus_enum_to_string.py
+++ b/backend/alembic/versions/a803b8e613be_convert_syncjobstatus_enum_to_string.py
@@ -1,0 +1,110 @@
+"""convert_syncjobstatus_enum_to_string
+
+Revision ID: a803b8e613be
+Revises: 51f41d4cb9db
+Create Date: 2025-09-22 17:22:19.462000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a803b8e613be"
+down_revision = "51f41d4cb9db"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Convert syncjobstatus enum to string column for flexibility.
+
+    The enum approach has caused issues with mismatched values between Python and database.
+    Converting to string allows more flexibility and avoids enum value synchronization issues.
+    """
+    # Step 1: Add a temporary column with string type
+    op.add_column("sync_job", sa.Column("status_temp", sa.String(50), nullable=True))
+
+    # Step 2: Copy and map the enum values to string values
+    # Map database enum values to Python enum values (lowercase)
+    # Note: CREATED doesn't exist in the current database enum
+    op.execute(
+        """
+        UPDATE sync_job
+        SET status_temp = CASE
+            WHEN status = 'PENDING' THEN 'pending'
+            WHEN status = 'IN_PROGRESS' THEN 'running'
+            WHEN status = 'COMPLETED' THEN 'completed'
+            WHEN status = 'FAILED' THEN 'failed'
+            WHEN status = 'CANCELLED' THEN 'cancelled'
+            ELSE LOWER(status::text)
+        END
+    """
+    )
+
+    # Step 3: Drop the old enum column
+    op.drop_column("sync_job", "status")
+
+    # Step 4: Rename the temporary column to status
+    op.alter_column("sync_job", "status_temp", new_column_name="status")
+
+    # Step 5: Set NOT NULL constraint and default value
+    op.alter_column("sync_job", "status", nullable=False)
+    op.execute("ALTER TABLE sync_job ALTER COLUMN status SET DEFAULT 'pending'")
+
+    # Step 6: Drop the enum type since it's no longer used
+    op.execute("DROP TYPE IF EXISTS syncjobstatus CASCADE")
+
+
+def downgrade():
+    """Convert string column back to enum type.
+
+    This recreates the enum and converts the string values back.
+    """
+    # Step 1: Create the enum type
+    op.execute(
+        """
+        CREATE TYPE syncjobstatus AS ENUM (
+            'PENDING',
+            'IN_PROGRESS',
+            'COMPLETED',
+            'FAILED',
+            'CANCELLED'
+        )
+    """
+    )
+
+    # Step 2: Add temporary enum column
+    op.execute(
+        """
+        ALTER TABLE sync_job
+        ADD COLUMN status_enum syncjobstatus
+    """
+    )
+
+    # Step 3: Map string values back to enum values
+    op.execute(
+        """
+        UPDATE sync_job
+        SET status_enum = CASE
+            WHEN status = 'pending' THEN 'PENDING'::syncjobstatus
+            WHEN status = 'running' THEN 'IN_PROGRESS'::syncjobstatus
+            WHEN status = 'completed' THEN 'COMPLETED'::syncjobstatus
+            WHEN status = 'failed' THEN 'FAILED'::syncjobstatus
+            WHEN status = 'cancelled' THEN 'CANCELLED'::syncjobstatus
+            WHEN status = 'created' THEN 'PENDING'::syncjobstatus
+            ELSE 'PENDING'::syncjobstatus
+        END
+    """
+    )
+
+    # Step 4: Drop the string column
+    op.drop_column("sync_job", "status")
+
+    # Step 5: Rename enum column to status
+    op.alter_column("sync_job", "status_enum", new_column_name="status")
+
+    # Step 6: Set NOT NULL and default
+    op.alter_column("sync_job", "status", nullable=False)
+    op.execute("ALTER TABLE sync_job ALTER COLUMN status SET DEFAULT 'PENDING'::syncjobstatus")

--- a/backend/alembic/versions/b1d1597dbcdb_add_proxy_code_to_connection_init_.py
+++ b/backend/alembic/versions/b1d1597dbcdb_add_proxy_code_to_connection_init_.py
@@ -1,0 +1,25 @@
+"""Add proxy_code to connection_init_session
+
+Revision ID: b1d1597dbcdb
+Revises: a803b8e613be
+Create Date: 2025-09-22 19:47:20.262182
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b1d1597dbcdb"
+down_revision = "a803b8e613be"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/fern/scripts/api_config.py
+++ b/fern/scripts/api_config.py
@@ -15,16 +15,13 @@ INCLUDED_ENDPOINTS = {
     "/source-connections/nested/": {"post": True},  # POC nested auth structure
     "/source-connections/{source_connection_id}/": {
         "get": True,
-        "put": True,
+        "patch": True,  # Update endpoint uses PATCH, not PUT
         "delete": True,
     },
     "/source-connections/{source_connection_id}/run/": {"post": True},
     "/source-connections/{source_connection_id}/jobs/": {"get": True},
     "/source-connections/{source_connection_id}/jobs/{job_id}/": {"get": True},
     "/source-connections/{source_connection_id}/jobs/{job_id}/cancel/": {"post": True},
-    # Auth Providers
-    "/auth-providers/connect/": {"put": True},
-    "/auth-providers/detail/{short_name}/": {"get": True},
 }
 
 # API group descriptions for documentation
@@ -32,7 +29,6 @@ API_GROUPS = {
     "Sources": "API endpoints for discovering available data source connectors and their configuration requirements",
     "Collections": "API endpoints for managing collections - logical groups of data sources that provide unified search capabilities",
     "Source Connections": "API endpoints for managing live connections to data sources. Source connections are the actual configured instances that Airweave uses to sync data from your apps and databases, transforming it into searchable, structured information within collections",
-    "Auth Providers": "API endpoints for managing authentication provider connections and credentials",
 }
 
 

--- a/frontend/src/components/collection/SourceConnectionStateView.tsx
+++ b/frontend/src/components/collection/SourceConnectionStateView.tsx
@@ -585,10 +585,11 @@ const SourceConnectionStateView: React.FC<Props> = ({
       {isNotAuthorized && sourceConnection && (
         <SourceAuthenticationView
           sourceName={sourceConnection.name}
+          sourceShortName={sourceConnection.short_name}
           authenticationUrl={sourceConnection.auth?.auth_url}
           onRefreshUrl={handleRefreshAuthUrl}
           isRefreshing={isRefreshingAuth}
-          showBorder={true}
+          showBorder={false}
           onDelete={handleDeleteConnection}
         />
       )}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Tightened source connection objects and list endpoint to return complete stats with clean auth/status, and simplified OAuth redirect handling. Also moved sync job status to strings and wired schedule updates into Temporal.

- New Features
  - List endpoint now returns auth method, entity count, and last job status via a single bulk query; status/auth are computed server‑side.
  - OAuth: create redirect session first, store redirect_session_id on init session, and serve a stable auth_url (with expiry) from the redirect session.
  - Collection status now derives from last job state of authenticated connections (e.g., running, failed).
  - Updating a sync’s cron now also updates the Temporal schedule.

- Migration
  - Run Alembic migrations: convert sync_job.status enum → string; add redirect_session_id to connection_init_session.
  - Clients: the update endpoint is PATCH at /source-connections/{source_connection_id}/.

<!-- End of auto-generated description by cubic. -->

