### PR TITLE
Enhance authentication configuration validation

### DIFF
--- a/.cursor/rules/form-validation.mdc
+++ b/.cursor/rules/form-validation.mdc
@@ -4,26 +4,56 @@ alwaysApply: false
 ---
 # Airweave Validation System
 
-### Philosophy
+## Philosophy
 Minimal, non-intrusive validation that guides without blocking. No success messages or harsh errors, just essential hints.
 
 ## Core Components
 
 ### `ValidatedInput` Component
 - Replaces standard inputs with validation-aware inputs
-- Shows hints after 500ms delay (debounced)
-- Immediate validation on blur
+- Shows hints after debounce delay (typically 500ms)
+- Immediate validation on blur for some fields
 - Subtle 30% opacity border colors
+- Real-time feedback during typing (not just on submit)
 
-### Validation Rules (`rules.ts`)
-- `collectionNameValidation`: 4-64 chars
-- `sourceConnectionNameValidation`: 4-42 chars
-- `urlValidation`: Must start with `http://` or `https://`
-- `emailValidation`: Basic format check
-- `apiKeyValidation`: Detects placeholder text
+### Validation Rules (`lib/validation/rules.ts`)
+
+#### General Validators
+- **`collectionNameValidation`**: 4-64 characters
+- **`sourceConnectionNameValidation`**: 4-42 characters
+- **`urlValidation`**: Must start with `http://` or `https://`
+- **`emailValidation`**: Basic format check
+- **`apiKeyValidation`**: Detects placeholder text, shows on change with 500ms debounce
+
+#### Source-Specific Validators
+
+**GitHub**
+- **`githubTokenValidation`**: Validates format (ghp_, github_pat_, or 40-char hex)
+- **`repoNameValidation`**: Enforces owner/repo format (e.g., "airweave-ai/airweave")
+
+**Stripe**
+- **`stripeApiKeyValidation`**: Checks for sk_test_ or sk_live_ prefix, min 20 chars
+
+**Bitbucket**
+- **`workspaceValidation`**: Alphanumeric + hyphens + underscores
+- **`repoSlugValidation`**: Alphanumeric + hyphens + underscores + dots
+
+**PostgreSQL/Databases**
+- **`databaseHostValidation`**: Rejects protocol prefixes (http://, postgresql://, etc.)
+- **`databasePortValidation`**: Validates 1-65535 range, rejects non-numeric strings
+- **`databaseTablesValidation`**: Accepts "*" or comma-separated table names
+
+**Auth Providers**
+- **`clientIdValidation`**: Generic client ID validation
+- **`clientSecretValidation`**: Generic client secret validation
+- **`authConfigIdValidation`**: For Composio config IDs
+- **`accountIdValidation`**: For auth provider account IDs
+- **`projectIdValidation`**: For Pipedream project IDs
+- **`environmentValidation`**: For environment fields
 
 ## Usage
 
+### Basic Usage
 ```tsx
 import { ValidatedInput } from '@/components/ui/validated-input';
 import { collectionNameValidation } from '@/lib/validation/rules';
@@ -37,13 +67,80 @@ import { collectionNameValidation } from '@/lib/validation/rules';
 />
 ```
 
+### Source-Specific Auth Fields
+```tsx
+import { getAuthFieldValidation } from '@/lib/validation/rules';
+
+// Auto-detects validation based on field name and source
+<ValidatedInput
+  value={authFields[field.name]}
+  onChange={(value) => setAuthFields({ ...authFields, [field.name]: value })}
+  validation={getAuthFieldValidation(field.name, sourceDetails?.short_name)}
+/>
+```
+
 ## Field Type Detection
-The `getAuthFieldValidation()` function auto-detects validation based on field names:
-- `url`, `endpoint`, `cluster_url` → URL validation (requires protocol)
-- `email`, `username` → Email validation
-- `api_key`, `token` → API key validation
+
+The `getAuthFieldValidation(fieldType: string, sourceShortName?: string)` function auto-detects validation based on field names and optionally source context:
+
+### Source-Specific Routing
+- **Stripe `api_key`** → `stripeApiKeyValidation` (when sourceShortName === 'stripe')
+- Other sources fall through to generic validators
+
+### Field Name Mapping
+- **API Keys & Tokens**
+  - `api_key` → Generic API key validation (placeholder detection)
+  - `token`, `access_token` → API key validation
+  - `personal_access_token` → GitHub token validation
+
+- **URLs**
+  - `url`, `endpoint`, `base_url`, `cluster_url`, `uri` → URL validation (requires http:// or https://)
+
+- **Database Fields**
+  - `host` → Database host validation (no protocol)
+  - `port` → Port range validation (1-65535, numeric only)
+  - `tables` → Table list validation (* or comma-separated)
+
+- **User Credentials**
+  - `email`, `username` → Email validation
+  - `client_id` → Client ID validation
+  - `client_secret` → Client secret validation
+
+- **Source-Specific Fields**
+  - `repo_name` → GitHub repository validation
+  - `workspace` → Bitbucket workspace validation
+  - `repo_slug` → Bitbucket repo slug validation (allows dots)
+
+- **Auth Provider Fields**
+  - `auth_config_id` → Auth config ID validation
+  - `account_id` → Account ID validation
+  - `project_id` → Project ID validation
+  - `external_user_id` → External user ID validation
+  - `environment` → Environment validation
+
+## Validation Timing
+
+### Debounce Settings
+- **500ms**: Most text fields (repo names, GitHub tokens, Stripe keys, API keys)
+- **300ms**: Database ports
+- **0ms**: Some specialized fields requiring immediate feedback
+
+### Show Behavior
+- **`showOn: 'change'`**: Validates during typing (after debounce) - used for most fields
+- **`showOn: 'blur'`**: Validates only when field loses focus - rarely used
 
 ## Visual Feedback
-- **Info**: Gray text, amber border at 20% opacity
-- **Warning**: Amber text/border at 30% opacity
-- **No success states**: We don't celebrate, just guide
+- **Info**: Gray text, amber border at 20% opacity (for empty/incomplete fields)
+- **Warning**: Amber text/border at 30% opacity (for invalid inputs)
+- **No success states**: We don't celebrate valid input, just guide when invalid
+
+## Implementation Notes
+
+### Port Validation
+Uses regex check (`/^\d+$/`) before `parseInt` to reject strings like "123abc" that would otherwise parse as valid.
+
+### Empty Field Handling
+Most validators return `{ isValid: true }` for empty fields to allow partial form completion. Backend validation handles required field checks on submission.
+
+### Source Context Awareness
+The validation system can route to source-specific validators when `sourceShortName` is provided, enabling different validation logic for fields with common names (like `api_key`) across different sources.

--- a/backend/airweave/platform/configs/auth.py
+++ b/backend/airweave/platform/configs/auth.py
@@ -619,15 +619,6 @@ class TrelloAuthConfig(AuthConfig):
         description="The OAuth1 access token secret for Trello",
     )
 
-    @field_validator("oauth_token", "oauth_token_secret")
-    @classmethod
-    def validate_oauth_tokens(cls, v: str, info) -> str:
-        """Validate OAuth1 tokens are not empty."""
-        if not v or not v.strip():
-            field_name = info.field_name.replace("_", " ").title()
-            raise ValueError(f"{field_name} is required")
-        return v.strip()
-
 
 # AUTH PROVIDER AUTHENTICATION CONFIGS
 # These are for authenticating TO auth providers themselves

--- a/backend/airweave/platform/configs/auth.py
+++ b/backend/airweave/platform/configs/auth.py
@@ -93,15 +93,37 @@ class ODBCAuthConfig(AuthConfig):
 class BaseDatabaseAuthConfig(AuthConfig):
     """Base database authentication configuration."""
 
-    host: str = Field(title="Host", description="The host of the PostgreSQL database")
-    port: int = Field(title="Port", description="The port of the PostgreSQL database")
-    database: str = Field(title="Database", description="The name of the PostgreSQL database")
-    user: str = Field(title="Username", description="The username for the PostgreSQL database")
-    password: str = Field(title="Password", description="The password for the PostgreSQL database")
+    host: str = Field(
+        title="Host",
+        description="The host of the PostgreSQL database",
+        min_length=1,
+    )
+    port: int = Field(
+        title="Port",
+        description="The port of the PostgreSQL database",
+        gt=0,
+        le=65535,
+    )
+    database: str = Field(
+        title="Database",
+        description="The name of the PostgreSQL database",
+        min_length=1,
+    )
+    user: str = Field(
+        title="Username",
+        description="The username for the PostgreSQL database",
+        min_length=1,
+    )
+    password: str = Field(
+        title="Password",
+        description="The password for the PostgreSQL database",
+        min_length=1,
+    )
     schema: str = Field(
         default="public",
         title="Schema",
         description="The schema of the PostgreSQL database",
+        min_length=1,
     )
     tables: str = Field(
         default="*",
@@ -110,7 +132,62 @@ class BaseDatabaseAuthConfig(AuthConfig):
             "Comma separated list of tables and views to sync. For example, 'users,orders'. "
             "For all tables (not views), use '*'."
         ),
+        min_length=1,
     )
