### PR TITLE
fix(source connections): use custom byoc instead of dropping on override

### DIFF
--- a/backend/airweave/platform/auth/services.py
+++ b/backend/airweave/platform/auth/services.py
@@ -564,6 +564,12 @@ class OAuth2Service:
             "redirect_uri": redirect_uri,
         }
 
+        # ADD THIS DEBUG LOGGING HERE - BEFORE the credential handling
+        logger.info(f"DEBUG - Using redirect_uri: {redirect_uri}")
+        logger.info(f"DEBUG - Using client_id: {client_id}")
+        logger.info(f"DEBUG - Code length: {len(code)}")
+        logger.info(f"DEBUG - Backend URL: {integration_config.backend_url}")
+
         if integration_config.client_credential_location == "header":
             encoded_credentials = OAuth2Service._encode_client_credentials(client_id, client_secret)
             headers["Authorization"] = f"Basic {encoded_credentials}"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes BYOC OAuth for source connections by pulling client_id/client_secret from the nested authentication object and saving the correct auth method. Also prevents secret leakage in the init payload.

- **Bug Fixes**
  - Read BYOC credentials from authentication, with fallbacks to custom_client and top-level fields.
  - Exclude the entire authentication object from the init payload to avoid leaking client_secret.
  - Save auth_method as OAUTH_BYOC when BYOC creds are present, else OAUTH_BROWSER.
  - Validate config via payload.config; use readable_collection_id and support schedule.cron.
  - Add debug logs in OAuth code exchange for redirect_uri, client_id, code length, and backend URL.

<!-- End of auto-generated description by cubic. -->

