### PR TITLE
ci: pass COHERE/GROQ/CEREBRAS API keys to CI workflows

### DIFF
--- a/.github/workflows/monke.yml
+++ b/.github/workflows/monke.yml
@@ -43,6 +43,13 @@ jobs:
       # These will be overridden by Key Vault if present
       DM_AUTH_PROVIDER: composio
 
+      # AI provider keys for backend runtime
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+      COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+
     steps:
       - uses: actions/checkout@v5
 
@@ -116,6 +123,9 @@ jobs:
                 # Core dependencies
                 - OPENAI_API_KEY=${OPENAI_API_KEY}
                 - MISTRAL_API_KEY=${MISTRAL_API_KEY}
+                - COHERE_API_KEY=${COHERE_API_KEY}
+                - GROQ_API_KEY=${GROQ_API_KEY}
+                - CEREBRAS_API_KEY=${CEREBRAS_API_KEY}
                 # Azure Key Vault for SaaS credentials
                 - AZURE_KEY_VAULT_URL=${AZURE_KEY_VAULT_URL}
                 - DM_AUTH_PROVIDER=${DM_AUTH_PROVIDER}
@@ -126,6 +136,9 @@ jobs:
                 # Core dependencies
                 - OPENAI_API_KEY=${OPENAI_API_KEY}
                 - MISTRAL_API_KEY=${MISTRAL_API_KEY}
+                - COHERE_API_KEY=${COHERE_API_KEY}
+                - GROQ_API_KEY=${GROQ_API_KEY}
+                - CEREBRAS_API_KEY=${CEREBRAS_API_KEY}
                 # Azure Key Vault for SaaS credentials
                 - AZURE_KEY_VAULT_URL=${AZURE_KEY_VAULT_URL}
                 - DM_AUTH_PROVIDER=${DM_AUTH_PROVIDER}
@@ -179,6 +192,9 @@ jobs:
           # Core dependencies (keep these as GitHub secrets)
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
 
           # Azure Key Vault for SaaS app credentials
           AZURE_KEY_VAULT_URL: ${{ secrets.AZURE_KEY_VAULT_URL }}

--- a/.github/workflows/test-public-api.yml
+++ b/.github/workflows/test-public-api.yml
@@ -69,6 +69,9 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY || 'dummy-key' }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY || 'dummy-key' }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY || 'dummy-key' }}
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY || 'dummy-key' }}
           # Required for start.sh to skip interactive prompts
           NONINTERACTIVE: "1"
           # Set required environment variables for the containers
@@ -77,6 +80,12 @@ jobs:
         run: |
           echo "Starting services using start.sh..."
           # start.sh will create .env from .env.example and generate keys
+          # Ensure AI keys are in .env so containers pick them up
+          echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> .env
+          echo "MISTRAL_API_KEY=${MISTRAL_API_KEY}" >> .env
+          echo "COHERE_API_KEY=${COHERE_API_KEY}" >> .env
+          echo "GROQ_API_KEY=${GROQ_API_KEY}" >> .env
+          echo "CEREBRAS_API_KEY=${CEREBRAS_API_KEY}" >> .env
           ./start.sh --noninteractive
 
           # The script already does health checks, but let's verify


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Pass COHERE, GROQ, and CEREBRAS API keys into CI so backend services and public API tests can run these providers reliably. monke.yml forwards the keys from GitHub secrets to container envs, and test-public-api.yml sets them (with dummy fallbacks) and writes them into .env before start.sh.

<!-- End of auto-generated description by cubic. -->