+
+    @field_validator("host")
+    @classmethod
+    def validate_host(cls, v: str) -> str:
+        """Validate database host."""
+        if not v or not v.strip():
+            raise ValueError("Host is required")
+        v = v.strip()
+        # Host should not include protocol
+        if v.startswith(("http://", "https://", "postgresql://", "mysql://")):
+            raise ValueError(
+                "Host should not include protocol (e.g., use 'localhost' not 'postgresql://localhost')"
+            )
+        return v
+
+    @field_validator("port")
+    @classmethod
+    def validate_port(cls, v: int) -> int:
+        """Validate database port."""
+        if v <= 0 or v > 65535:
+            raise ValueError("Port must be between 1 and 65535")
+        return v
+
+    @field_validator("database", "user", "password", "schema")
+    @classmethod
+    def validate_not_empty(cls, v: str, info) -> str:
+        """Validate that required fields are not empty."""
+        if not v or not v.strip():
+            field_name = info.field_name.replace("_", " ").title()
+            raise ValueError(f"{field_name} is required")
+        return v.strip()
+
+    @field_validator("tables")
+    @classmethod
+    def validate_tables(cls, v: str) -> str:
+        """Validate tables list."""
+        if not v or not v.strip():
+            raise ValueError("Tables field is required (use '*' for all tables)")
+        v = v.strip()
+        # Allow * for all tables, or comma-separated list
+        if v == "*":
+            return v
+        # Split by comma and validate each table name
+        tables = [t.strip() for t in v.split(",")]
+        for table in tables:
+            if not table:
+                raise ValueError("Empty table name in list")
+            # Basic validation - alphanumeric, underscore, and dot (for schema.table)
+            if not all(c.isalnum() or c in "._" for c in table):
+                raise ValueError(
+                    f"Invalid table name '{table}'. "
+                    "Use alphanumeric characters, underscores, and dots only"
+                )
+        return v
 
     class Config:
         """Pydantic config."""
