### PR TITLE
fix(cancel-sync): workflow cancellation and activity catching

### DIFF
--- a/backend/airweave/platform/temporal/activities.py
+++ b/backend/airweave/platform/temporal/activities.py
@@ -1,36 +1,12 @@
 """Temporal activities for Airweave."""
 
 import asyncio
+from contextlib import suppress
 from datetime import datetime
 from typing import Any, Dict, Optional
 from uuid import UUID
 
 from temporalio import activity
-from temporalio.exceptions import CancelledError as ActivityCancelledError
-
-
-async def _send_heartbeats(should_heartbeat_flag: dict) -> bool:
-    """Send regular heartbeats to Temporal."""
-    cancellation_requested = False
-    heartbeat_count = 0
-    while should_heartbeat_flag["value"]:
-        try:
-            # Check if cancellation was requested
-            if activity.is_cancelled():
-                activity.logger.info("Activity cancellation detected via heartbeat")
-                cancellation_requested = True
-                break
-
-            # Send heartbeat with progress info
-            heartbeat_count += 1
-            activity.heartbeat(f"Sync in progress, heartbeat #{heartbeat_count}")
-
-            # Wait 30 seconds before next heartbeat
-            await asyncio.sleep(30)
-        except Exception as e:
-            activity.logger.error(f"Error sending heartbeat: {e}")
-            break
-    return cancellation_requested
 
 
 async def _run_sync_task(
@@ -56,57 +32,6 @@ async def _run_sync_task(
         access_token=access_token,
         force_full_sync=force_full_sync,
     )
-
-
-async def _wait_for_sync_completion(sync_task, heartbeat_task, should_heartbeat_flag, sync_job):
-    """Wait for sync completion or handle cancellation."""
-    # Wait for sync to complete or cancellation
-    while not sync_task.done():
-        # Check for cancellation every second
-        try:
-            await asyncio.wait_for(asyncio.shield(sync_task), timeout=1.0)
-        except asyncio.TimeoutError:
-            # Check if we should cancel
-            cancellation_requested = False
-            if heartbeat_task.done():
-                try:
-                    cancellation_requested = await heartbeat_task
-                except Exception:
-                    pass
-
-            if cancellation_requested or activity.is_cancelled():
-                activity.logger.info("Cancelling sync task due to activity cancellation")
-                sync_task.cancel()
-                try:
-                    await sync_task
-                except asyncio.CancelledError:
-                    activity.logger.info("Sync task cancelled successfully")
-                    raise ActivityCancelledError("Activity was cancelled by user") from None
-            # Otherwise continue waiting
-            continue
-
-    # If we get here, sync completed normally
-    activity.logger.info(f"Completed sync activity for job {sync_job.id}")
-
-
-async def _cleanup_tasks(heartbeat_task, sync_task, should_heartbeat_flag):
-    """Clean up background tasks."""
-    # Stop heartbeating
-    should_heartbeat_flag["value"] = False
-    if heartbeat_task and not heartbeat_task.done():
-        heartbeat_task.cancel()
-        try:
-            await heartbeat_task
-        except asyncio.CancelledError:
-            pass
-
-    # Cancel sync task if still running
-    if sync_task and not sync_task.done():
-        sync_task.cancel()
-        try:
-            await sync_task
-        except asyncio.CancelledError:
-            pass
 
 
 # Import inside the activity to avoid issues with Temporal's sandboxing
@@ -169,46 +94,118 @@ async def run_sync_activity(
         ),
     )
 
-    activity.logger.info(f"Starting sync activity for job {sync_job.id}")
-
-    # Start background tasks
-    heartbeat_task = None
-    sync_task = None
-    should_heartbeat_flag = {"value": True}
+    ctx.logger.debug(f"\n\nStarting sync activity for job {sync_job.id}\n\n")
+    # Start the sync task
+    sync_task = asyncio.create_task(
+        _run_sync_task(
+            sync,
+            sync_job,
+            sync_dag,
+            collection,
+            source_connection,
+            ctx,
+            access_token,
+            force_full_sync,
+        )
+    )
 
     try:
-        # Import here to avoid Temporal sandboxing issues
+        while True:
+            try:
+                await asyncio.wait_for(asyncio.shield(sync_task), timeout=1)
+                break
+            except asyncio.TimeoutError:
+                ctx.logger.debug("HEARTBEAT: Sync in progress")
+                activity.heartbeat("Sync in progress")
 
-        # Start heartbeat task
-        heartbeat_task = asyncio.create_task(_send_heartbeats(should_heartbeat_flag))
+        ctx.logger.info(f"\n\nCompleted sync activity for job {sync_job.id}\n\n")
 
-        # Start the sync
-        sync_task = asyncio.create_task(
-            _run_sync_task(
-                sync,
-                sync_job,
-                sync_dag,
-                collection,
-                source_connection,
-                ctx,
-                access_token,
-                force_full_sync,
-            )
-        )
-
-        await _wait_for_sync_completion(sync_task, heartbeat_task, should_heartbeat_flag, sync_job)
-
-    except ActivityCancelledError:
-        activity.logger.info(f"Sync activity cancelled for job {sync_job.id}")
-        raise
     except asyncio.CancelledError:
-        activity.logger.info(f"Sync activity cancelled (asyncio) for job {sync_job.id}")
-        raise ActivityCancelledError("Activity was cancelled") from None
-    except Exception as e:
-        activity.logger.error(f"Failed sync activity for job {sync_job.id}: {e}")
+        ctx.logger.info(f"\n\nSync activity cancelled for job {sync_job.id}\n\n")
+        # Ensure the internal sync task is cancelled and awaited
+        sync_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await sync_task
+
+        try:
+            # Import inside to avoid sandbox issues
+            from airweave.core.datetime_utils import utc_now_naive
+            from airweave.core.shared_models import SyncJobStatus
+            from airweave.core.sync_job_service import sync_job_service
+
+            await sync_job_service.update_status(
+                sync_job_id=sync_job.id,
+                status=SyncJobStatus.CANCELLED,
+                ctx=ctx,
+                error="Workflow was cancelled",
+                failed_at=utc_now_naive(),
+            )
+            ctx.logger.debug(f"\n\nUpdated job {sync_job.id} to CANCELLED\n\n")
+        except Exception as status_err:
+            ctx.logger.error(f"Failed to update job {sync_job.id} to CANCELLED: {status_err}")
         raise
-    finally:
-        await _cleanup_tasks(heartbeat_task, sync_task, should_heartbeat_flag)
+    except Exception as e:
+        ctx.logger.error(f"Failed sync activity for job {sync_job.id}: {e}")
+        raise
+
+
+@activity.defn
+async def mark_sync_job_cancelled_activity(
+    sync_job_id: str,
+    ctx_dict: Dict[str, Any],
+    reason: Optional[str] = None,
+    when_iso: Optional[str] = None,
+) -> None:
+    """Mark a sync job as CANCELLED (used when workflow cancels before activity starts).
+
+    Args:
+        sync_job_id: The sync job ID (str UUID)
+        ctx_dict: Serialized ApiContext dict
+        reason: Optional cancellation reason
+        when_iso: Optional ISO timestamp for failed_at
+    """
+    from airweave import schemas
+    from airweave.api.context import ApiContext
+    from airweave.core.logging import LoggerConfigurator
+    from airweave.core.shared_models import SyncJobStatus
+    from airweave.core.sync_job_service import sync_job_service
+
+    # Reconstruct context
+    organization = schemas.Organization(**ctx_dict["organization"])
+    user = schemas.User(**ctx_dict["user"]) if ctx_dict.get("user") else None
+
+    ctx = ApiContext(
+        request_id=ctx_dict["request_id"],
+        organization=organization,
+        user=user,
+        auth_method=ctx_dict["auth_method"],
+        auth_metadata=ctx_dict.get("auth_metadata"),
+        logger=LoggerConfigurator.configure_logger(
+            "airweave.temporal.activity.cancel_pre_activity",
+            dimensions={
+                "sync_job_id": sync_job_id,
+                "organization_id": str(organization.id),
+                "organization_name": organization.name,
+            },
+        ),
+    )
+
+    failed_at = None
+    if when_iso:
+        try:
+            failed_at = datetime.fromisoformat(when_iso)
+        except Exception:
+            failed_at = None
+
+    ctx.logger.debug(f"Marking sync job {sync_job_id} as CANCELLED (pre-activity): {reason or ''}")
+
+    await sync_job_service.update_status(
+        sync_job_id=UUID(sync_job_id),
+        status=SyncJobStatus.CANCELLED,
+        ctx=ctx,
+        error=reason,
+        failed_at=failed_at,
+    )
 
 
 @activity.defn
