### PR TITLE
fix: unified temporal scheduling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
     "python.analysis.extraPaths": [
         "${workspaceFolder}/backend"
     ],
-    "python.defaultInterpreterPath": "${workspaceFolder}/backend/venv/bin/python",
+    "python.defaultInterpreterPath": "${command:python.interpreterPath}",
     "terminal.integrated.env.osx": {
         "PYTHONPATH": "${workspaceFolder}/backend:${env:PYTHONPATH}"
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,16 @@
     "python.analysis.extraPaths": [
         "${workspaceFolder}/backend"
     ],
-    "python.defaultInterpreterPath": "${command:python.interpreterPath}",
+    "python.defaultInterpreterPath": "${workspaceFolder}/backend/venv/bin/python",
+    "terminal.integrated.env.osx": {
+        "PYTHONPATH": "${workspaceFolder}/backend:${env:PYTHONPATH}"
+    },
+    "terminal.integrated.env.linux": {
+        "PYTHONPATH": "${workspaceFolder}/backend:${env:PYTHONPATH}"
+    },
+    "terminal.integrated.env.windows": {
+        "PYTHONPATH": "${workspaceFolder}/backend;${env:PYTHONPATH}"
+    },
     "python.testing.pytestPath": "${command:python.interpreterPath}",
     "python.testing.autoTestDiscoverOnSaveEnabled": true,
     "python.debugOptions": [

--- a/backend/airweave/core/sync_service.py
+++ b/backend/airweave/core/sync_service.py
@@ -84,6 +84,7 @@ class SyncService:
                 cron_schedule=sync_in.cron_schedule,
                 db=db,
                 ctx=ctx,
+                uow=uow,
             )
 
         # Run immediately if requested

--- a/backend/airweave/models/source.py
+++ b/backend/airweave/models/source.py
@@ -33,6 +33,9 @@ class Source(Base):
     output_entity_definition_ids = Column(JSON, nullable=False)
     config_schema = Column(JSON, nullable=True)  # JSON Schema for configuration
     labels: Mapped[list[str]] = mapped_column(JSON, nullable=True, default=list)
+    supports_continuous: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
 
     __table_args__ = (UniqueConstraint("name", "organization_id", name="uq_source_name_org"),)
 

--- a/backend/airweave/models/sync.py
+++ b/backend/airweave/models/sync.py
@@ -33,7 +33,6 @@ class Sync(OrganizationBase, UserMixin):
     )
     temporal_schedule_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     sync_type: Mapped[str] = mapped_column(String(50), default="full")
-    minute_level_cron_schedule: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     sync_metadata: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
 
     jobs: Mapped[list["SyncJob"]] = relationship(
@@ -95,8 +94,9 @@ def delete_temporal_schedules_after_sync_delete(mapper, connection, target):
         import asyncio
 
         schedule_ids = [
-            f"minute-sync-{target.id}",
-            f"daily-cleanup-{target.id}",
+            f"sync-{target.id}",  # Regular schedule
+            f"minute-sync-{target.id}",  # Minute-level schedule
+            f"daily-cleanup-{target.id}",  # Daily cleanup schedule
         ]
 
         async def _cleanup():

--- a/backend/airweave/platform/db_sync.py
+++ b/backend/airweave/platform/db_sync.py
@@ -374,6 +374,7 @@ async def _sync_sources(
             class_name=source_class.__name__,
             output_entity_definition_ids=output_entity_ids,
             labels=getattr(source_class, "_labels", []),
+            supports_continuous=getattr(source_class, "_supports_continuous", False),
         )
         source_definitions.append(source_def)
 

--- a/backend/airweave/platform/decorators.py
+++ b/backend/airweave/platform/decorators.py
@@ -18,6 +18,7 @@ def source(
     auth_config_class: Optional[Type[BaseModel]] = None,
     config_class: Optional[Type[BaseModel]] = None,
     labels: Optional[List[str]] = None,
+    supports_continuous: bool = False,
 ) -> Callable[[type], type]:
     """Enhanced source decorator with OAuth type tracking.
 
@@ -30,6 +31,7 @@ def source(
         auth_config_class: Pydantic model for auth configuration (for DIRECT auth only)
         config_class: Pydantic model for source configuration
         labels: Tags for categorization (e.g., "CRM", "Database")
+        supports_continuous: Whether source supports cursor-based continuous syncing (default False)
 
     Example:
         # OAuth source (no auth config)
@@ -66,6 +68,7 @@ def source(
         cls._auth_config_class = auth_config_class
         cls._config_class = config_class
         cls._labels = labels or []
+        cls._supports_continuous = supports_continuous
 
         # Add validation method if not present
         if not hasattr(cls, "validate"):

--- a/backend/airweave/platform/sources/asana.py
+++ b/backend/airweave/platform/sources/asana.py
@@ -32,6 +32,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="AsanaConfig",
     labels=["Project Management"],
+    supports_continuous=False,
 )
 class AsanaSource(BaseSource):
     """Asana source connector integrates with the Asana API to extract and synchronize data.

--- a/backend/airweave/platform/sources/bitbucket.py
+++ b/backend/airweave/platform/sources/bitbucket.py
@@ -35,6 +35,7 @@ from airweave.schemas.source_connection import AuthenticationMethod
     auth_config_class="BitbucketAuthConfig",
     config_class="BitbucketConfig",
     labels=["Code"],
+    supports_continuous=False,
 )
 class BitbucketSource(BaseSource):
     """Bitbucket source connector integrates with the Bitbucket REST API to extract data.

--- a/backend/airweave/platform/sources/confluence.py
+++ b/backend/airweave/platform/sources/confluence.py
@@ -88,6 +88,7 @@ class AsyncIteratorWrapper:
     auth_config_class=None,
     config_class="ConfluenceConfig",
     labels=["Knowledge Base", "Documentation"],
+    supports_continuous=False,
 )
 class ConfluenceSource(BaseSource):
     """Confluence source connector integrates with the Confluence REST API to extract content.