@@ -141,7 +218,8 @@ class QdrantAuthConfig(AuthConfig):
 
     url: str = Field(title="URL", description="The URL of the Qdrant service")
     api_key: str = Field(
-        title="API Key", description="The API key for the Qdrant service (if required)"
+        title="API Key",
+        description="The API key for the Qdrant service (if required)",
     )
 
 
@@ -174,7 +252,21 @@ class AttioAuthConfig(APIKeyAuthConfig):
     api_key: str = Field(
         title="API Key",
         description="The API key for Attio. Generate one in Workspace Settings > Developers.",
+        min_length=10,
     )
+
+    @field_validator("api_key")
+    @classmethod
+    def validate_api_key(cls, v: str) -> str:
+        """Validate Attio API key."""
+        if not v or not v.strip():
+            raise ValueError("API key is required")
+        v = v.strip()
+        # Check for common placeholder values
+        placeholder_values = ["your-api-key", "xxx", "api-key-here", "paste-here", "placeholder"]
+        if any(placeholder in v.lower() for placeholder in placeholder_values):
+            raise ValueError("Please enter your actual API key, not a placeholder value")
+        return v
 
 
 class BitbucketAuthConfig(AuthConfig):
@@ -195,6 +287,7 @@ class BitbucketAuthConfig(AuthConfig):
             "- read:repository:bitbucket\n\n"
             "When using this, also provide your Atlassian email address."
         ),