@@ -233,8 +230,6 @@ async def create_sync_job_activity(
     Raises:
         Exception: If a sync job is already running and force_full_sync is False
     """
-    from uuid import UUID
-
     from airweave import crud, schemas
     from airweave.api.context import ApiContext
     from airweave.core.logging import LoggerConfigurator
@@ -260,9 +255,7 @@ async def create_sync_job_activity(
         ),
     )
 
-    activity.logger.info(
-        f"Creating sync job for sync {sync_id} (force_full_sync={force_full_sync})"
-    )
+    ctx.logger.debug(f"Creating sync job for sync {sync_id} (force_full_sync={force_full_sync})")
 
     async with get_db_context() as db:
         # Check if there's already a running sync job for this sync
@@ -275,7 +268,7 @@ async def create_sync_job_activity(
         if running_jobs:
             if force_full_sync:
                 # For daily cleanup, wait for running jobs to complete
-                activity.logger.info(
+                ctx.logger.debug(
                     f"🔄 Daily cleanup sync for {sync_id}: "
                     f"Found {len(running_jobs)} running job(s). "
                     f"Waiting for them to complete before starting cleanup..."
@@ -305,14 +298,14 @@ async def create_sync_job_activity(
                         )
 
                         if not still_running:
-                            activity.logger.info(
+                            ctx.logger.info(
                                 f"✅ Running jobs completed. "
                                 f"Proceeding with cleanup sync for {sync_id}"
                             )
                             break
                 else:
                     # Timeout reached
-                    activity.logger.error(
+                    ctx.logger.error(
                         f"❌ Timeout waiting for running jobs to complete for sync {sync_id}. "
                         f"Skipping cleanup sync."
                     )
@@ -321,7 +314,7 @@ async def create_sync_job_activity(
                     )
             else:
                 # For regular incremental syncs, skip if job is running
-                activity.logger.warning(
+                ctx.logger.warning(
                     f"Sync {sync_id} already has {len(running_jobs)} running jobs. "
                     f"Skipping new job creation."
                 )
@@ -342,102 +335,8 @@ async def create_sync_job_activity(
         # Refresh the object to ensure all attributes are loaded
         await db.refresh(sync_job)
 
-        activity.logger.info(f"Created sync job {sync_job_id} for sync {sync_id}")
+        ctx.logger.info(f"Created sync job {sync_job_id} for sync {sync_id}")
 
         # Convert to dict for return
         sync_job_schema = schemas.SyncJob.model_validate(sync_job)
         return sync_job_schema.model_dump(mode="json")
-
-
-@activity.defn
-async def update_sync_job_status_activity(
-    sync_job_id: str,
-    status: str,
-    ctx_dict: Dict[str, Any],
-    error: Optional[str] = None,
-    failed_at: Optional[str] = None,
-) -> None:
-    """Activity to update sync job status.
-
-    This activity is used to update the sync job status when errors occur
-    or when the workflow is cancelled.
-
-    Args:
-        sync_job_id: The sync job ID
-        status: The new status string (e.g., "failed", "cancelled")
-        ctx_dict: The current authentication context as dict
-        error: Optional error message
-        failed_at: Optional timestamp when the job failed
-    """
-    # Import here to avoid Temporal sandboxing issues
-    from airweave import schemas
-    from airweave.api.context import ApiContext
-    from airweave.core.logging import LoggerConfigurator
-    from airweave.core.shared_models import SyncJobStatus
-    from airweave.core.sync_job_service import sync_job_service
-
-    # Reconstruct user if present
-    user = schemas.User(**ctx_dict["user"]) if ctx_dict.get("user") else None
-
-    # Reconstruct organization from the dictionary
-    organization = schemas.Organization(**ctx_dict["organization"])
-
-    # Reconstruct ApiContext with a new logger
-    logger = LoggerConfigurator.configure_logger(
-        "airweave.temporal.activity",
-        dimensions={
-            "sync_job_id": sync_job_id,
-            "organization_id": str(organization.id),
-            "organization_name": organization.name,
-        },
-    )
-
-    # Reconstruct user if present
-    user = schemas.User(**ctx_dict["user"]) if ctx_dict.get("user") else None
-
-    ctx = ApiContext(
-        request_id=ctx_dict["request_id"],
-        organization=organization,
-        user=user,
-        auth_method=ctx_dict["auth_method"],
-        auth_metadata=ctx_dict.get("auth_metadata"),
-        logger=logger,
-    )
-
-    # Convert string status to SyncJobStatus enum
-    # Handle both lowercase (Python enum values) and uppercase (database values)
-    try:
-        # First try direct enum value match (lowercase Python enum values)
-        status_enum = SyncJobStatus(status.lower())
-    except ValueError:
-        # Fallback: try to find enum by attribute name
-        try:
-            status_upper = status.upper()
-            if hasattr(SyncJobStatus, status_upper):
-                status_enum = getattr(SyncJobStatus, status_upper)
-            else:
-                activity.logger.error(f"Invalid status: {status}")
-                raise ValueError(f"Invalid sync job status: {status}") from None
-        except ValueError:
-            activity.logger.error(f"Invalid status: {status}")
-            raise ValueError(f"Invalid sync job status: {status}") from None
-
-    # Convert failed_at string to datetime if provided
-    failed_at_dt = datetime.fromisoformat(failed_at) if failed_at else None
-
-    activity.logger.info(f"Updating sync job {sync_job_id} status to {status_enum.name}")
-
-    try:
-        await sync_job_service.update_status(
-            sync_job_id=UUID(sync_job_id),
-            status=status_enum,
-            ctx=ctx,
-            error=error,
-            failed_at=failed_at_dt,
-        )
-        activity.logger.info(
-            f"Successfully updated sync job {sync_job_id} status to {status_enum.name}"
-        )
-    except Exception as e:
-        activity.logger.error(f"Failed to update sync job {sync_job_id} status: {e}")
-        raise

--- a/backend/airweave/platform/temporal/worker.py
+++ b/backend/airweave/platform/temporal/worker.py
@@ -11,8 +11,8 @@ from airweave.core.logging import logger
 from airweave.platform.entities._base import ensure_file_entity_models
 from airweave.platform.temporal.activities import (
     create_sync_job_activity,
+    mark_sync_job_cancelled_activity,
     run_sync_activity,
-    update_sync_job_status_activity,
 )
 from airweave.platform.temporal.client import temporal_client
 from airweave.platform.temporal.workflows import RunSourceConnectionWorkflow
@@ -45,8 +45,8 @@ class TemporalWorker:
                 workflows=[RunSourceConnectionWorkflow],
                 activities=[
                     run_sync_activity,
-                    update_sync_job_status_activity,
                     create_sync_job_activity,
+                    mark_sync_job_cancelled_activity,
                 ],
                 workflow_runner=sandbox_config,
             )

--- a/backend/airweave/platform/temporal/workflows.py
+++ b/backend/airweave/platform/temporal/workflows.py
@@ -2,51 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from typing import Any, Dict, Optional
 
 from temporalio import workflow
 from temporalio.common import RetryPolicy
-from temporalio.exceptions import ActivityError, CancelledError
-
-from airweave.platform.utils.error_utils import get_error_message
+from temporalio.exceptions import is_cancelled_exception
 
 
 @workflow.defn
 class RunSourceConnectionWorkflow:
     """Workflow for running a source connection sync."""
-
-    async def _update_job_status(
-        self,
-        sync_job_id: str,
-        status: str,
-        ctx_dict: Dict[str, Any],
-        error_message: Optional[str] = None,
-    ) -> None:
-        """Helper method to update sync job status."""
-        from airweave.platform.temporal.activities import update_sync_job_status_activity
-
-        try:
-            await workflow.execute_activity(
-                update_sync_job_status_activity,
-                args=[
-                    sync_job_id,
-                    status,
-                    ctx_dict,
-                    error_message,
-                    workflow.now().replace(tzinfo=None).isoformat(),
-                ],
-                start_to_close_timeout=timedelta(seconds=30),
-                retry_policy=RetryPolicy(
-                    maximum_attempts=3,
-                    initial_interval=timedelta(seconds=1),
-                ),
-            )
-            workflow.logger.info(
-                f"Successfully updated sync job {sync_job_id} status to {status.upper()}"
-            )
-        except Exception as e:
-            workflow.logger.error(f"Failed to update sync job status: {e}")
 
     async def _create_sync_job_if_needed(
         self,
@@ -62,10 +29,6 @@ class RunSourceConnectionWorkflow:
         if sync_job_dict is None:
             sync_id = sync_dict.get("id")
             try:
-                workflow.logger.info(
-                    f"Creating new sync job for scheduled run of sync {sync_id} "
-                    f"(force_full_sync={force_full_sync})"
-                )
                 # For forced full sync (daily cleanup), use longer timeout to allow waiting
                 timeout = (
                     timedelta(hours=1, minutes=5) if force_full_sync else timedelta(seconds=30)
@@ -81,12 +44,9 @@ class RunSourceConnectionWorkflow:
                         initial_interval=timedelta(seconds=1),
                     ),
                 )
-                workflow.logger.info(
-                    f"Created sync job {sync_job_dict.get('id')} for sync {sync_id}"
-                )
             except Exception as e:
                 # If we can't create a sync job (e.g., one is already running), skip this run
-                workflow.logger.warning(f"Skipping scheduled run for sync {sync_id}: {str(e)}")
+                ctx_dict["logger"].warning(f"Skipping scheduled run for sync {sync_id}: {str(e)}")
                 return None  # Signal to exit gracefully
         return sync_job_dict
 
@@ -123,11 +83,11 @@ class RunSourceConnectionWorkflow:
         if sync_job_dict is None:
             return  # Exit gracefully if we couldn't create a job
 
-        sync_job_id = sync_job_dict.get("id")
-        error_message = None
-
+        # Execute the sync activity; it is responsible for status updates when in flight
+        # try:
+        # Deterministic/cancellable sleep to test pre-activity cancellation
+        # TODO: delete
         try:
-            # Execute the sync activity
             await workflow.execute_activity(
                 run_sync_activity,
                 args=[
@@ -141,59 +101,38 @@ class RunSourceConnectionWorkflow:
                     force_full_sync,
                 ],
                 start_to_close_timeout=timedelta(days=7),
-                heartbeat_timeout=timedelta(minutes=10),  # Fail if no heartbeat for 10 minutes
+                heartbeat_timeout=timedelta(minutes=10),
+                cancellation_type=workflow.ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
                 retry_policy=RetryPolicy(
                     initial_interval=timedelta(seconds=1),
                     maximum_interval=timedelta(minutes=5),
                     maximum_attempts=1,
                 ),
             )
-
-        except CancelledError:
-            # Handle workflow cancellation (e.g., from kill command)
-            error_message = "Workflow was cancelled"
-            workflow.logger.error(f"Sync job {sync_job_id} was cancelled")
-
-            # Update sync job status to CANCELLED
-            await self._update_job_status(sync_job_id, "cancelled", ctx_dict, error_message)
-
-            # Re-raise the original error
-            raise
-
-        except ActivityError as e:
-            # Check if the cause is a CancelledError - handle as cancellation
-            if hasattr(e, "cause") and isinstance(e.cause, CancelledError):
-                error_message = "Workflow was cancelled"
-                workflow.logger.error(f"Sync job {sync_job_id} was cancelled (via ActivityError)")
-
-                # Update sync job status to CANCELLED
-                await self._update_job_status(sync_job_id, "cancelled", ctx_dict, error_message)
-
-                # Re-raise the original error
-                raise
-            else:
-                # Handle other ActivityErrors as failures
-                # Extract the real error message
-                if hasattr(e, "cause") and e.cause:
-                    error_message = get_error_message(e.cause)
-                else:
-                    error_message = get_error_message(e)
-
-                workflow.logger.error(f"Sync job {sync_job_id} failed: {error_message}")
-
-                # Update sync job with the real error
-                await self._update_job_status(sync_job_id, "failed", ctx_dict, error_message)
-
-                # Re-raise the original error
+        except asyncio.CancelledError as e:
+            # only treat true cancellations specially
+            if not is_cancelled_exception(e):
                 raise
 
-        except Exception as e:
-            # Handle any other errors (generic exceptions)
-            error_message = get_error_message(e)
-            workflow.logger.error(f"Sync job {sync_job_id} failed: {error_message}")
+            # ensure DB gets updated even though the workflow was cancelled
+            from airweave.platform.temporal.activities import mark_sync_job_cancelled_activity
 
-            # Update sync job status to FAILED
-            await self._update_job_status(sync_job_id, "failed", ctx_dict, error_message)
-
-            # Re-raise the original error
-            raise
+            reason = f"{type(e).__name__}: {e}"
+            try:
+                await asyncio.shield(
+                    workflow.execute_activity(
+                        mark_sync_job_cancelled_activity,
+                        args=[
+                            str(sync_job_dict["id"]),
+                            ctx_dict,
+                            reason,
+                            workflow.now().replace(tzinfo=None).isoformat(),
+                        ],
+                        start_to_close_timeout=timedelta(seconds=30),
+                        # fire-and-forget semantics on the server side
+                        cancellation_type=workflow.ActivityCancellationType.ABANDON,
+                    )
+                )
+            finally:
+                # keep Workflow result as CANCELED
+                raise


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make sync workflow cancellation reliable and consistent. Uses deterministic workflow IDs, updates job status to CANCELLED in all paths, and simplifies activity/workflow handling.

- **Bug Fixes**
  - Cancel running workflows by job ID using a deterministic ID (sync-{job_id}).
  - Persist CANCELLED status whether the workflow is cancelled before the activity starts or mid-activity.
  - API cancel_job now sends a Temporal cancel, returns 404 if no workflow, and 503 if Temporal is disabled.

- **Refactors**
  - Removed update_sync_job_status_activity; added mark_sync_job_cancelled_activity for pre-activity cancellations.
  - Simplified run_sync_activity: streamlined heartbeats and proper cancellation handling.
  - Workflow uses WAIT_CANCELLATION_COMPLETED for activity cancellation and ABANDON for the cancel-status activity.
  - Simplified Temporal cancel logic (no workflow listing).

<!-- End of auto-generated description by cubic. -->

