### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The search interface is exposed via REST API or MCP. When using MCP, Airweave es
     - [Python](#python)
     - [TypeScript/JavaScript](#typescriptjavascript)
   - [🔑 Key Features](#-key-features)
-  - [🔧 Technology Stack](#-technology-stack)
+  - [🔧 Technology Stack](#-tech-stack)
   - [👥 Contributing](#-contributing)
   - [📄 License](#-license)
   - [🔗 Connect](#-connect)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix broken README table-of-contents link for the Tech Stack section by updating the anchor to #-tech-stack so it navigates correctly.

<!-- End of auto-generated description by cubic. -->

