### PR TITLE
fix: add clickup logo for darkmode

### DIFF
--- a/frontend/src/components/icons/apps/clickup-light.svg
+++ b/frontend/src/components/icons/apps/clickup-light.svg
@@ -1,0 +1,33 @@
+<svg version="1.1" id="Layer_1" xmlns:x="ns_extend;" xmlns:i="ns_ai;" xmlns:graph="ns_graphs;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 54.8 65.8" style="enable-background:new 0 0 54.8 65.8;" xml:space="preserve">
+ <style type="text/css">
+  .st0{fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_1_);}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_2_);}
+ </style>
+ <metadata>
+  <sfw xmlns="ns_sfw;">
+   <slices>
+   </slices>
+   <sliceSourceBounds bottomLeftOrigin="true" height="65.8" width="54.8" x="0.8" y="2.9">
+   </sliceSourceBounds>
+  </sfw>
+ </metadata>
+ <g>
+  <linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="0" y1="15.0492" x2="54.8446" y2="15.0492" gradientTransform="matrix(1 0 0 -1 0 69.3604)">
+   <stop offset="0" style="stop-color:#8930FD">
+   </stop>
+   <stop offset="1" style="stop-color:#49CCF9">
+   </stop>
+  </linearGradient>
+  <path class="st0" d="M0,50.6l10.1-7.8c5.4,7,11.1,10.3,17.4,10.3c6.3,0,11.9-3.2,17-10.2l10.3,7.6c-7.4,10-16.6,15.3-27.3,15.3
+		C16.9,65.8,7.6,60.5,0,50.6z">
+  </path>
+  <linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="1.1953" y1="53.166" x2="53.7447" y2="53.166" gradientTransform="matrix(1 0 0 -1 0 69.3604)">
+   <stop offset="0" style="stop-color:#FF02F0">
+   </stop>
+   <stop offset="1" style="stop-color:#FFC800">
+   </stop>
+  </linearGradient>
+  <path class="st1" d="M27.5,16.9l-18,15.5l-8.3-9.7L27.6,0l26.2,22.7l-8.4,9.6L27.5,16.9z">
+  </path>
+ </g>
+</svg>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a light-themed ClickUp logo SVG for dark mode to ensure proper contrast and visibility on dark backgrounds.

<!-- End of auto-generated description by cubic. -->

