### PR TITLE
fix(SourceConfigView): fix broken OAuth setup link for BYOC connectors

### DIFF
--- a/frontend/src/components/creation-views/SourceConfigView.tsx
+++ b/frontend/src/components/creation-views/SourceConfigView.tsx
@@ -685,7 +685,7 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
                                 Need help setting up OAuth?
                               </span>
                               <a
-                                href="https://docs.airweave.ai/integrations/oauth-setup"
+                                href={`https://docs.airweave.ai/docs/connectors/${selectedSource.replace(/_/g, '-')}`}
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className={cn(


### PR DESCRIPTION
Link to relevant source connector doc instead.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the broken “Need help setting up OAuth?” link for BYOC connectors in SourceConfigView. The link now dynamically points to the selected connector’s docs page by converting underscores to hyphens.

<!-- End of auto-generated description by cubic. -->

