### PR TITLE
hotfix: team members and merge heads

### DIFF
--- a/backend/airweave/core/guard_rail_service.py
+++ b/backend/airweave/core/guard_rail_service.py
@@ -148,8 +148,7 @@ class GuardRailService:
         async with self._lock:
             # Bypass all checks for local development
             if settings.LOCAL_DEVELOPMENT:
-                pass
-                # return True
+                return True
 
             # Check if organization has billing - legacy orgs are exempt
             has_billing = await self._check_has_billing()

--- a/backend/airweave/crud/crud_usage.py
+++ b/backend/airweave/crud/crud_usage.py
@@ -205,7 +205,8 @@ class CRUDUsage(CRUDBaseOrganization[Usage, UsageCreate, UsageUpdate]):
                     "modified_at": updated_row.modified_at,
                 }
 
-                updated = Usage(
+                # Create SQLAlchemy model first (without team_members)
+                updated_model = Usage(
                     id=updated_values["id"],
                     organization_id=updated_values["organization_id"],
                     entities=updated_values["entities"],
@@ -214,8 +215,13 @@ class CRUDUsage(CRUDBaseOrganization[Usage, UsageCreate, UsageUpdate]):
                     billing_period_id=updated_values["billing_period_id"],
                     created_at=updated_values["created_at"],
                     modified_at=updated_values["modified_at"],
-                    team_members=None,  # Not stored in database, populated separately
                 )
+
+                # Convert to Pydantic schema and add team_members
+                from airweave.schemas.usage import Usage as UsageSchema
+
+                updated = UsageSchema.model_validate(updated_model)
+                updated.team_members = None  # Not stored in database, populated separately
 
                 logger.info(
                     f"[increment_usage] Updated values: "

--- a/backend/alembic/versions/97b3317e4b70_merge_heads.py
+++ b/backend/alembic/versions/97b3317e4b70_merge_heads.py
@@ -1,0 +1,24 @@
+"""merge heads
+
+Revision ID: 97b3317e4b70
+Revises: remove_syncs_collections
+Create Date: 2025-09-23 20:31:56.545741
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '97b3317e4b70'
+down_revision = ('4ee815df1fed', 'remove_syncs_collections')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Ensure local development bypasses guard rail checks and correct team_members handling in Usage updates. Add an Alembic merge-head to unify migration history.

- **Bug Fixes**
  - Return True for LOCAL_DEVELOPMENT in guard rail checks.
  - Build Usage as an SQLAlchemy model, then validate to the Pydantic schema and set team_members=None (not persisted).

- **Migration**
  - Add a no-op Alembic merge-head revision to reconcile divergent heads (no schema changes).

<!-- End of auto-generated description by cubic. -->

