### PR TITLE
fix: Add missing blocked sources check in SourceConfigView creation flow

### DIFF
--- a/frontend/src/components/creation-views/SourceConfigView.tsx
+++ b/frontend/src/components/creation-views/SourceConfigView.tsx
@@ -75,6 +75,17 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
 
   const { authProviderConnections, fetchAuthProviderConnections } = useAuthProvidersStore();
 
+  // Sources that are temporarily blocked from using auth providers
+  const SOURCES_BLOCKED_FROM_AUTH_PROVIDERS = [
+    "confluence",
+    "jira",
+    "bitbucket",
+    "github",
+    "ctti",
+    "monday",
+    "postgresql"
+  ];
+
   const [isCreating, setIsCreating] = useState(false);
   const [sourceDetails, setSourceDetails] = useState<SourceDetails | null>(null);
   const [authFields, setAuthFields] = useState<Record<string, string>>({});
@@ -163,8 +174,10 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
       methods.push('oauth2');
     }
 
-    // Add external provider if any are connected and source supports it
-    if (authProviderConnections.length > 0 && sourceDetails.auth_methods.includes('auth_provider')) {
+    // Add external provider if any are connected and source supports it and is not blocked
+    if (authProviderConnections.length > 0 &&
+      sourceDetails.auth_methods.includes('auth_provider') &&
+      !SOURCES_BLOCKED_FROM_AUTH_PROVIDERS.includes(sourceDetails.short_name)) {
       methods.push('external_provider');
     }
 


### PR DESCRIPTION
Fixes a bug where auth provider options were showing up for blocked sources (like GitHub) in the collection creation flow. Syncing then fails without any error (Needs to be addressed separately too). 

## Problem
`SourceConfigView` component in `creation-views/` was missing the `SOURCES_BLOCKED_FROM_AUTH_PROVIDERS` check entirely, causing auth provider options to appear for all sources that support auth providers, regardless of whether they should be blocked.

## Solution
- Added `SOURCES_BLOCKED_FROM_AUTH_PROVIDERS` list to match other components
- Updated `getAvailableAuthMethods()` to check blocked sources before adding `external_provider` method
- Fixed linting error for better code quality
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add missing blocked-sources check in SourceConfigView so auth provider options are hidden for blocked sources (e.g., GitHub) in the collection creation flow. This prevents users from selecting invalid auth methods that would later fail during sync.

<!-- End of auto-generated description by cubic. -->

