### PR TITLE
refactor: remove entities_processed metric from sync job details

### DIFF
--- a/backend/airweave/core/source_connection_service_helpers.py
+++ b/backend/airweave/core/source_connection_service_helpers.py
@@ -659,12 +659,8 @@ class SourceConnectionHelpers:
                     entities_inserted = getattr(job, "entities_inserted", 0) or 0
                     entities_updated = getattr(job, "entities_updated", 0) or 0
                     entities_deleted = getattr(job, "entities_deleted", 0) or 0
-                    entities_kept = getattr(job, "entities_kept", 0) or 0
                     entities_skipped = getattr(job, "entities_skipped", 0) or 0
 
-                    entities_processed = (
-                        entities_inserted + entities_updated + entities_deleted + entities_kept
-                    )
                     entities_failed = entities_skipped
 
                     last_job = schemas.SyncJobDetails(
@@ -673,7 +669,6 @@ class SourceConnectionHelpers:
                         started_at=getattr(job, "started_at", None),
                         completed_at=getattr(job, "completed_at", None),
                         duration_seconds=duration_seconds,
-                        entities_processed=entities_processed,
                         entities_inserted=entities_inserted,
                         entities_updated=entities_updated,
                         entities_deleted=entities_deleted,
@@ -913,7 +908,6 @@ class SourceConnectionHelpers:
                 if job.completed_at and job.started_at
                 else None
             ),
-            entities_processed=getattr(job, "entities_processed", 0),
             entities_inserted=getattr(job, "entities_inserted", 0),
             entities_updated=getattr(job, "entities_updated", 0),
             entities_deleted=getattr(job, "entities_deleted", 0),

--- a/backend/airweave/schemas/source_connection.py
+++ b/backend/airweave/schemas/source_connection.py
@@ -308,7 +308,6 @@ class SyncJobDetails(BaseModel):
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     duration_seconds: Optional[float] = None
-    entities_processed: int = 0
     entities_inserted: int = 0
     entities_updated: int = 0
     entities_deleted: int = 0
@@ -400,7 +399,6 @@ class SourceConnectionJob(BaseModel):
     duration_seconds: Optional[float] = None
 
     # Metrics
-    entities_processed: int = 0
     entities_inserted: int = 0
     entities_updated: int = 0
     entities_deleted: int = 0

--- a/backend/tests/e2e/smoke/test_source_connections_direct_auth.py
+++ b/backend/tests/e2e/smoke/test_source_connections_direct_auth.py
@@ -183,7 +183,9 @@ class TestDirectAuthentication:
         updated_connection = response.json()
 
         assert updated_connection["sync"]["last_job"]["status"] in ["completed", "running"]
-        assert updated_connection["sync"]["last_job"]["entities_processed"] >= 0
+        # Verify individual entity metrics are tracked
+        assert updated_connection["sync"]["last_job"]["entities_inserted"] >= 0
+        assert updated_connection["sync"]["last_job"]["entities_updated"] >= 0
 
         # Cleanup
         await api_client.delete(f"/source-connections/{connection['id']}")