+        min_length=10,
     )
 
     email: str = Field(
@@ -205,12 +298,15 @@ class BitbucketAuthConfig(AuthConfig):
     workspace: str = Field(
         title="Workspace",
         description="Bitbucket workspace slug (e.g., 'my-workspace')",
+        min_length=1,
+        pattern=r"^[a-zA-Z0-9_-]+$",
     )
     repo_slug: Optional[str] = Field(
         default="",
         title="Repository Slug",
         description="Specific repository to sync (e.g., 'my-repo'). "
         "If empty, syncs all repositories in the workspace.",
+        pattern=r"^[a-zA-Z0-9_.-]*$",
     )
 
     @model_validator(mode="after")
@@ -281,11 +377,55 @@ class GitHubAuthConfig(AuthConfig):
     personal_access_token: str = Field(
         title="Personal Access Token",
         description="GitHub PAT with read rights (code, contents, metadata) to the repository",
+        min_length=4,
     )
     repo_name: str = Field(
         title="Repository Name",
         description="Repository to sync in owner/repo format (e.g., 'airweave-ai/airweave')",
+        min_length=3,
+        pattern=r"^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$",
     )
+
+    @field_validator("personal_access_token")
+    @classmethod
+    def validate_personal_access_token(cls, v: str) -> str:
+        """Validate GitHub personal access token format."""
+        if not v or not v.strip():
+            raise ValueError("Personal access token is required")
+        v = v.strip()
+        # GitHub classic tokens start with ghp_, fine-grained tokens start with github_pat_
+        # Also allow legacy tokens (40 char hex)
+        if not (
+            v.startswith("ghp_")
+            or v.startswith("github_pat_")
+            or (len(v) == 40 and all(c in "0123456789abcdef" for c in v.lower()))
+        ):
+            raise ValueError(
+                "Invalid token format. Expected format: "
+                "ghp_... or github_pat_... or 40-character hex"
+            )
+        return v
+
+    @field_validator("repo_name")
+    @classmethod
+    def validate_repo_name(cls, v: str) -> str:
+        """Validate repository name is in owner/repo format."""
+        if not v or not v.strip():
+            raise ValueError("Repository name is required")
+        v = v.strip()
+        if "/" not in v:
+            raise ValueError(
+                "Repository must be in 'owner/repo' format (e.g., 'airweave-ai/airweave')"
+            )
+        parts = v.split("/")
+        if len(parts) != 2:
+            raise ValueError(
+                "Repository must be in 'owner/repo' format (e.g., 'airweave-ai/airweave')"
+            )
+        owner, repo = parts
+        if not owner or not repo:
+            raise ValueError("Both owner and repository name must be non-empty")
+        return v
 
 
 class GmailAuthConfig(OAuth2BYOCAuthConfig):
@@ -385,11 +525,24 @@ class CTTIAuthConfig(AuthConfig):
     """CTTI Clinical Trials authentication credentials schema."""
 
     username: str = Field(
-        title="Username", description="Username for the AACT Clinical Trials database"
+        title="Username",
+        description="Username for the AACT Clinical Trials database",
+        min_length=1,
     )
     password: str = Field(
-        title="Password", description="Password for the AACT Clinical Trials database"
+        title="Password",
+        description="Password for the AACT Clinical Trials database",
+        min_length=1,
     )
+
+    @field_validator("username", "password")
+    @classmethod
+    def validate_not_empty(cls, v: str, info) -> str:
+        """Validate that username and password are not empty."""
+        if not v or not v.strip():
+            field_name = info.field_name.replace("_", " ").title()
+            raise ValueError(f"{field_name} is required")
+        return v.strip()
 
 
 class PostgreSQLAuthConfig(BaseDatabaseAuthConfig):
@@ -424,7 +577,19 @@ class StripeAuthConfig(AuthConfig):
         description="The API key for the Stripe account. Should start with 'sk_test_' for test mode"
         " or 'sk_live_' for live mode.",
         pattern="^sk_(test|live)_[A-Za-z0-9]+$",
+        min_length=20,
     )