--- a/backend/airweave/platform/sources/ctti.py
+++ b/backend/airweave/platform/sources/ctti.py
@@ -122,6 +122,7 @@ async def _retry_with_backoff(func, *args, max_retries=3, **kwargs):
     auth_config_class="CTTIAuthConfig",
     config_class="CTTIConfig",
     labels=["Clinical Trials", "Database"],
+    supports_continuous=False,
 )
 class CTTISource(BaseSource):
     """CTTI source connector integrates with the AACT PostgreSQL database to extract trials.

--- a/backend/airweave/platform/sources/dropbox.py
+++ b/backend/airweave/platform/sources/dropbox.py
@@ -29,6 +29,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="DropboxConfig",
     labels=["File Storage"],
+    supports_continuous=False,
 )
 class DropboxSource(BaseSource):
     """Dropbox source connector integrates with the Dropbox API to extract and synchronize files.

--- a/backend/airweave/platform/sources/github.py
+++ b/backend/airweave/platform/sources/github.py
@@ -35,6 +35,7 @@ from airweave.schemas.source_connection import AuthenticationMethod
     auth_config_class="GitHubAuthConfig",
     config_class="GitHubConfig",
     labels=["Code"],
+    supports_continuous=True,
 )
 class GitHubSource(BaseSource):
     """GitHub source connector integrates with the GitHub REST API to extract and synchronize data.

--- a/backend/airweave/platform/sources/gmail.py
+++ b/backend/airweave/platform/sources/gmail.py
@@ -53,6 +53,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="GmailConfig",
     labels=["Communication", "Email"],
+    supports_continuous=True,
 )
 class GmailSource(BaseSource):
     """Gmail source connector integrates with the Gmail API to extract and synchronize email data.

--- a/backend/airweave/platform/sources/google_calendar.py
+++ b/backend/airweave/platform/sources/google_calendar.py
@@ -63,6 +63,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="GoogleCalendarConfig",
     labels=["Productivity", "Calendar"],
+    supports_continuous=False,
 )
 class GoogleCalendarSource(BaseSource):
     """Google Calendar source connector integrates with the Google Calendar API to extract data.

--- a/backend/airweave/platform/sources/google_drive.py
+++ b/backend/airweave/platform/sources/google_drive.py
@@ -37,12 +37,14 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
         AuthenticationMethod.OAUTH_BROWSER,
         AuthenticationMethod.OAUTH_TOKEN,
         AuthenticationMethod.AUTH_PROVIDER,
+        AuthenticationMethod.OAUTH_BYOC,
     ],
     oauth_type=OAuthType.WITH_REFRESH,
     requires_byoc=True,
     auth_config_class=None,
     config_class="GoogleDriveConfig",
     labels=["File Storage"],
+    supports_continuous=True,
 )
 class GoogleDriveSource(BaseSource):
     """Google Drive source connector integrates with the Google Drive API to extract files.

--- a/backend/airweave/platform/sources/hubspot.py
+++ b/backend/airweave/platform/sources/hubspot.py
@@ -29,6 +29,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     oauth_type=OAuthType.WITH_REFRESH,
     config_class="HubspotConfig",
     labels=["CRM", "Marketing"],
+    supports_continuous=False,
 )
 class HubspotSource(BaseSource):
     """HubSpot source connector integrates with the HubSpot CRM API to extract CRM data.

--- a/backend/airweave/platform/sources/jira.py
+++ b/backend/airweave/platform/sources/jira.py
@@ -36,6 +36,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="JiraConfig",
     labels=["Project Management", "Issue Tracking"],
+    supports_continuous=False,
 )
 class JiraSource(BaseSource):
     """Jira source connector integrates with the Jira REST API to extract project management data.

--- a/backend/airweave/platform/sources/linear.py
+++ b/backend/airweave/platform/sources/linear.py
@@ -34,6 +34,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="LinearConfig",
     labels=["Project Management"],
+    supports_continuous=False,
 )
 class LinearSource(BaseSource):
     """Linear source connector integrates with the Linear GraphQL API to extract project data.

--- a/backend/airweave/platform/sources/monday.py
+++ b/backend/airweave/platform/sources/monday.py
@@ -36,6 +36,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="MondayConfig",
     labels=["Project Management"],
+    supports_continuous=False,
 )
 class MondaySource(BaseSource):
     """Monday source connector integrates with the Monday.com GraphQL API to extract work data.

--- a/backend/airweave/platform/sources/notion.py
+++ b/backend/airweave/platform/sources/notion.py
@@ -40,6 +40,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="NotionConfig",
     labels=["Knowledge Base", "Productivity"],
