### PR TITLE
fix(async): async modules use get_running_loop to re-use existing

### DIFF
--- a/backend/airweave/platform/sync/async_helpers.py
+++ b/backend/airweave/platform/sync/async_helpers.py
@@ -40,7 +40,7 @@ async def run_in_thread_pool(func: Callable[..., T], *args, **kwargs) -> T:
 
     This avoids creating excessive threads by using a controlled thread pool.
     """
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     executor = await get_cpu_executor()
 
     # If there are keyword arguments, wrap the function with partial

--- a/backend/airweave/platform/sync/orchestrator.py
+++ b/backend/airweave/platform/sync/orchestrator.py
@@ -173,7 +173,7 @@ class SyncOrchestrator:
                 # Set a latency-based flush deadline on first element
                 if flush_deadline is None and self.max_batch_latency_ms > 0:
                     flush_deadline = (
-                        asyncio.get_event_loop().time() + self.max_batch_latency_ms / 1000.0
+                        asyncio.get_running_loop().time() + self.max_batch_latency_ms / 1000.0
                     )
 
                 # Size-based flush
@@ -186,7 +186,10 @@ class SyncOrchestrator:
                     continue
 
                 # Time-based flush (checked when new items arrive)
-                if flush_deadline is not None and asyncio.get_event_loop().time() >= flush_deadline:
+                if (
+                    flush_deadline is not None
+                    and asyncio.get_running_loop().time() >= flush_deadline
+                ):
                     pending_tasks = await self._submit_batch_and_trim(
                         batch_buffer, pending_tasks, source_node
                     )

--- a/backend/airweave/platform/sync/pubsub.py
+++ b/backend/airweave/platform/sync/pubsub.py
@@ -146,13 +146,13 @@ class SyncProgress:
         # Calculate rate if possible
         rate_info = ""
         if hasattr(self, "_start_time"):
-            elapsed = asyncio.get_event_loop().time() - self._start_time
+            elapsed = asyncio.get_running_loop().time() - self._start_time
             if elapsed > 0:
                 rate = total_ops / elapsed
                 rate_info = f" | Rate: {rate:.1f} ops/sec"
         else:
             # Set start time on first status update
-            self._start_time = asyncio.get_event_loop().time()
+            self._start_time = asyncio.get_running_loop().time()
 
         # Log entity type breakdown if available
         entity_info = ""

--- a/backend/airweave/platform/sync/router.py
+++ b/backend/airweave/platform/sync/router.py
@@ -155,7 +155,7 @@ class SyncDAGRouter:
         """Route an entity to its next consumer based on DAG structure."""
         entity_context = f"Entity({entity.entity_id})"
         entity_type = type(entity)
-        router_start = asyncio.get_event_loop().time()
+        router_start = asyncio.get_running_loop().time()
 
         # Handle special entity types with dedicated processing
         if self._is_code_file_entity(entity_type, entity):

--- a/backend/airweave/platform/sync/worker_pool.py
+++ b/backend/airweave/platform/sync/worker_pool.py
@@ -70,10 +70,10 @@ class AsyncWorkerPool:
                 f"(thread: {thread_id})"
             )
 
-            start_time = asyncio.get_event_loop().time()
+            start_time = asyncio.get_running_loop().time()
             try:
                 result = await coro(*args, **kwargs)
-                elapsed = asyncio.get_event_loop().time() - start_time
+                elapsed = asyncio.get_running_loop().time() - start_time
 
                 self.logger.debug(
                     f"✅ WORKER_COMPLETE [{task_id}] Task completed successfully "
@@ -82,14 +82,14 @@ class AsyncWorkerPool:
                 return result
 
             except asyncio.CancelledError:
-                elapsed = asyncio.get_event_loop().time() - start_time
+                elapsed = asyncio.get_running_loop().time() - start_time
                 self.logger.warning(
                     f"🚫 WORKER_CANCELLED [{task_id}] "
                     f"Cancelled after {elapsed:.2f}s (thread: {thread_id})"
                 )
                 raise
             except Exception as e:
-                elapsed = asyncio.get_event_loop().time() - start_time
+                elapsed = asyncio.get_running_loop().time() - start_time
                 self.logger.warning(
                     f"❌ WORKER_ERROR [{task_id}] Task failed after {elapsed:.2f}s "
                     f"(thread: {thread_id}): {type(e).__name__}: {str(e)}"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Use asyncio.get_running_loop() across async modules to reuse the active event loop and avoid loop-mismatch issues. This stabilizes timing and executor usage in orchestrator, worker pool, router, and pubsub.

- **Bug Fixes**
  - Replaced get_event_loop() with get_running_loop() for time checks and scheduling.
  - Ensures consistent timing and executor handling in thread pool runs, batch flushing, status logging, routing, and worker tasks.

<!-- End of auto-generated description by cubic. -->

