### PR TITLE
fix: pipedream docs

### DIFF
--- a/fern/docs/pages/auth-providers/pipedream.mdx
+++ b/fern/docs/pages/auth-providers/pipedream.mdx
@@ -19,7 +19,7 @@ This integration involves two separate OAuth clients:
 2. **Source app OAuth clients**: Custom OAuth clients you create for each source app (Notion, Slack, etc.)
 
 <Callout type="warning">
-**Important**: Pipedream only exposes credentials for accounts created with your own custom OAuth clients. Default Pipedream OAuth connections cannot be used with Airweave.
+**Important**: Pipedream only exposes credentials for accounts created with your own custom OAuth clients. Default Pipedream OAuth connections use the Proxy API.
 </Callout>
 
 ## Prerequisites


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated Pipedream auth provider docs to clarify that default Pipedream OAuth connections use the Proxy API. This makes it clear that credentials are only exposed for accounts created with your own custom OAuth clients.

<!-- End of auto-generated description by cubic. -->

