### PR TITLE
Another option to build docker updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ cd airweave
 chmod +x start.sh
 ./start.sh
 
-# 2. Build and run #Option 2
-cd 'folderpath\airweave'; docker compose version; docker info; docker compose -f docker/docker-compose.yml up -d; docker ps -a --filter "name=airweave" --format "{{.Names}}\t{{.Status}}"; docker logs airweave-backend --tail 200
+# 2. Build and run #Option 2(if option 1 gives any error)
+docker compose -f docker\docker-compose.yml up -d
 ```
 
 That's it! Access the dashboard at http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -68,9 +68,12 @@ Make sure docker and docker-compose are installed, then...
 git clone https://github.com/airweave-ai/airweave.git
 cd airweave
 
-# 2. Build and run
+# 2. Build and run #Option 1
 chmod +x start.sh
 ./start.sh
+
+# 2. Build and run #Option 2
+cd 'folderpath\airweave'; docker compose version; docker info; docker compose -f docker/docker-compose.yml up -d; docker ps -a --filter "name=airweave" --format "{{.Names}}\t{{.Status}}"; docker logs airweave-backend --tail 200
 ```
 
 That's it! Access the dashboard at http://localhost:8080


### PR DESCRIPTION
In some cases, we may get issues for

 chmod +x start.sh ./start.sh
This program is blocked by group policy. For more information, contact your system administrator. Error code: Bash/ERROR_ACCESS_DISABLED_BY_POLICY
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add an alternative Docker build/run path in the README for environments where Bash scripts are blocked (e.g., Windows group policy). It uses direct docker compose commands to start Airweave and check status/logs.

<!-- End of auto-generated description by cubic. -->

