### PR TITLE
fix(bitbucket): Fix authentication to use Basic auth with email:token format & deprecate app passwords

### DIFF
--- a/backend/airweave/platform/configs/auth.py
+++ b/backend/airweave/platform/configs/auth.py
@@ -186,7 +186,9 @@ class BitbucketAuthConfig(AuthConfig):
     access_token: str = Field(
         title="API Token",
         description=(
-            "Create a Bitbucket API token [here](https://id.atlassian.com/manage-profile/security/api-tokens) with scopes:\n"
+            "Create a Bitbucket API token "
+            "[here](https://id.atlassian.com/manage-profile/security/api-tokens) "
+            "with scopes:\n"
             "- account\n"
             "- read:user:bitbucket\n"
             "- read:workspace:bitbucket\n"

--- a/backend/airweave/platform/configs/auth.py
+++ b/backend/airweave/platform/configs/auth.py
@@ -193,11 +193,11 @@ class BitbucketAuthConfig(AuthConfig):
             "- read:user:bitbucket\n"
             "- read:workspace:bitbucket\n"
             "- read:repository:bitbucket\n\n"
-            "When using this, also provide your Atlassian email as username."
+            "When using this, also provide your Atlassian email address."
         ),
     )
 
-    username: str = Field(
+    email: str = Field(
         title="Email",
         description="Your Atlassian email address (required for API token authentication)",
     )
@@ -218,7 +218,7 @@ class BitbucketAuthConfig(AuthConfig):
         """Ensure required authentication fields are provided."""
         if not self.access_token or not self.access_token.strip():
             raise ValueError("API token is required")
-        if not self.username or not self.username.strip():
+        if not self.email or not self.email.strip():
             raise ValueError("Atlassian email is required")
         return self
 

--- a/backend/airweave/platform/sources/bitbucket.py
+++ b/backend/airweave/platform/sources/bitbucket.py
@@ -63,7 +63,7 @@ class BitbucketSource(BaseSource):
         instance = cls()
 
         instance.access_token = credentials.access_token
-        instance.username = credentials.username
+        instance.email = credentials.email
         instance.workspace = credentials.workspace
         instance.repo_slug = credentials.repo_slug
 
@@ -75,7 +75,7 @@ class BitbucketSource(BaseSource):
     def _get_auth(self) -> httpx.BasicAuth:
         """Get Basic authentication object for Bitbucket API requests.
 
-        Bitbucket API uses Basic authentication with username (email) and API token.
+        Bitbucket API uses Basic authentication with email and API token.
 
         Returns:
             httpx.BasicAuth object configured for the request
@@ -84,15 +84,15 @@ class BitbucketSource(BaseSource):
             ValueError: If authentication credentials are missing
         """
         access_token = getattr(self, "access_token", None)
-        username = getattr(self, "username", None)
+        email = getattr(self, "email", None)
 
         if not access_token or not access_token.strip():
             raise ValueError("API token is required")
-        if not username or not username.strip():
-            raise ValueError("Username (Atlassian email) is required")
+        if not email or not email.strip():
+            raise ValueError("Atlassian email is required")
 
         self.logger.debug("Using API token authentication")
-        return httpx.BasicAuth(username=username, password=access_token)
+        return httpx.BasicAuth(username=email, password=access_token)
 
     @tenacity.retry(
         retry=retry_if_exception_type(httpx.HTTPError),

--- a/backend/airweave/platform/sources/bitbucket.py
+++ b/backend/airweave/platform/sources/bitbucket.py
@@ -85,12 +85,12 @@ class BitbucketSource(BaseSource):
         """
         access_token = getattr(self, "access_token", None)
         username = getattr(self, "username", None)
-        
+
         if not access_token or not access_token.strip():
             raise ValueError("API token is required")
         if not username or not username.strip():
             raise ValueError("Username (Atlassian email) is required")
-            
+
         self.logger.debug("Using API token authentication")
         return httpx.BasicAuth(username=username, password=access_token)
 

--- a/frontend/src/components/creation-views/SourceConfigView.tsx
+++ b/frontend/src/components/creation-views/SourceConfigView.tsx
@@ -12,6 +12,7 @@ import { AuthProviderSelector } from './AuthProviderSelector';
 import { useAuthProvidersStore } from '@/lib/stores/authProviders';
 import { ValidatedInput } from '@/components/ui/validated-input';
 import { sourceConnectionNameValidation, getAuthFieldValidation, clientIdValidation, clientSecretValidation, redirectUrlValidation } from '@/lib/validation/rules';
+import ReactMarkdown from 'react-markdown';
 
 interface SourceConfigViewProps {
   humanReadableId: string;
@@ -468,7 +469,7 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
               <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">
                 Create Source Connection
               </h2>
-              <p className="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
+              <p className="my-2.5 text-sm text-gray-500 dark:text-gray-400">
                 Connect your {sourceName || 'data source'} to sync and search its content
               </p>
             </div>
@@ -538,9 +539,35 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
                             {field.required && <span className="text-red-500 ml-1">*</span>}
                           </label>
                           {field.description && (
-                            <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">
-                              {field.description}
-                            </p>
+                            <div className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">
+                              <ReactMarkdown
+                                components={{
+                                  p: ({ children }) => <span>{children}</span>,
+                                  a: ({ href, children }) => (
+                                    <a
+                                      href={href}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                                    >
+                                      {children}
+                                    </a>
+                                  ),
+                                  ul: ({ children }) => (
+                                    <ul className="list-disc pl-4 my-2 space-y-0.5">
+                                      {children}
+                                    </ul>
+                                  ),
+                                  li: ({ children }) => (
+                                    <li className="text-xs text-gray-500 dark:text-gray-400">
+                                      {children}
+                                    </li>
+                                  ),
+                                }}
+                              >
+                                {field.description}
+                              </ReactMarkdown>
+                            </div>
                           )}
                           <ValidatedInput
                             type={field.name.includes('password') || field.name.includes('token') ? 'password' : 'text'}
@@ -573,9 +600,35 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
                             {field.required && <span className="text-red-500 ml-1">*</span>}
                           </label>
                           {field.description && (
-                            <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">
-                              {field.description}
-                            </p>
+                            <div className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">
+                              <ReactMarkdown
+                                components={{
+                                  p: ({ children }) => <span>{children}</span>,
+                                  a: ({ href, children }) => (
+                                    <a
+                                      href={href}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                                    >
+                                      {children}
+                                    </a>
+                                  ),
+                                  ul: ({ children }) => (
+                                    <ul className="list-disc pl-4 my-2 space-y-0.5">
+                                      {children}
+                                    </ul>
+                                  ),
+                                  li: ({ children }) => (
+                                    <li className="text-xs text-gray-500 dark:text-gray-400">
+                                      {children}
+                                    </li>
+                                  ),
+                                }}
+                              >
+                                {field.description}
+                              </ReactMarkdown>
+                            </div>
                           )}
                           <input
                             type="text"


### PR DESCRIPTION
Bitbucket source connections were failing with "Authentication credentials are invalid" error when using API tokens. The issue was that we were incorrectly using Bearer authentication (`Authorization: Bearer {token}`) when Bitbucket API tokens require Basic authentication with email:token format.

Besides the issue with the endpoint auth, I really struggled to set up BitBucket for two reasons:

1. It was unclear where to set up the API Token and which scopes are necessary. There are two sites that let you create a token, and only one of these sites allows you to specify the scopes. The default setup is useless, potentially due to new access restrictions introduced by Atlassian.
2. There was no validation in place to prevent users from continuing when they don't attach an email as username when using an API Token.
3. App passwords have been deprecated in September 2025. Full support is killed in 2026. To avoid carrying this tech debt in the first place we should not support it at all. Since BitBucket never worked in the first place, i argue we can skip writing a migration for this.

The next diff will enable auth providers for BitBucket once this issue has been resolved: [#861](https://github.com/airweave-ai/airweave/pull/861)

**Current** - no required fields, app password still enabled, API Token source and scope unclear, username allowed
<img width="627" height="541" alt="Screenshot 2025-10-06 at 12 45 41" src="https://github.com/user-attachments/assets/e5a2aa24-513a-4798-ac65-c3f36cd87c1b" />

**New** - required fields, improved descriptions with markdown, only email allowed
<img width="615" height="540" alt="Screenshot 2025-10-06 at 12 46 56" src="https://github.com/user-attachments/assets/a97b7059-cbad-4184-af3c-78abcefce960" />