+    supports_continuous=False,
 )
 class NotionSource(BaseSource):
     """Notion source connector integrates with the Notion API to extract and synchronize content.

--- a/backend/airweave/platform/sources/onedrive.py
+++ b/backend/airweave/platform/sources/onedrive.py
@@ -39,6 +39,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="OneDriveConfig",
     labels=["File Storage"],
+    supports_continuous=False,
 )
 class OneDriveSource(BaseSource):
     """OneDrive source connector integrates with the Microsoft Graph API to extract files.

--- a/backend/airweave/platform/sources/outlook_calendar.py
+++ b/backend/airweave/platform/sources/outlook_calendar.py
@@ -39,6 +39,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="OutlookCalendarConfig",
     labels=["Productivity", "Calendar"],
+    supports_continuous=False,
 )
 class OutlookCalendarSource(BaseSource):
     """Outlook Calendar source connector integrates with the Microsoft Graph API to extract data.

--- a/backend/airweave/platform/sources/outlook_mail.py
+++ b/backend/airweave/platform/sources/outlook_mail.py
@@ -41,6 +41,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="OutlookMailConfig",
     labels=["Communication", "Email"],
+    supports_continuous=True,
 )
 class OutlookMailSource(BaseSource):
     """Outlook Mail source connector integrates with the Microsoft Graph API to extract email data.

--- a/backend/airweave/platform/sources/postgresql.py
+++ b/backend/airweave/platform/sources/postgresql.py
@@ -49,6 +49,7 @@ PG_TYPE_MAP = {
     auth_config_class="PostgreSQLAuthConfig",
     config_class="PostgreSQLConfig",
     labels=["Database"],
+    supports_continuous=True,
 )
 class PostgreSQLSource(BaseSource):
     """PostgreSQL source connector integrates with PostgreSQL databases to extract structured data.

--- a/backend/airweave/platform/sources/stripe.py
+++ b/backend/airweave/platform/sources/stripe.py
@@ -49,6 +49,7 @@ from airweave.schemas.source_connection import AuthenticationMethod
     auth_config_class="StripeAuthConfig",
     config_class="StripeConfig",
     labels=["Payment"],
+    supports_continuous=False,
 )
 class StripeSource(BaseSource):
     """Stripe source connector integrates with the Stripe API to extract payment and financial data.

--- a/backend/airweave/platform/sources/todoist.py
+++ b/backend/airweave/platform/sources/todoist.py
@@ -28,6 +28,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
     auth_config_class=None,
     config_class="TodoistConfig",
     labels=["Productivity", "Task Management"],
