### PR TITLE
fix(pipedream): make pipedream credentials optional

### DIFF
--- a/backend/airweave/platform/auth_providers/pipedream.py
+++ b/backend/airweave/platform/auth_providers/pipedream.py
@@ -119,9 +119,9 @@ class PipedreamAuthProvider(BaseAuthProvider):
         instance = cls()
         instance.client_id = credentials["client_id"]
         instance.client_secret = credentials["client_secret"]
-        instance.project_id = config["project_id"]
-        instance.account_id = config["account_id"]
-        instance.external_user_id = config["external_user_id"]
+        instance.project_id = config.get("project_id")
+        instance.account_id = config.get("account_id")
+        instance.external_user_id = config.get("external_user_id")
         instance.environment = config.get("environment", "production")
 
         # Initialize token management


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make Pipedream auth treat project_id, account_id, and external_user_id as optional. Prevents KeyErrors when these fields are missing and allows setups to work with only client_id and client_secret.

<!-- End of auto-generated description by cubic. -->