--- a/frontend/src/components/collection/SourceConnectionStateView.tsx
+++ b/frontend/src/components/collection/SourceConnectionStateView.tsx
@@ -33,7 +33,6 @@ interface LastSyncJob {
   started_at?: string;
   completed_at?: string;
   duration_seconds?: number;
-  entities_processed?: number;
   entities_inserted?: number;
   entities_updated?: number;
   entities_deleted?: number;
@@ -372,10 +371,10 @@ const SourceConnectionStateView: React.FC<Props> = ({
       // 2. Job reaches a final state
       // 3. Status is not a running state (means job ended or never started)
       if (syncStatus === 'cancelling' ||
-          syncStatus === 'cancelled' ||
-          syncStatus === 'completed' ||
-          syncStatus === 'failed' ||
-          (!syncStatus || (syncStatus !== 'running' && syncStatus !== 'in_progress' && syncStatus !== 'pending' && syncStatus !== 'created'))) {
+        syncStatus === 'cancelled' ||
+        syncStatus === 'completed' ||
+        syncStatus === 'failed' ||
+        (!syncStatus || (syncStatus !== 'running' && syncStatus !== 'in_progress' && syncStatus !== 'pending' && syncStatus !== 'created'))) {
         console.log('Clearing isLocalCancelling due to status:', syncStatus);
         setIsLocalCancelling(false);
         if (cancelTimeoutRef.current) {

--- a/frontend/src/services/entityStateMediator.ts
+++ b/frontend/src/services/entityStateMediator.ts
@@ -128,7 +128,6 @@ export class EntityStateMediator {
         last_sync_job: {
           id: jobId,
           status: 'pending',
-          entities_processed: 0,
           entities_inserted: 0,
           entities_updated: 0,
           entities_deleted: 0,
@@ -182,8 +181,7 @@ export class EntityStateMediator {
                   entity_states: entityStates,
                   last_sync_job: {
                     ...currentConnection.last_sync_job,
-                    status: 'in_progress' as const,
-                    entities_processed: data.total_entities || 0
+                    status: 'in_progress' as const
                   },
                   lastUpdated: new Date()
                 };
@@ -216,7 +214,6 @@ export class EntityStateMediator {
                   last_sync_job: {
                     ...currentConnection.last_sync_job,
                     status: data.final_status || (data.is_failed ? 'failed' : 'completed'),
-                    entities_processed: data.total_entities || 0,
                     completed_at: data.timestamp || new Date().toISOString(),
                     error: data.error
                   },

--- a/frontend/src/stores/entityStateStore.ts
+++ b/frontend/src/stores/entityStateStore.ts
@@ -19,7 +19,6 @@ export interface LastSyncJob {
   duration_seconds?: number;
 
   // Entity metrics
-  entities_processed: number;
   entities_inserted: number;
   entities_updated: number;
   entities_deleted: number;
@@ -69,7 +68,6 @@ export interface SyncProgressUpdate {
   type: 'sync_progress';
   source_connection_id: string;
   job_id: string;
-  entities_processed: number;
   entities_inserted: number;
   entities_updated: number;
   entities_deleted: number;
@@ -84,7 +82,6 @@ export interface SyncCompleteUpdate {
   status: SyncJobStatus;
   duration_seconds: number;
   final_counts: {
-    entities_processed: number;
     entities_inserted: number;
     entities_updated: number;
     entities_deleted: number;
@@ -109,7 +106,6 @@ interface EntityStateStore {
   // Getters
   getConnection: (connectionId: string) => SourceConnectionState | undefined;
   getLastSyncJob: (connectionId: string) => LastSyncJob | undefined;
-  getTotalEntities: (connectionId: string) => number;
   isJobActive: (jobId: string) => boolean;
   getActiveJobsCount: () => number;
 }
@@ -155,7 +151,6 @@ export const useEntityStateStore = create<EntityStateStore>()(
               last_sync_job: {
                 id: update.job_id,
                 status: 'in_progress',
-                entities_processed: update.entities_processed,
                 entities_inserted: update.entities_inserted,
                 entities_updated: update.entities_updated,
                 entities_deleted: update.entities_deleted,
@@ -172,7 +167,6 @@ export const useEntityStateStore = create<EntityStateStore>()(
                 ...existing.last_sync_job,
                 id: update.job_id,
                 status: 'in_progress',
-                entities_processed: update.entities_processed,
                 entities_inserted: update.entities_inserted,
                 entities_updated: update.entities_updated,
                 entities_deleted: update.entities_deleted,
@@ -209,7 +203,6 @@ export const useEntityStateStore = create<EntityStateStore>()(
                 id: update.job_id,
                 status: update.status,
                 duration_seconds: update.duration_seconds,
-                entities_processed: update.final_counts.entities_processed,
                 entities_inserted: update.final_counts.entities_inserted,
                 entities_updated: update.final_counts.entities_updated,
                 entities_deleted: update.final_counts.entities_deleted,
@@ -258,12 +251,6 @@ export const useEntityStateStore = create<EntityStateStore>()(
 
       getLastSyncJob: (connectionId) => {
         return get().sourceConnections.get(connectionId)?.last_sync_job;
-      },
-
-      getTotalEntities: (connectionId) => {
-        const connection = get().sourceConnections.get(connectionId);
-        if (!connection?.last_sync_job) return 0;
-        return connection.last_sync_job.entities_processed || 0;
       },
 
       isJobActive: (jobId) => {


### PR DESCRIPTION
- Removed entities_processed from SourceConnectionHelpers, SyncJobDetails, and related schemas.
- Updated tests and frontend components to reflect the removal of entities_processed.
- Adjusted entity state management to ensure consistency without the entities_processed metric.

posthog analytics remains unaffected (it's computed there locally)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the entities_processed metric from sync job details across backend and frontend. We now rely on individual metrics (inserted, updated, deleted, skipped) for state and UI.

- **Refactors**
  - Dropped entities_processed from schemas and helper responses.
  - Updated frontend types, store, and mediator to stop using entities_processed.
  - Adjusted e2e tests to assert individual counts.
  - PostHog analytics unaffected (computed locally).

<!-- End of auto-generated description by cubic. -->