+    supports_continuous=False,
 )
 class TodoistSource(BaseSource):
     """Todoist source connector integrates with the Todoist REST API to extract task data.

--- a/backend/airweave/schemas/source.py
+++ b/backend/airweave/schemas/source.py
@@ -77,17 +77,18 @@ class SourceBase(BaseModel):
             "and structure that this connector outputs."
         ),
     )
-    organization_id: Optional[UUID] = Field(
-        None,
-        description=(
-            "Organization identifier for custom source connectors. System sources have this "
-            "set to null."
-        ),
-    )
     labels: Optional[List[str]] = Field(
         None,
         description=(
             "Categorization tags to help users discover and filter sources by domain or use case."
+        ),
+    )
+    supports_continuous: bool = Field(
+        False,
+        description=(
+            "Whether this source supports cursor-based continuous syncing for incremental data "
+            "extraction. Sources with this capability can track their sync position and resume "
+            "from where they left off."
         ),
     )
 

--- a/backend/airweave/schemas/sync.py
+++ b/backend/airweave/schemas/sync.py
@@ -24,7 +24,6 @@ class SyncBase(BaseModel):
     next_scheduled_run: Optional[datetime] = None
     temporal_schedule_id: Optional[str] = None
     sync_type: str = "full"
-    minute_level_cron_schedule: Optional[str] = None
     sync_metadata: Optional[dict] = None
     status: Optional[SyncStatus] = SyncStatus.ACTIVE
 
@@ -52,21 +51,6 @@ class SyncBase(BaseModel):
         cron_pattern = r"^(\*|[0-9]{1,2}|[0-9]{1,2}-[0-9]{1,2}|[0-9]{1,2}/[0-9]{1,2}|[0-9]{1,2},[0-9]{1,2}|\*\/[0-9]{1,2}) (\*|[0-9]{1,2}|[0-9]{1,2}-[0-9]{1,2}|[0-9]{1,2}/[0-9]{1,2}|[0-9]{1,2},[0-9]{1,2}|\*\/[0-9]{1,2}) (\*|[0-9]{1,2}|[0-9]{1,2}-[0-9]{1,2}|[0-9]{1,2}/[0-9]{1,2}|[0-9]{1,2},[0-9]{1,2}|\*\/[0-9]{1,2}) (\*|[0-9]{1,2}|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|[0-9]{1,2}-[0-9]{1,2}|[0-9]{1,2}/[0-9]{1,2}|[0-9]{1,2},[0-9]{1,2}|\*\/[0-9]{1,2}) (\*|[0-6]|SUN|MON|TUE|WED|THU|FRI|SAT|[0-6]-[0-6]|[0-6]/[0-6]|[0-6],[0-6]|\*\/[0-6])$"  # noqa: E501
         if not re.match(cron_pattern, v):
             raise ValueError("Invalid cron schedule format")
-        return v
-
-    @field_validator("minute_level_cron_schedule")
-    def validate_minute_level_cron_schedule(cls, v: Optional[str]) -> Optional[str]:
-        """Validate minute-level cron schedule format for incremental syncs."""
-        if v is None:
-            return None
-        # Allow minute-level patterns like */1, */5, */15, */30
-        # Restrict minute values to 0-59 range
-        minute_level_pattern = r"^(\*\/[1-5]?[0-9]|[0-5]?[0-9]) \* \* \* \*$"
-        if not re.match(minute_level_pattern, v):
-            raise ValueError(
-                "Minute-level cron must be minute-level only "
-                "(e.g., */1 * * * * for every minute) with valid minute values (0-59)"
-            )
         return v
 
     @field_validator("sync_type")
@@ -102,22 +86,6 @@ class SyncUpdate(BaseModel):
     status: Optional[SyncStatus] = None
     temporal_schedule_id: Optional[str] = None
     sync_type: Optional[str] = None
-    minute_level_cron_schedule: Optional[str] = None
-
-    @field_validator("minute_level_cron_schedule")
-    def validate_minute_level_cron_schedule(cls, v: Optional[str]) -> Optional[str]:
-        """Validate minute-level cron schedule format for incremental syncs."""
-        if v is None:
-            return None
-        # Allow minute-level patterns like */1, */5, */15, */30
-        # Restrict minute values to 0-59 range
-        minute_level_pattern = r"^(\*\/[1-5]?[0-9]|[0-5]?[0-9]) \* \* \* \*$"
-        if not re.match(minute_level_pattern, v):
-            raise ValueError(
-                "Minute-level cron must be minute-level only "
-                "(e.g., */1 * * * * for every minute) with valid minute values (0-59)"
-            )
-        return v
 
     @field_validator("sync_type")
     def validate_sync_type(cls, v: Optional[str]) -> Optional[str]:
@@ -191,28 +159,12 @@ class SyncWithoutConnections(BaseModel):
     sync_metadata: Optional[dict] = None
     temporal_schedule_id: Optional[str] = None
     sync_type: str = "full"
-    minute_level_cron_schedule: Optional[str] = None
     id: UUID
     organization_id: UUID
     created_at: datetime
     modified_at: datetime
     created_by_email: Optional[EmailStr] = None
     modified_by_email: Optional[EmailStr] = None
-
-    @field_validator("minute_level_cron_schedule")
-    def validate_minute_level_cron_schedule(cls, v: Optional[str]) -> Optional[str]:
-        """Validate minute-level cron schedule format for incremental syncs."""
-        if v is None:
-            return None
-        # Allow minute-level patterns like */1, */5, */15, */30
-        # Restrict minute values to 0-59 range
-        minute_level_pattern = r"^(\*\/[1-5]?[0-9]|[0-5]?[0-9]) \* \* \* \*$"
-        if not re.match(minute_level_pattern, v):
-            raise ValueError(
-                "Minute-level cron must be minute-level only "
-                "(e.g., */1 * * * * for every minute) with valid minute values (0-59)"
-            )
-        return v
 
     @field_validator("sync_type")
     def validate_sync_type(cls, v: Optional[str]) -> Optional[str]:

--- a/backend/alembic/versions/c3d4e5f6g7h8_add_supports_continuous_to_source.py
+++ b/backend/alembic/versions/c3d4e5f6g7h8_add_supports_continuous_to_source.py
@@ -1,0 +1,32 @@
+"""Add supports_continuous field to source table
+
+Revision ID: c3d4e5f6g7h8
+Revises: 264fdc0ac89c
+Create Date: 2025-09-25 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6g7h8"
+down_revision: Union[str, None] = "264fdc0ac89c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add supports_continuous column to source table."""
+    op.add_column(
+        "source",
+        sa.Column("supports_continuous", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    """Remove supports_continuous column from source table."""
+    op.drop_column("source", "supports_continuous")

--- a/backend/alembic/versions/c60291fb2129_remove_minute_level_cron_schedule_from_.py
+++ b/backend/alembic/versions/c60291fb2129_remove_minute_level_cron_schedule_from_.py
@@ -1,0 +1,95 @@
+"""Remove minute_level_cron_schedule from sync table
+
+Revision ID: c60291fb2129
+Revises: c3d4e5f6g7h8
+Create Date: 2025-09-25 11:41:34.343624
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c60291fb2129"
+down_revision = "c3d4e5f6g7h8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Unify CRON schedule fields by migrating minute_level_cron_schedule to cron_schedule
+    and then removing the minute_level_cron_schedule column.
+    """
+
+    # Step 1: Migrate existing minute_level_cron_schedule values to cron_schedule
+    # For any syncs that have minute_level_cron_schedule but no cron_schedule
+    op.execute(
+        """
+        UPDATE sync
+        SET cron_schedule = minute_level_cron_schedule,
+            sync_type = 'incremental'
+        WHERE minute_level_cron_schedule IS NOT NULL
+          AND cron_schedule IS NULL
+    """
+    )
+
+    # Step 2: Handle conflicts where both fields are set
+    # Prefer minute_level_cron_schedule as it was more specific
+    op.execute(
+        """
+        UPDATE sync
+        SET cron_schedule = minute_level_cron_schedule,
+            sync_type = 'incremental'
+        WHERE minute_level_cron_schedule IS NOT NULL
+          AND cron_schedule IS NOT NULL
+    """
+    )
+
+    # Step 3: Update sync_type for existing cron_schedule entries
+    # Set to incremental for minute-level patterns (*/N where N < 60)
+    op.execute(
+        """
+        UPDATE sync
+        SET sync_type = 'incremental'
+        WHERE cron_schedule ~ '^(\\*/[1-5]?[0-9]|[0-5]?[0-9]) \\* \\* \\* \\*$'
+          AND (
+              cron_schedule ~ '^\\*/([1-9]|[1-5][0-9]) \\* \\* \\* \\*$'
+              OR cron_schedule ~ '^[0-5]?[0-9] \\* \\* \\* \\*$'
+          )
+    """
+    )
+
+    # Step 4: Drop the minute_level_cron_schedule column
+    op.drop_column("sync", "minute_level_cron_schedule")
+
+
+def downgrade():
+    """
+    Restore minute_level_cron_schedule column and migrate incremental syncs back to it.
+    """
+
+    # Step 1: Re-add the minute_level_cron_schedule column
+    op.add_column(
+        "sync",
+        sa.Column(
+            "minute_level_cron_schedule", sa.VARCHAR(length=100), autoincrement=False, nullable=True
+        ),
+    )
+
+    # Step 2: Migrate minute-level schedules back to minute_level_cron_schedule
+    # Move schedules that are minute-level patterns (*/N where N < 60) for incremental syncs
+    op.execute(
+        """
+        UPDATE sync
+        SET minute_level_cron_schedule = cron_schedule,
+            cron_schedule = NULL
+        WHERE sync_type = 'incremental'
+          AND cron_schedule ~ '^(\\*/[1-5]?[0-9]|[0-5]?[0-9]) \\* \\* \\* \\*$'
+          AND (
+              cron_schedule ~ '^\\*/([1-9]|[1-5][0-9]) \\* \\* \\* \\*$'
+              OR cron_schedule ~ '^[0-5]?[0-9] \\* \\* \\* \\*$'
+          )
+    """
+    )

--- a/backend/tests/e2e/smoke/public_api_tests/test_temporal_schedules.py
+++ b/backend/tests/e2e/smoke/public_api_tests/test_temporal_schedules.py
@@ -1,0 +1,388 @@
+"""
+Test module for CRON Schedule Updates with Temporal Validation.
+
+This module tests the integration between source connection schedule updates
+and Temporal workflow scheduler.
+"""
+
+import time
+import requests
+from typing import Optional, List, Dict, Any
+
+
+def structured_calendar_to_cron(structured_cal: dict) -> str:
+    """Convert Temporal's structuredCalendar to a CRON expression.
+
+    The structuredCalendar format uses:
+    - step=1 with only step means "at 0" (first unit)
+    - step=1 with end means "every unit from 0 to end"
+    - step=N means "every N units"
+    - start/end with step=1 means "every unit in range"
+    - Multiple entries in an array mean comma-separated values (e.g., 6,18 for hours)
+    """
+    # Extract the schedule components - these can be lists for comma-separated values
+    minutes = structured_cal.get("minute", [{}])
+    hours = structured_cal.get("hour", [{}])
+    days_of_month = structured_cal.get("dayOfMonth", [{}])
+    months = structured_cal.get("month", [{}])
+    days_of_week = structured_cal.get("dayOfWeek", [{}])
+
+    # Convert minutes (handle multiple entries for comma-separated values)
+    minute_parts = []
+    for minute in minutes:
+        if not minute:  # Empty dict
+            continue
+        if minute.get("step") == 1:
+            if "start" in minute and "end" in minute:
+                # Check if start == end (specific minute) or range
+                if minute["start"] == minute["end"]:
+                    # Specific minute (most common case: minute 0)
+                    minute_parts.append(str(minute["start"]))
+                else:
+                    # Range of minutes
+                    minute_parts.append("*")
+            elif "end" in minute or "start" in minute:
+                # Has range, means every minute in range
+                minute_parts.append("*")
+            else:
+                # No range, just step=1 means minute 0
+                minute_parts.append("0")
+        elif minute.get("step"):
+            minute_parts.append(f"*/{minute['step']}")
+        elif "start" in minute:
+            # Specific minute value
+            minute_parts.append(str(minute.get("start", 0)))
+        # Don't add anything for empty dicts
+    minute_part = ",".join(minute_parts) if minute_parts else "0"
+
+    # Convert hours (handle multiple entries for comma-separated values)
+    hour_parts = []
+    for hour in hours:
+        if not hour:  # Empty dict
+            continue
+        if hour.get("step") == 1:
+            if "start" in hour and "end" in hour:
+                # Check if start == end (specific hour) or range
+                if hour["start"] == hour["end"]:
+                    # Specific hour (e.g., start: 6, end: 6, step: 1)
+                    hour_parts.append(str(hour["start"]))
+                else:
+                    # Range of hours (e.g., start: 0, end: 23, step: 1)
+                    hour_parts.append("*")
+            elif "end" in hour:
+                # Has end but no start, means every hour (0-23)
+                hour_parts.append("*")
+            else:
+                # No end, just step=1 means hour 0
+                hour_parts.append("0")
+        elif hour.get("step"):
+            hour_parts.append(f"*/{hour['step']}")
+        elif "start" in hour:
+            # Specific hour value
+            hour_parts.append(str(hour.get("start", 0)))
+        # Don't add anything for empty dicts
+    hour_part = ",".join(hour_parts) if hour_parts else "0"
+
+    # Convert day of month (usually single value)
+    day_of_month = days_of_month[0] if days_of_month else {}
+    if day_of_month.get("step") == 1 and ("start" in day_of_month or "end" in day_of_month):
+        day_part = "*"
+    else:
+        day_part = str(day_of_month.get("start", 1)) if day_of_month else "*"
+
+    # Convert month (usually single value)
+    month = months[0] if months else {}
+    if month.get("step") == 1 and ("start" in month or "end" in month):
+        month_part = "*"
+    else:
+        month_part = str(month.get("start", 1)) if month else "*"
+
+    # Convert day of week (usually single value)
+    day_of_week = days_of_week[0] if days_of_week else {}
+    if day_of_week.get("step") == 1 and "end" in day_of_week:
+        weekday_part = "*"
+    elif day_of_week.get("start") is not None:
+        if day_of_week.get("end"):
+            weekday_part = f"{day_of_week['start']}-{day_of_week['end']}"
+        else:
+            weekday_part = str(day_of_week["start"])
+    else:
+        weekday_part = "*"
+
+    return f"{minute_part} {hour_part} {day_part} {month_part} {weekday_part}"
+
+
+def check_temporal_schedules_by_cron(expected_cron: str = None) -> Dict[str, Any]:
+    """Check Temporal schedules using the REST API and verify CRON expressions."""
+    import requests
+
+    # Use Temporal REST API to list schedules
+    temporal_api_url = "http://localhost:8088/api/v1/namespaces/default/schedules"
+
+    try:
+        # List all schedules
+        response = requests.get(temporal_api_url)
+        response.raise_for_status()
+
+        schedules_data = response.json()
+        matching_schedules = []
+        all_schedule_ids = []
+
+        # Process each schedule
+        for schedule in schedules_data.get("schedules", []):
+            schedule_id = schedule.get("scheduleId", "")
+            all_schedule_ids.append(schedule_id)
+
+            # Check if schedule has info with spec
+            info = schedule.get("info", {})
+            spec = info.get("spec", {})
+
+            # Check for structuredCalendar (new format) or cronExpressions (old format)
+            cron_expr = None
+            if "structuredCalendar" in spec and spec["structuredCalendar"]:
+                # Convert structured calendar to CRON
+                structured_cal = spec["structuredCalendar"][0]
+                cron_expr = structured_calendar_to_cron(structured_cal)
+            elif "cronExpressions" in spec and spec["cronExpressions"]:
+                cron_expr = spec["cronExpressions"][0]
+
+            if cron_expr and expected_cron and cron_expr == expected_cron:
+                matching_schedules.append(schedule_id)
+                print(f"    ✓ Found matching schedule: {schedule_id} with CRON: {cron_expr}")
+
+        if expected_cron:
+            return len(matching_schedules) > 0, matching_schedules
+        else:
+            # If no expected CRON, just return if there are any schedules
+            return len(all_schedule_ids) > 0, all_schedule_ids
+
+    except Exception as e:
+        print(f"    ⚠️ Error connecting to Temporal REST API: {e}")
+        raise
+
+
+def run_temporal_schedule_tests(api_url: str, headers: dict, test_conn_id: str) -> None:
+    """
+    Run all CRON schedule tests with Temporal validation.
+
+    Args:
+        api_url: The API URL
+        headers: Request headers with authentication
+        test_conn_id: The connection ID to test with
+    """
+    print("\n📌 Test 2: CRON Schedule Updates with Temporal Validation")
+
+    # Test 1: Update to daily schedule (should create regular schedule)
+    print("  Testing schedule update to daily...")
+    update_payload = {"schedule": {"cron": "0 0 * * *"}}  # Daily at midnight
+    response = requests.patch(
+        f"{api_url}/source-connections/{test_conn_id}", json=update_payload, headers=headers
+    )
+    assert response.status_code == 200, f"Failed to update schedule: {response.text}"
+
+    updated_conn = response.json()
+    assert updated_conn["schedule"] is not None, "Schedule should be present"
+    assert updated_conn["schedule"]["cron"] == "0 0 * * *", "CRON not updated correctly"
+
+    # Check Temporal schedule directly
+    time.sleep(2)  # Give Temporal time to create/update schedule
+    has_schedule, matching = check_temporal_schedules_by_cron("0 0 * * *")
+    assert has_schedule, "Should have at least one schedule with CRON '0 0 * * *'"
+    assert len(matching) >= 1, f"Should have at least one matching schedule, got {matching}"
+    print(f"    ✓ Daily schedule created in Temporal")
+
+    # Test 2: Update to hourly schedule (should still be regular schedule)
+    print("  Testing schedule update to hourly...")
+    update_payload = {"schedule": {"cron": "0 * * * *"}}  # Every hour
+    response = requests.patch(
+        f"{api_url}/source-connections/{test_conn_id}", json=update_payload, headers=headers
+    )
+    assert response.status_code == 200, f"Failed to update to hourly: {response.text}"
+
+    updated_conn = response.json()
+    assert updated_conn["schedule"]["cron"] == "0 * * * *", "CRON not updated to hourly"
+
+    # Check Temporal schedule directly
+    time.sleep(2)
+    has_schedule, matching = check_temporal_schedules_by_cron("0 * * * *")
+    assert has_schedule, f"Should have at least one schedule with CRON '0 * * * *', got {matching}"
+    print(f"    ✓ Hourly schedule created in Temporal")
+
+    # Test 3: Try minute-level schedule (should fail for Stripe - no continuous support)
+    print("  Testing minute-level schedule (should fail for non-continuous sources)...")
+    update_payload = {"schedule": {"cron": "*/5 * * * *"}}  # Every 5 minutes
+    response = requests.patch(
+        f"{api_url}/source-connections/{test_conn_id}", json=update_payload, headers=headers
+    )
+    # Stripe doesn't support continuous, so this should fail with 400
+    assert (
+        response.status_code == 400
+    ), f"Expected 400 for minute-level on non-continuous source, got {response.status_code}"
+    if response.status_code == 400:
+        error = response.json()
+        detail = error.get("detail", "").lower()
+        assert "does not support continuous" in detail or "minimum schedule interval" in detail
+    print("    ✓ Minute-level schedule correctly rejected for non-continuous source")
+
+    # Test 4: Update to twice-daily schedule (simpler than weekday-specific)
+    print("  Testing twice-daily schedule update...")
+    update_payload = {"schedule": {"cron": "0 6,18 * * *"}}  # At 6 AM and 6 PM daily
+    response = requests.patch(
+        f"{api_url}/source-connections/{test_conn_id}", json=update_payload, headers=headers
+    )
+    assert response.status_code == 200, f"Failed to update twice-daily schedule: {response.text}"
+
+    updated_conn = response.json()
+    assert updated_conn["schedule"]["cron"] == "0 6,18 * * *", "Twice-daily CRON not updated"
+    print("    ✓ Updated to twice-daily schedule (6 AM and 6 PM)")
+
+    # Test 5: Disable schedule (set to null/empty) - should delete Temporal schedule
+    print("  Testing schedule removal and Temporal deletion...")
+
+    # Wait for the schedule to be created/updated in Temporal
+    time.sleep(2)
+
+    # First, count schedules with the current CRON (from test 4: twice-daily schedule)
+    current_cron = "0 6,18 * * *"  # The twice-daily schedule from test 4
+    has_before, schedules_before = check_temporal_schedules_by_cron(current_cron)
+    schedules_before_count = len(schedules_before) if has_before else 0
+    print(f"    Schedules with CRON '{current_cron}' before removal: {schedules_before_count}")
+
+    update_payload = {"schedule": {"cron": None}}  # Remove schedule
+    response = requests.patch(
+        f"{api_url}/source-connections/{test_conn_id}", json=update_payload, headers=headers
+    )
+    assert response.status_code == 200, f"Failed to remove schedule: {response.text}"
+
+    updated_conn = response.json()
+    # Schedule object might still exist but cron should be None
+    if updated_conn.get("schedule"):
+        assert updated_conn["schedule"]["cron"] is None, "CRON should be None"
+
+    # Check that the schedule with that CRON was deleted
+    time.sleep(2)
+    has_after, schedules_after = check_temporal_schedules_by_cron(current_cron)
+    schedules_after_count = len(schedules_after) if has_after else 0
+
+    # We should have fewer schedules with this CRON (ideally one less)
+    assert (
+        schedules_after_count < schedules_before_count
+    ), f"Should have fewer schedules with CRON '{current_cron}' after removal (had {schedules_before_count}, now {schedules_after_count})"
+
+    print(
+        f"    ✓ Schedule removed (schedules with CRON '{current_cron}': {schedules_before_count} → {schedules_after_count})"
+    )
+    print("    ✓ Verified schedule deletion in Temporal")
+
+    # Test 6: Re-enable with different schedule - should create new Temporal schedule
+    print("  Testing schedule re-enable with Temporal recreation...")
+    update_payload = {"schedule": {"cron": "30 2 * * *"}}  # Daily at 2:30 AM
+    response = requests.patch(
+        f"{api_url}/source-connections/{test_conn_id}", json=update_payload, headers=headers
+    )
+    assert response.status_code == 200, f"Failed to re-enable schedule: {response.text}"
+
+    updated_conn = response.json()
+    assert updated_conn["schedule"]["cron"] == "30 2 * * *", "Schedule not re-enabled"
+
+    # Check that Temporal schedule was recreated with new CRON
+    time.sleep(2)
+    has_schedule, matching = check_temporal_schedules_by_cron("30 2 * * *")
+    assert has_schedule, "Should have at least one schedule with CRON '30 2 * * *'"
+    print(f"    ✓ New Temporal schedule created with CRON '30 2 * * *'")
+    print("    ✓ Schedule successfully re-enabled in Temporal")
+
+    # Test 7: Invalid CRON expression (should fail with 422)
+    print("  Testing invalid CRON expression...")
+    update_payload = {"schedule": {"cron": "invalid cron expression"}}
+    response = requests.patch(
+        f"{api_url}/source-connections/{test_conn_id}", json=update_payload, headers=headers
+    )
+    assert response.status_code == 422, f"Expected 422 for invalid cron, got {response.status_code}"
+    print("    ✓ Invalid CRON correctly rejected with 422")
+
+    # Test 8: Update schedule along with other fields
+    print("  Testing combined update (schedule + name)...")
+    update_payload = {
+        "name": "Updated Connection with Schedule",
+        "description": "Testing combined updates",
+        "schedule": {"cron": "15 3 * * 1"},  # Weekly on Monday at 3:15 AM
+    }
+    response = requests.patch(
+        f"{api_url}/source-connections/{test_conn_id}", json=update_payload, headers=headers
+    )
+    assert response.status_code == 200, f"Failed combined update: {response.text}"
+
+    updated_conn = response.json()
+    assert updated_conn["name"] == "Updated Connection with Schedule", "Name not updated"
+    assert updated_conn["description"] == "Testing combined updates", "Description not updated"
+    assert updated_conn["schedule"]["cron"] == "15 3 * * 1", "Schedule not updated in combined"
+    print("    ✓ Combined update successful")
+
+    print("\n  ✅ CRON schedule update tests with Temporal validation passed")
+
+
+def test_minute_level_schedules(
+    api_url: str, headers: dict, created_connections: List[str]
+) -> None:
+    """
+    Test minute-level schedules for continuous sources.
+
+    Args:
+        api_url: The API URL
+        headers: Request headers with authentication
+        created_connections: List of created connection IDs
+    """
+    print("\n  Testing minute-level schedules for continuous sources...")
+
+    # Try to find a connection that supports continuous syncs (e.g., GitHub, Notion)
+    notion_conn_id = None
+    for conn_id in created_connections:
+        response = requests.get(f"{api_url}/source-connections/{conn_id}", headers=headers)
+        if response.status_code == 200:
+            conn = response.json()
+            # Check the short_name directly on the connection
+            if conn.get("short_name") in ["notion", "github", "google_drive"]:
+                notion_conn_id = conn_id
+                print(f"    Found continuous-capable source: {conn['short_name']} ({conn_id})")
+                break
+
+    if notion_conn_id:
+        # Test minute-level schedule
+        print("    Testing minute-level schedule on continuous source...")
+        update_payload = {"schedule": {"cron": "*/15 * * * *"}}  # Every 15 minutes
+        response = requests.patch(
+            f"{api_url}/source-connections/{notion_conn_id}",
+            json=update_payload,
+            headers=headers,
+        )
+
+        if response.status_code == 200:
+            updated_conn = response.json()
+            assert updated_conn["schedule"]["cron"] == "*/15 * * * *", "Minute-level CRON not set"
+
+            # Check Temporal schedule directly
+            time.sleep(2)
+            has_schedule, matching = check_temporal_schedules_by_cron("*/15 * * * *")
+            assert (
+                has_schedule
+            ), "Should have at least one schedule with CRON '*/15 * * * *' for continuous source"
+
+            print(f"    ✓ Minute-level schedule created successfully for continuous source")
+            print(f"    ✓ Matching schedules: {matching}")
+
+            # Clean up - remove the minute-level schedule
+            update_payload = {"schedule": {"cron": None}}
+            requests.patch(
+                f"{api_url}/source-connections/{notion_conn_id}",
+                json=update_payload,
+                headers=headers,
+            )
+            print("    ✓ Cleaned up minute-level schedule")
+        else:
+            print(f"    ⚠️ Could not set minute-level schedule: {response.status_code}")
+            if response.status_code == 400:
+                error = response.json()
+                print(f"    Error: {error.get('detail', 'Unknown error')}")
+    else:
+        print("    ⚠️ No continuous-capable source found for minute-level testing")

--- a/backend/tests/e2e/smoke/public_api_tests/test_temporal_schedules.py
+++ b/backend/tests/e2e/smoke/public_api_tests/test_temporal_schedules.py
@@ -3,6 +3,9 @@ Test module for CRON Schedule Updates with Temporal Validation.
 
 This module tests the integration between source connection schedule updates
 and Temporal workflow scheduler.
+
+NOTE: These tests are only run when testing locally (localhost) as they require
+direct access to the Temporal API which is not available in dev/prod environments.
 """
 
 import time


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Unified Temporal scheduling with a single cron_schedule field and strict per-source validation. Minute-level schedules are now only allowed for sources that support continuous syncs, improving reliability and clarity.

- **New Features**
  - Added supports_continuous to Source and enforced schedule rules: sub-hourly only for continuous sources; hourly+ for others.
  - Unified schedule storage; removed minute_level_cron_schedule and wrote changes to cron_schedule with correct sync_type.
  - CRON validation using croniter; API checks before creating/updating schedules.
  - Temporal schedules now distinguish regular vs minute-level and are fully cleaned up on removal.
  - Added end-to-end tests that verify schedule creation, updates, deletion, and minute-level behavior via Temporal REST API.

- **Migration**
  - Alembic: add supports_continuous to source (default false).
  - Alembic: migrate minute_level_cron_schedule → cron_schedule; set sync_type=incremental for minute-level patterns; drop old column.
  - Startup runs migrations with a fixed PYTHONPATH to ensure consistent execution.

<!-- End of auto-generated description by cubic. -->