+
+    @field_validator("api_key")
+    @classmethod
+    def validate_api_key(cls, v: str) -> str:
+        """Validate Stripe API key format."""
+        if not v or not v.strip():
+            raise ValueError("API key is required")
+        v = v.strip()
+        if not v.startswith(("sk_test_", "sk_live_")):
+            raise ValueError("Stripe API key must start with 'sk_test_' or 'sk_live_'")
+        return v
 
 
 class TodoistAuthConfig(OAuth2AuthConfig):
@@ -445,10 +610,23 @@ class TrelloAuthConfig(AuthConfig):
     Trello uses OAuth1, which requires both a token and token secret.
     """
 
-    oauth_token: str = Field(title="OAuth Token", description="The OAuth1 access token for Trello")
-    oauth_token_secret: str = Field(
-        title="OAuth Token Secret", description="The OAuth1 access token secret for Trello"
+    oauth_token: str = Field(
+        title="OAuth Token",
+        description="The OAuth1 access token for Trello",
     )
+    oauth_token_secret: str = Field(
+        title="OAuth Token Secret",
+        description="The OAuth1 access token secret for Trello",
+    )
+
+    @field_validator("oauth_token", "oauth_token_secret")
+    @classmethod
+    def validate_oauth_tokens(cls, v: str, info) -> str:
+        """Validate OAuth1 tokens are not empty."""
+        if not v or not v.strip():
+            field_name = info.field_name.replace("_", " ").title()
+            raise ValueError(f"{field_name} is required")
+        return v.strip()
 
 
 # AUTH PROVIDER AUTHENTICATION CONFIGS

--- a/frontend/src/components/creation-views/SourceConfigView.tsx
+++ b/frontend/src/components/creation-views/SourceConfigView.tsx
@@ -574,7 +574,7 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
                             placeholder=""
                             value={authFields[field.name] || ''}
                             onChange={(value) => setAuthFields({ ...authFields, [field.name]: value })}
-                            validation={getAuthFieldValidation(field.name)}
+                            validation={getAuthFieldValidation(field.name, sourceDetails?.short_name)}
                             className={cn(
                               "focus:border-gray-400 dark:focus:border-gray-600",
                               isDark

--- a/frontend/src/lib/validation/rules.ts
+++ b/frontend/src/lib/validation/rules.ts
@@ -717,33 +717,6 @@ export const stripeApiKeyValidation: FieldValidation<string> = {
 };
 
 /**
- * OAuth token validation (for Trello, etc.)
- */
-export const oauthTokenValidation: FieldValidation<string> = {
-  field: 'oauth_token',
-  debounceMs: 0,
-  showOn: 'blur',
-  validate: (value: string): ValidationResult => {
-    const trimmed = value.trim();
-
-    if (!trimmed) {
-      return { isValid: true, severity: 'info' };
-    }
-
-    // OAuth tokens vary in length, just check for minimum reasonable length
-    if (trimmed.length < 10) {
-      return {
-        isValid: false,
-        hint: 'OAuth token appears too short',
-        severity: 'warning'
-      };
-    }
-
-    return { isValid: true, severity: 'info' };
-  }
-};
-
-/**
  * Get validation for a specific auth field type
  * @param fieldType - The name of the field to validate
  * @param sourceShortName - Optional source short name for source-specific validations
@@ -763,9 +736,6 @@ export function getAuthFieldValidation(fieldType: string, sourceShortName?: stri
       return apiKeyValidation;
     case 'personal_access_token':
       return githubTokenValidation;
-    case 'oauth_token':
-    case 'oauth_token_secret':
-      return oauthTokenValidation;
 
     // URLs
     case 'url':

--- a/frontend/src/lib/validation/rules.ts
+++ b/frontend/src/lib/validation/rules.ts
@@ -583,8 +583,8 @@ export const databasePortValidation: FieldValidation<string> = {
       return { isValid: true, severity: 'info' };
     }
 
-    const port = parseInt(trimmed, 10);
-    if (isNaN(port)) {
+    // Check if the entire string is numeric (reject "123abc")
+    if (!/^\d+$/.test(trimmed)) {
       return {
         isValid: false,
         hint: 'Port must be a number',
@@ -592,6 +592,7 @@ export const databasePortValidation: FieldValidation<string> = {
       };
     }
 
+    const port = parseInt(trimmed, 10);
     if (port < 1 || port > 65535) {
       return {
         isValid: false,

--- a/frontend/src/lib/validation/rules.ts
+++ b/frontend/src/lib/validation/rules.ts
@@ -81,8 +81,8 @@ export const sourceConnectionNameValidation: FieldValidation<string> = {
  */
 export const apiKeyValidation: FieldValidation<string> = {
   field: 'api_key',
-  debounceMs: 0,
-  showOn: 'blur',
+  debounceMs: 500,
+  showOn: 'change',
   validate: (value: string): ValidationResult => {
     if (!value) return { isValid: true, severity: 'info' };
 
@@ -434,21 +434,356 @@ export const redirectUrlValidation: FieldValidation<string> = {
 };
 
 /**
- * Get validation for a specific auth field type
+ * Repository name validation (owner/repo format)
  */
-export function getAuthFieldValidation(fieldType: string): FieldValidation<string> | null {
+export const repoNameValidation: FieldValidation<string> = {
+  field: 'repo_name',
+  debounceMs: 500,
+  showOn: 'change',
+  validate: (value: string): ValidationResult => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return { isValid: true, severity: 'info' };
+    }
+
+    // Must contain a slash
+    if (!trimmed.includes('/')) {
+      return {
+        isValid: false,
+        hint: 'Repository must be in owner/repo format (e.g., airweave-ai/airweave)',
+        severity: 'warning'
+      };
+    }
+
+    const parts = trimmed.split('/');
+    if (parts.length !== 2) {
+      return {
+        isValid: false,
+        hint: 'Repository must be in owner/repo format (e.g., airweave-ai/airweave)',
+        severity: 'warning'
+      };
+    }
+
+    const [owner, repo] = parts;
+    if (!owner || !repo) {
+      return {
+        isValid: false,
+        hint: 'Both owner and repository name must be non-empty',
+        severity: 'warning'
+      };
+    }
+
+    // Check for valid characters
+    const validPattern = /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_.-]+$/;
+    if (!validPattern.test(trimmed)) {
+      return {
+        isValid: false,
+        hint: 'Use only letters, numbers, hyphens, underscores, and dots',
+        severity: 'warning'
+      };
+    }
+
+    return { isValid: true, severity: 'info' };
+  }
+};
+
+/**
+ * Workspace validation (for Bitbucket, etc.)
+ */
+export const workspaceValidation: FieldValidation<string> = {
+  field: 'workspace',
+  debounceMs: 500,
+  showOn: 'change',
+  validate: (value: string): ValidationResult => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return { isValid: true, severity: 'info' };
+    }
+
+    // Check for valid characters
+    if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+      return {
+        isValid: false,
+        hint: 'Workspace can only contain letters, numbers, hyphens, and underscores',
+        severity: 'warning'
+      };
+    }
+
+    return { isValid: true, severity: 'info' };
+  }
+};
+
+/**
+ * Repository slug validation (for Bitbucket repo_slug)
+ */
+export const repoSlugValidation: FieldValidation<string> = {
+  field: 'repo_slug',
+  debounceMs: 500,
+  showOn: 'change',
+  validate: (value: string): ValidationResult => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return { isValid: true, severity: 'info' };
+    }
+
+    // Check for valid characters (includes dots for repo slugs)
+    if (!/^[a-zA-Z0-9_.-]+$/.test(trimmed)) {
+      return {
+        isValid: false,
+        hint: 'Repository slug can only contain letters, numbers, hyphens, underscores, and dots',
+        severity: 'warning'
+      };
+    }
+
+    return { isValid: true, severity: 'info' };
+  }
+};
+
+/**
+ * Database host validation (no protocol required)
+ */
+export const databaseHostValidation: FieldValidation<string> = {
+  field: 'host',
+  debounceMs: 500,
+  showOn: 'change',
+  validate: (value: string): ValidationResult => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return { isValid: true, severity: 'info' };
+    }
+
+    // Host should NOT include protocol
+    if (trimmed.startsWith('http://') || trimmed.startsWith('https://') || trimmed.includes('://')) {
+      return {
+        isValid: false,
+        hint: 'Host should not include protocol (e.g., use "localhost" not "postgresql://localhost")',
+        severity: 'warning'
+      };
+    }
+
+    return { isValid: true, severity: 'info' };
+  }
+};
+
+/**
+ * Database port validation
+ */
+export const databasePortValidation: FieldValidation<string> = {
+  field: 'port',
+  debounceMs: 300,
+  showOn: 'change',
+  validate: (value: string): ValidationResult => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return { isValid: true, severity: 'info' };
+    }
+
+    const port = parseInt(trimmed, 10);
+    if (isNaN(port)) {
+      return {
+        isValid: false,
+        hint: 'Port must be a number',
+        severity: 'warning'
+      };
+    }
+
+    if (port < 1 || port > 65535) {
+      return {
+        isValid: false,
+        hint: 'Port must be between 1 and 65535',
+        severity: 'warning'
+      };
+    }
+
+    return { isValid: true, severity: 'info' };
+  }
+};
+
+/**
+ * Database tables validation
+ */
+export const databaseTablesValidation: FieldValidation<string> = {
+  field: 'tables',
+  debounceMs: 500,
+  showOn: 'change',
+  validate: (value: string): ValidationResult => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return {
+        isValid: false,
+        hint: 'Tables field is required (use "*" for all tables)',
+        severity: 'info'
+      };
+    }
+
+    // Allow * for all tables
+    if (trimmed === '*') {
+      return { isValid: true, severity: 'info' };
+    }
+
+    // Split by comma and validate each table name
+    const tables = trimmed.split(',').map(t => t.trim());
+    for (const table of tables) {
+      if (!table) {
+        return {
+          isValid: false,
+          hint: 'Empty table name in list',
+          severity: 'warning'
+        };
+      }
+      // Check for valid characters (alphanumeric, underscore, dot)
+      if (!/^[a-zA-Z0-9_.]+$/.test(table)) {
+        return {
+          isValid: false,
+          hint: 'Table names can only contain letters, numbers, underscores, and dots',
+          severity: 'warning'
+        };
+      }
+    }
+
+    return { isValid: true, severity: 'info' };
+  }
+};
+
+/**
+ * GitHub Personal Access Token validation
+ */
+export const githubTokenValidation: FieldValidation<string> = {
+  field: 'personal_access_token',
+  debounceMs: 0,
+  showOn: 'blur',
+  validate: (value: string): ValidationResult => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return { isValid: true, severity: 'info' };
+    }
+
+    // Check for valid GitHub token formats
+    const isClassicToken = trimmed.startsWith('ghp_');
+    const isFineGrainedToken = trimmed.startsWith('github_pat_');
+    const isLegacyToken = trimmed.length === 40 && /^[0-9a-fA-F]+$/.test(trimmed);
+
+    if (!isClassicToken && !isFineGrainedToken && !isLegacyToken) {
+      return {
+        isValid: false,
+        hint: 'GitHub token should start with "ghp_" (classic) or "github_pat_" (fine-grained)',
+        severity: 'warning'
+      };
+    }
+
+    return { isValid: true, severity: 'info' };
+  }
+};
+
+/**
+ * Stripe API key validation
+ */
+export const stripeApiKeyValidation: FieldValidation<string> = {
+  field: 'api_key',
+  debounceMs: 500,
+  showOn: 'change',
+  validate: (value: string): ValidationResult => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return { isValid: true, severity: 'info' };
+    }
+
+    if (!trimmed.startsWith('sk_test_') && !trimmed.startsWith('sk_live_')) {
+      return {
+        isValid: false,
+        hint: 'Stripe API key must start with "sk_test_" or "sk_live_"',
+        severity: 'warning'
+      };
+    }
+
+    if (trimmed.length < 20) {
+      return {
+        isValid: false,
+        hint: 'Stripe API key appears too short',
+        severity: 'warning'
+      };
+    }
+
+    return { isValid: true, severity: 'info' };
+  }
+};
+
+/**
+ * OAuth token validation (for Trello, etc.)
+ */
+export const oauthTokenValidation: FieldValidation<string> = {
+  field: 'oauth_token',
+  debounceMs: 0,
+  showOn: 'blur',
+  validate: (value: string): ValidationResult => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return { isValid: true, severity: 'info' };
+    }
+
+    // OAuth tokens vary in length, just check for minimum reasonable length
+    if (trimmed.length < 10) {
+      return {
+        isValid: false,
+        hint: 'OAuth token appears too short',
+        severity: 'warning'
+      };
+    }
+
+    return { isValid: true, severity: 'info' };
+  }
+};
+
+/**
+ * Get validation for a specific auth field type
+ * @param fieldType - The name of the field to validate
+ * @param sourceShortName - Optional source short name for source-specific validations
+ */
+export function getAuthFieldValidation(fieldType: string, sourceShortName?: string): FieldValidation<string> | null {
+  // Source-specific validations for common field names
+  if (fieldType === 'api_key' && sourceShortName === 'stripe') {
+    return stripeApiKeyValidation;
+  }
+
   switch (fieldType) {
+    // API keys and tokens
     case 'api_key':
+      return apiKeyValidation;
     case 'token':
     case 'access_token':
-    case 'personal_access_token':
       return apiKeyValidation;
+    case 'personal_access_token':
+      return githubTokenValidation;
+    case 'oauth_token':
+    case 'oauth_token_secret':
+      return oauthTokenValidation;
+
+    // URLs
     case 'url':
     case 'endpoint':
     case 'base_url':
     case 'cluster_url':
-      // Note: 'host' is NOT included - database hosts don't need http:// prefix
+    case 'uri':
       return urlValidation;
+
+    // Database fields
+    case 'host':
+      return databaseHostValidation;
+    case 'port':
+      return databasePortValidation;
+    case 'tables':
+      return databaseTablesValidation;
+
+    // User credentials
     case 'email':
     case 'username':
       return emailValidation;
@@ -456,6 +791,16 @@ export function getAuthFieldValidation(fieldType: string): FieldValidation<strin
       return clientIdValidation;
     case 'client_secret':
       return clientSecretValidation;
+
+    // Source-specific fields
+    case 'repo_name':
+      return repoNameValidation;
+    case 'workspace':
+      return workspaceValidation;
+    case 'repo_slug':
+      return repoSlugValidation;
+
+    // Auth provider fields
     case 'auth_config_id':
       return authConfigIdValidation;
     case 'account_id':
@@ -468,6 +813,7 @@ export function getAuthFieldValidation(fieldType: string): FieldValidation<strin
       return environmentValidation;
     case 'external_user_id':
       return externalUserIdValidation;
+
     default:
       return null;
   }


### PR DESCRIPTION
- Added field validators for various authentication configurations, including database host, port, and required fields for Bitbucket and GitHub.
- Improved validation rules for API keys, repository names, and workspace slugs to ensure proper formatting and prevent common errors.
- Updated the validation logic in the frontend to reflect these changes, ensuring a more robust user experience when configuring authentication settings.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Strengthened backend and frontend validations for authentication configs to prevent common setup errors and give clearer form feedback. This covers database fields, repo inputs, and API keys across GitHub, Bitbucket, Stripe, Trello, Attio, and more.

- **New Features**
  - Backend validators for database host/port/tables, GitHub PAT format and owner/repo, Bitbucket workspace/repo slug, Stripe key prefixes, Trello OAuth tokens, Attio API key placeholders, and required CTTI credentials.
  - Frontend rules mirror backend: new checks for repo_name, workspace, repo_slug, host, port, tables, tokens, and Stripe keys.
  - getAuthFieldValidation now accepts sourceShortName (routes Stripe-specific checks). api_key validation debounced to 500ms and shows hints on change.

<!-- End of auto-generated description by cubic. -->

