### PR TITLE
feat: enable auth providers for github, confluence, jira, bitbucket

### DIFF
--- a/.cursor/rules/monke.mdc
+++ b/.cursor/rules/monke.mdc
@@ -71,9 +71,9 @@ Bongos are auto-discovered by `BongoRegistry` via the `connector_type` class att
 ### Example
 ```python
 class GitHubBongo(BaseBongo):
-    def __init__(self, credentials: Dict[str, Any]):
+    def __init__(self, credentials: Dict[str, Any], config: Dict[str, Any]):
         super().__init__(credentials)
-        self.repo_name = credentials["repo_name"]
+        self.repo_name = config["repo_name"]  # Now from config_fields
         self.token = credentials["personal_access_token"]
 
     async def create_entities(self) -> List[Dict[str, Any]]:
@@ -102,8 +102,8 @@ connector:
   auth_mode: direct  # or "provider"
   auth_fields:
     personal_access_token: MONKE_GITHUB_PERSONAL_ACCESS_TOKEN
-    repo_name: MONKE_GITHUB_REPO_NAME
   config_fields:
+    repo_name: MONKE_GITHUB_REPO_NAME  # Moved from auth_fields
     branch: "main"
     post_create_sleep_seconds: 15
 

--- a/backend/airweave/platform/auth_providers/composio.py
+++ b/backend/airweave/platform/auth_providers/composio.py
@@ -25,7 +25,6 @@ class ComposioAuthProvider(BaseAuthProvider):
     # Sources that Composio does not support
     BLOCKED_SOURCES = [
         "postgresql",
-        "bitbucket",
         "ctti",
     ]
 

--- a/backend/airweave/platform/auth_providers/composio.py
+++ b/backend/airweave/platform/auth_providers/composio.py
@@ -25,7 +25,6 @@ class ComposioAuthProvider(BaseAuthProvider):
     # Sources that Composio does not support
     BLOCKED_SOURCES = [
         "postgresql",
-        "jira",
         "bitbucket",
         "ctti",
     ]

--- a/backend/airweave/platform/auth_providers/composio.py
+++ b/backend/airweave/platform/auth_providers/composio.py
@@ -25,7 +25,6 @@ class ComposioAuthProvider(BaseAuthProvider):
     # Sources that Composio does not support
     BLOCKED_SOURCES = [
         "postgresql",
-        "confluence",
         "jira",
         "bitbucket",
         "ctti",

--- a/backend/airweave/platform/auth_providers/composio.py
+++ b/backend/airweave/platform/auth_providers/composio.py
@@ -28,7 +28,6 @@ class ComposioAuthProvider(BaseAuthProvider):
         "confluence",
         "jira",
         "bitbucket",
-        "github",
         "ctti",
     ]
 
@@ -36,6 +35,7 @@ class ComposioAuthProvider(BaseAuthProvider):
     # Key: Airweave field name, Value: Composio field name
     FIELD_NAME_MAPPING = {
         "api_key": "generic_api_key",  # Stripe and other API key sources
+        "personal_access_token": "access_token",  # GitHub PAT mapping
         # Add more mappings as needed
     }
 

--- a/backend/airweave/platform/auth_providers/pipedream.py
+++ b/backend/airweave/platform/auth_providers/pipedream.py
@@ -56,7 +56,6 @@ class PipedreamAuthProvider(BaseAuthProvider):
 
     # Sources that Pipedream does not support
     BLOCKED_SOURCES = [
-        "bitbucket",
         "ctti",
     ]
 

--- a/backend/airweave/platform/auth_providers/pipedream.py
+++ b/backend/airweave/platform/auth_providers/pipedream.py
@@ -56,7 +56,6 @@ class PipedreamAuthProvider(BaseAuthProvider):
 
     # Sources that Pipedream does not support
     BLOCKED_SOURCES = [
-        "jira",
         "bitbucket",
         "ctti",
     ]

--- a/backend/airweave/platform/auth_providers/pipedream.py
+++ b/backend/airweave/platform/auth_providers/pipedream.py
@@ -56,7 +56,6 @@ class PipedreamAuthProvider(BaseAuthProvider):
 
     # Sources that Pipedream does not support
     BLOCKED_SOURCES = [
-        "confluence",
         "jira",
         "bitbucket",
         "ctti",

--- a/backend/airweave/platform/auth_providers/pipedream.py
+++ b/backend/airweave/platform/auth_providers/pipedream.py
@@ -59,7 +59,6 @@ class PipedreamAuthProvider(BaseAuthProvider):
         "confluence",
         "jira",
         "bitbucket",
-        "github",
         "ctti",
     ]
 
@@ -71,6 +70,7 @@ class PipedreamAuthProvider(BaseAuthProvider):
         "refresh_token": "oauth_refresh_token",
         "client_id": "oauth_client_id",
         "client_secret": "oauth_client_secret",
+        "personal_access_token": "access_token",  # GitHub PAT mapping
         # Add more mappings as discovered
     }
 

--- a/backend/airweave/platform/configs/auth.py
+++ b/backend/airweave/platform/configs/auth.py
@@ -392,11 +392,12 @@ class GitHubAuthConfig(AuthConfig):
         if not (
             v.startswith("ghp_")
             or v.startswith("github_pat_")
+            or v.startswith("gho_")
             or (len(v) == 40 and all(c in "0123456789abcdef" for c in v.lower()))
         ):
             raise ValueError(
                 "Invalid token format. Expected format: "
-                "ghp_... or github_pat_... or 40-character hex"
+                "ghp_... or github_pat_... or gho_... or 40-character hex"
             )
         return v
 

--- a/backend/airweave/platform/configs/auth.py
+++ b/backend/airweave/platform/configs/auth.py
@@ -379,12 +379,6 @@ class GitHubAuthConfig(AuthConfig):
         description="GitHub PAT with read rights (code, contents, metadata) to the repository",
         min_length=4,
     )
-    repo_name: str = Field(
-        title="Repository Name",
-        description="Repository to sync in owner/repo format (e.g., 'airweave-ai/airweave')",
-        min_length=3,
-        pattern=r"^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$",
-    )
 
     @field_validator("personal_access_token")
     @classmethod
@@ -404,27 +398,6 @@ class GitHubAuthConfig(AuthConfig):
                 "Invalid token format. Expected format: "
                 "ghp_... or github_pat_... or 40-character hex"
             )
-        return v
-
-    @field_validator("repo_name")
-    @classmethod
-    def validate_repo_name(cls, v: str) -> str:
-        """Validate repository name is in owner/repo format."""
-        if not v or not v.strip():
-            raise ValueError("Repository name is required")
-        v = v.strip()
-        if "/" not in v:
-            raise ValueError(
-                "Repository must be in 'owner/repo' format (e.g., 'airweave-ai/airweave')"
-            )
-        parts = v.split("/")
-        if len(parts) != 2:
-            raise ValueError(
-                "Repository must be in 'owner/repo' format (e.g., 'airweave-ai/airweave')"
-            )
-        owner, repo = parts
-        if not owner or not repo:
-            raise ValueError("Both owner and repository name must be non-empty")
         return v
 
 

--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -100,6 +100,10 @@ class ElasticsearchConfig(SourceConfig):
 class GitHubConfig(SourceConfig):
     """Github configuration schema."""
 
+    repo_name: str = Field(
+        title="Repository Name",
+        description="Repository to sync in owner/repo format (e.g., 'airweave-ai/airweave')",
+    )
     branch: str = Field(
         default="",
         title="Branch name",

--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -103,6 +103,8 @@ class GitHubConfig(SourceConfig):
     repo_name: str = Field(
         title="Repository Name",
         description="Repository to sync in owner/repo format (e.g., 'airweave-ai/airweave')",
+        min_length=3,
+        pattern=r"^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$",
     )
     branch: str = Field(
         default="",
@@ -112,6 +114,27 @@ class GitHubConfig(SourceConfig):
             "If empty, uses the default branch."
         ),
     )
+
+    @field_validator("repo_name")
+    @classmethod
+    def validate_repo_name(cls, v: str) -> str:
+        """Validate repository name is in owner/repo format."""
+        if not v or not v.strip():
+            raise ValueError("Repository name is required")
+        v = v.strip()
+        if "/" not in v:
+            raise ValueError(
+                "Repository must be in 'owner/repo' format (e.g., 'airweave-ai/airweave')"
+            )
+        parts = v.split("/")
+        if len(parts) != 2:
+            raise ValueError(
+                "Repository must be in 'owner/repo' format (e.g., 'airweave-ai/airweave')"
+            )
+        owner, repo = parts
+        if not owner or not repo:
+            raise ValueError("Both owner and repository name must be non-empty")
+        return v
 
 
 class GitLabConfig(SourceConfig):

--- a/backend/airweave/platform/sources/github.py
+++ b/backend/airweave/platform/sources/github.py
@@ -96,7 +96,12 @@ class GitHubSource(BaseSource):
         instance = cls()
 
         instance.personal_access_token = credentials.personal_access_token
-        instance.repo_name = credentials.repo_name
+
+        # Repository name is always read from config (source configuration)
+        if not config or "repo_name" not in config:
+            raise ValueError("Repository name must be specified in source configuration")
+
+        instance.repo_name = config["repo_name"]
 
         instance.branch = config.get("branch", None)
 

--- a/backend/alembic/versions/6e39730bc45b_migrate_github_repo_name_from_auth_to_config.py
+++ b/backend/alembic/versions/6e39730bc45b_migrate_github_repo_name_from_auth_to_config.py
@@ -5,60 +5,91 @@ Revises: c60291fb2129
 Create Date: 2025-09-28 22:12:53.758477
 
 """
-from alembic import op
-import sqlalchemy as sa
+
 import json
-import os
+from typing import Optional
+
+import sqlalchemy as sa
+from alembic import op
 from cryptography.fernet import Fernet
+from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
-revision = '6e39730bc45b'
-down_revision = 'c60291fb2129'
+revision = "6e39730bc45b"
+down_revision = "c60291fb2129"
 branch_labels = None
 depends_on = None
 
 
-def get_encryption_key():
-    """Get encryption key from environment variable."""
-    key = os.environ.get('ENCRYPTION_KEY')
+def get_fernet() -> Fernet:
+    """Get Fernet instance for encryption/decryption.
+    
+    Returns:
+        Fernet instance configured with the encryption key.
+        
+    Raises:
+        RuntimeError: If ENCRYPTION_KEY is not set.
+    """
+    import os
+    
+    key = os.environ.get("ENCRYPTION_KEY")
     if not key:
-        raise ValueError("ENCRYPTION_KEY environment variable is not set")
-    return key.encode()
+        raise RuntimeError("ENCRYPTION_KEY environment variable must be set")
+    return Fernet(key.encode())
 
 
-def encrypt_data(data):
-    """Encrypt dictionary data using Fernet encryption."""
-    f = Fernet(get_encryption_key())
+def encrypt_credentials(data: dict) -> str:
+    """Encrypt credentials dictionary.
+    
+    Args:
+        data: Dictionary containing credentials.
+        
+    Returns:
+        Base64 encoded encrypted string.
+    """
+    f = get_fernet()
     json_str = json.dumps(data)
-    encrypted_data = f.encrypt(json_str.encode())
-    return encrypted_data.decode()
+    encrypted = f.encrypt(json_str.encode())
+    return encrypted.decode()
 
 
-def decrypt_data(encrypted_str):
-    """Decrypt data using Fernet encryption."""
+def decrypt_credentials(encrypted_str: str) -> Optional[dict]:
+    """Decrypt credentials string.
+    
+    Args:
+        encrypted_str: Base64 encoded encrypted string.
+        
+    Returns:
+        Decrypted dictionary or None if decryption fails.
+    """
     if not encrypted_str:
         return None
+    
     try:
-        f = Fernet(get_encryption_key())
-        decrypted_bytes = f.decrypt(encrypted_str.encode())
-        return json.loads(decrypted_bytes.decode())
+        f = get_fernet()
+        decrypted = f.decrypt(encrypted_str.encode())
+        return json.loads(decrypted.decode())
     except Exception:
+        # Log but don't fail migration for individual record issues
         return None
 
 
 def upgrade():
-    """Migrate GitHub repo_name from encrypted credentials to config_fields."""
+    """Move repo_name from encrypted GitHub credentials to source_connection config_fields.
     
-    # Check encryption key is available
+    This migration handles the architectural change where repo_name is moved from
+    GitHubAuthConfig (stored encrypted) to GitHubConfig (stored as plain config).
+    """
+    # Verify encryption key is available
     try:
-        get_encryption_key()
-    except ValueError:
-        raise RuntimeError("ENCRYPTION_KEY environment variable must be set")
+        get_fernet()
+    except RuntimeError as e:
+        raise RuntimeError(str(e))
     
     conn = op.get_bind()
     
-    # Find GitHub connections that need migration
-    result = op.execute("""
+    # Query GitHub source connections with their credentials
+    query = text("""
         SELECT 
             sc.id as source_connection_id,
             sc.config_fields,
@@ -68,67 +99,96 @@ def upgrade():
         JOIN connection c ON sc.connection_id = c.id
         JOIN integration_credential ic ON c.integration_credential_id = ic.id
         WHERE sc.short_name = 'github'
-        AND (sc.config_fields IS NULL OR NOT (sc.config_fields::jsonb ? 'repo_name'))
         AND ic.encrypted_credentials IS NOT NULL
     """)
     
-    migrated_count = 0
+    result = conn.execute(query)
+    rows = result.fetchall()
     
-    for row in result:
-        source_connection_id = row.source_connection_id
-        config_fields = row.config_fields or {}
-        credential_id = row.credential_id
-        encrypted_credentials = row.encrypted_credentials
-        
-        # Decrypt credentials
-        decrypted_credentials = decrypt_data(encrypted_credentials)
-        if not decrypted_credentials or 'repo_name' not in decrypted_credentials:
+    migrated_count = 0
+    skipped_count = 0
+    
+    for row in rows:
+        # Decrypt credentials to check for repo_name
+        credentials = decrypt_credentials(row.encrypted_credentials)
+        if not credentials or "repo_name" not in credentials:
+            skipped_count += 1
             continue
-            
-        repo_name = decrypted_credentials['repo_name']
+        
+        repo_name = credentials.get("repo_name")
         if not repo_name:
+            skipped_count += 1
             continue
-            
+        
+        # Parse existing config_fields
+        config_fields = {}
+        if row.config_fields:
+            if isinstance(row.config_fields, str):
+                try:
+                    config_fields = json.loads(row.config_fields)
+                except json.JSONDecodeError:
+                    config_fields = {}
+            else:
+                config_fields = dict(row.config_fields)
+        
+        # Skip if repo_name already exists in config
+        if config_fields.get("repo_name"):
+            skipped_count += 1
+            continue
+        
         # Add repo_name to config_fields
-        if isinstance(config_fields, str):
-            config_fields = json.loads(config_fields) if config_fields else {}
-        config_fields['repo_name'] = repo_name
+        config_fields["repo_name"] = repo_name
         
-        # Remove repo_name from credentials and re-encrypt
-        del decrypted_credentials['repo_name']
-        new_encrypted_credentials = encrypt_data(decrypted_credentials)
+        # Remove repo_name from credentials
+        del credentials["repo_name"]
+        new_encrypted = encrypt_credentials(credentials)
         
-        # Update both tables
-        op.execute(f"""
+        # Update source_connection config_fields
+        update_sc = text("""
             UPDATE source_connection 
-            SET config_fields = '{json.dumps(config_fields)}'::jsonb,
+            SET config_fields = :config_fields,
                 modified_at = CURRENT_TIMESTAMP
-            WHERE id = '{source_connection_id}'
+            WHERE id = :id
         """)
+        conn.execute(
+            update_sc,
+            {"config_fields": json.dumps(config_fields), "id": row.source_connection_id},
+        )
         
-        op.execute(f"""
+        # Update integration_credential without repo_name
+        update_ic = text("""
             UPDATE integration_credential 
-            SET encrypted_credentials = '{new_encrypted_credentials}',
+            SET encrypted_credentials = :encrypted,
                 modified_at = CURRENT_TIMESTAMP
-            WHERE id = '{credential_id}'
+            WHERE id = :id
         """)
+        conn.execute(
+            update_ic,
+            {"encrypted": new_encrypted, "id": row.credential_id},
+        )
         
         migrated_count += 1
     
-    print(f"Migrated {migrated_count} GitHub connections")
+    print(f"✅ Migrated {migrated_count} GitHub connections")
+    if skipped_count > 0:
+        print(f"ℹ️  Skipped {skipped_count} connections (no repo_name or already migrated)")
 
 
 def downgrade():
-    """Reverse the migration by moving repo_name back to encrypted credentials."""
+    """Move repo_name from source_connection config_fields back to encrypted credentials.
     
-    # Check encryption key is available
+    This reverses the migration by moving repo_name back to the encrypted credentials.
+    """
+    # Verify encryption key is available
     try:
-        get_encryption_key()
-    except ValueError:
-        raise RuntimeError("ENCRYPTION_KEY environment variable must be set")
+        get_fernet()
+    except RuntimeError as e:
+        raise RuntimeError(str(e))
     
-    # Find GitHub connections that have repo_name in config_fields
-    result = op.execute("""
+    conn = op.get_bind()
+    
+    # Query GitHub source connections with repo_name in config_fields
+    query = text("""
         SELECT 
             sc.id as source_connection_id,
             sc.config_fields,
@@ -138,64 +198,75 @@ def downgrade():
         JOIN connection c ON sc.connection_id = c.id
         JOIN integration_credential ic ON c.integration_credential_id = ic.id
         WHERE sc.short_name = 'github'
-        AND sc.config_fields IS NOT NULL 
-        AND (sc.config_fields::jsonb ? 'repo_name')
+        AND sc.config_fields IS NOT NULL
+        AND sc.config_fields::jsonb ? 'repo_name'
     """)
+    
+    result = conn.execute(query)
+    rows = result.fetchall()
     
     reverted_count = 0
     
-    for row in result:
-        source_connection_id = row.source_connection_id
-        config_fields = row.config_fields or {}
-        credential_id = row.credential_id
-        encrypted_credentials = row.encrypted_credentials
+    for row in rows:
+        # Parse config_fields
+        config_fields = {}
+        if isinstance(row.config_fields, str):
+            try:
+                config_fields = json.loads(row.config_fields)
+            except json.JSONDecodeError:
+                continue
+        else:
+            config_fields = dict(row.config_fields)
         
-        # Parse config_fields if it's a string
-        if isinstance(config_fields, str):
-            config_fields = json.loads(config_fields) if config_fields else {}
-        
-        if 'repo_name' not in config_fields:
-            continue
-            
-        repo_name = config_fields['repo_name']
+        repo_name = config_fields.get("repo_name")
         if not repo_name:
             continue
         
-        # Decrypt existing credentials or start with empty dict
-        decrypted_credentials = decrypt_data(encrypted_credentials) if encrypted_credentials else {}
-        if decrypted_credentials is None:
-            decrypted_credentials = {}
+        # Decrypt existing credentials or start fresh
+        credentials = decrypt_credentials(row.encrypted_credentials) if row.encrypted_credentials else {}
+        if credentials is None:
+            credentials = {}
         
-        # Add repo_name back to credentials
-        decrypted_credentials['repo_name'] = repo_name
-        new_encrypted_credentials = encrypt_data(decrypted_credentials)
+        # Add repo_name to credentials
+        credentials["repo_name"] = repo_name
+        new_encrypted = encrypt_credentials(credentials)
         
         # Remove repo_name from config_fields
-        del config_fields['repo_name']
+        del config_fields["repo_name"]
         
-        # Update both tables
+        # Update source_connection - set to NULL if config_fields is empty
         if config_fields:
-            op.execute(f"""
+            update_sc = text("""
                 UPDATE source_connection 
-                SET config_fields = '{json.dumps(config_fields)}'::jsonb,
+                SET config_fields = :config_fields,
                     modified_at = CURRENT_TIMESTAMP
-                WHERE id = '{source_connection_id}'
+                WHERE id = :id
             """)
+            conn.execute(
+                update_sc,
+                {"config_fields": json.dumps(config_fields), "id": row.source_connection_id},
+            )
         else:
-            op.execute(f"""
+            update_sc = text("""
                 UPDATE source_connection 
                 SET config_fields = NULL,
                     modified_at = CURRENT_TIMESTAMP
-                WHERE id = '{source_connection_id}'
+                WHERE id = :id
             """)
+            conn.execute(update_sc, {"id": row.source_connection_id})
         
-        op.execute(f"""
+        # Update integration_credential with repo_name
+        update_ic = text("""
             UPDATE integration_credential 
-            SET encrypted_credentials = '{new_encrypted_credentials}',
+            SET encrypted_credentials = :encrypted,
                 modified_at = CURRENT_TIMESTAMP
-            WHERE id = '{credential_id}'
+            WHERE id = :id
         """)
+        conn.execute(
+            update_ic,
+            {"encrypted": new_encrypted, "id": row.credential_id},
+        )
         
         reverted_count += 1
     
-    print(f"Reverted {reverted_count} GitHub connections")
+    print(f"✅ Reverted {reverted_count} GitHub connections")

--- a/backend/alembic/versions/6e39730bc45b_migrate_github_repo_name_from_auth_to_config.py
+++ b/backend/alembic/versions/6e39730bc45b_migrate_github_repo_name_from_auth_to_config.py
@@ -1,0 +1,201 @@
+"""migrate_github_repo_name_from_auth_to_config
+
+Revision ID: 6e39730bc45b
+Revises: c60291fb2129
+Create Date: 2025-09-28 22:12:53.758477
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import json
+import os
+from cryptography.fernet import Fernet
+
+# revision identifiers, used by Alembic.
+revision = '6e39730bc45b'
+down_revision = 'c60291fb2129'
+branch_labels = None
+depends_on = None
+
+
+def get_encryption_key():
+    """Get encryption key from environment variable."""
+    key = os.environ.get('ENCRYPTION_KEY')
+    if not key:
+        raise ValueError("ENCRYPTION_KEY environment variable is not set")
+    return key.encode()
+
+
+def encrypt_data(data):
+    """Encrypt dictionary data using Fernet encryption."""
+    f = Fernet(get_encryption_key())
+    json_str = json.dumps(data)
+    encrypted_data = f.encrypt(json_str.encode())
+    return encrypted_data.decode()
+
+
+def decrypt_data(encrypted_str):
+    """Decrypt data using Fernet encryption."""
+    if not encrypted_str:
+        return None
+    try:
+        f = Fernet(get_encryption_key())
+        decrypted_bytes = f.decrypt(encrypted_str.encode())
+        return json.loads(decrypted_bytes.decode())
+    except Exception:
+        return None
+
+
+def upgrade():
+    """Migrate GitHub repo_name from encrypted credentials to config_fields."""
+    
+    # Check encryption key is available
+    try:
+        get_encryption_key()
+    except ValueError:
+        raise RuntimeError("ENCRYPTION_KEY environment variable must be set")
+    
+    conn = op.get_bind()
+    
+    # Find GitHub connections that need migration
+    result = op.execute("""
+        SELECT 
+            sc.id as source_connection_id,
+            sc.config_fields,
+            ic.id as credential_id,
+            ic.encrypted_credentials
+        FROM source_connection sc
+        JOIN connection c ON sc.connection_id = c.id
+        JOIN integration_credential ic ON c.integration_credential_id = ic.id
+        WHERE sc.short_name = 'github'
+        AND (sc.config_fields IS NULL OR NOT (sc.config_fields::jsonb ? 'repo_name'))
+        AND ic.encrypted_credentials IS NOT NULL
+    """)
+    
+    migrated_count = 0
+    
+    for row in result:
+        source_connection_id = row.source_connection_id
+        config_fields = row.config_fields or {}
+        credential_id = row.credential_id
+        encrypted_credentials = row.encrypted_credentials
+        
+        # Decrypt credentials
+        decrypted_credentials = decrypt_data(encrypted_credentials)
+        if not decrypted_credentials or 'repo_name' not in decrypted_credentials:
+            continue
+            
+        repo_name = decrypted_credentials['repo_name']
+        if not repo_name:
+            continue
+            
+        # Add repo_name to config_fields
+        if isinstance(config_fields, str):
+            config_fields = json.loads(config_fields) if config_fields else {}
+        config_fields['repo_name'] = repo_name
+        
+        # Remove repo_name from credentials and re-encrypt
+        del decrypted_credentials['repo_name']
+        new_encrypted_credentials = encrypt_data(decrypted_credentials)
+        
+        # Update both tables
+        op.execute(f"""
+            UPDATE source_connection 
+            SET config_fields = '{json.dumps(config_fields)}'::jsonb,
+                modified_at = CURRENT_TIMESTAMP
+            WHERE id = '{source_connection_id}'
+        """)
+        
+        op.execute(f"""
+            UPDATE integration_credential 
+            SET encrypted_credentials = '{new_encrypted_credentials}',
+                modified_at = CURRENT_TIMESTAMP
+            WHERE id = '{credential_id}'
+        """)
+        
+        migrated_count += 1
+    
+    print(f"Migrated {migrated_count} GitHub connections")
+
+
+def downgrade():
+    """Reverse the migration by moving repo_name back to encrypted credentials."""
+    
+    # Check encryption key is available
+    try:
+        get_encryption_key()
+    except ValueError:
+        raise RuntimeError("ENCRYPTION_KEY environment variable must be set")
+    
+    # Find GitHub connections that have repo_name in config_fields
+    result = op.execute("""
+        SELECT 
+            sc.id as source_connection_id,
+            sc.config_fields,
+            ic.id as credential_id,
+            ic.encrypted_credentials
+        FROM source_connection sc
+        JOIN connection c ON sc.connection_id = c.id
+        JOIN integration_credential ic ON c.integration_credential_id = ic.id
+        WHERE sc.short_name = 'github'
+        AND sc.config_fields IS NOT NULL 
+        AND (sc.config_fields::jsonb ? 'repo_name')
+    """)
+    
+    reverted_count = 0
+    
+    for row in result:
+        source_connection_id = row.source_connection_id
+        config_fields = row.config_fields or {}
+        credential_id = row.credential_id
+        encrypted_credentials = row.encrypted_credentials
+        
+        # Parse config_fields if it's a string
+        if isinstance(config_fields, str):
+            config_fields = json.loads(config_fields) if config_fields else {}
+        
+        if 'repo_name' not in config_fields:
+            continue
+            
+        repo_name = config_fields['repo_name']
+        if not repo_name:
+            continue
+        
+        # Decrypt existing credentials or start with empty dict
+        decrypted_credentials = decrypt_data(encrypted_credentials) if encrypted_credentials else {}
+        if decrypted_credentials is None:
+            decrypted_credentials = {}
+        
+        # Add repo_name back to credentials
+        decrypted_credentials['repo_name'] = repo_name
+        new_encrypted_credentials = encrypt_data(decrypted_credentials)
+        
+        # Remove repo_name from config_fields
+        del config_fields['repo_name']
+        
+        # Update both tables
+        if config_fields:
+            op.execute(f"""
+                UPDATE source_connection 
+                SET config_fields = '{json.dumps(config_fields)}'::jsonb,
+                    modified_at = CURRENT_TIMESTAMP
+                WHERE id = '{source_connection_id}'
+            """)
+        else:
+            op.execute(f"""
+                UPDATE source_connection 
+                SET config_fields = NULL,
+                    modified_at = CURRENT_TIMESTAMP
+                WHERE id = '{source_connection_id}'
+            """)
+        
+        op.execute(f"""
+            UPDATE integration_credential 
+            SET encrypted_credentials = '{new_encrypted_credentials}',
+                modified_at = CURRENT_TIMESTAMP
+            WHERE id = '{credential_id}'
+        """)
+        
+        reverted_count += 1
+    
+    print(f"Reverted {reverted_count} GitHub connections")

--- a/backend/tests/e2e/smoke/test_sources.py
+++ b/backend/tests/e2e/smoke/test_sources.py
@@ -172,7 +172,7 @@ class TestSources:
     async def test_blocked_sources_have_no_auth_providers(self, api_client: httpx.AsyncClient):
         """Test that blocked sources correctly show empty supported_auth_providers."""
         # Sources that are known to be blocked by all providers
-        blocked_sources = ["github", "confluence", "jira", "bitbucket"]
+        blocked_sources = ["ctti"]
 
         for source_name in blocked_sources:
             response = await api_client.get(f"/sources/{source_name}")
@@ -194,7 +194,7 @@ class TestSources:
     async def test_supported_sources_have_auth_providers(self, api_client: httpx.AsyncClient):
         """Test that well-supported sources have auth providers listed."""
         # Sources that should be supported by at least one provider
-        supported_sources = ["notion", "slack", "stripe", "hubspot_crm", "linear"]
+        supported_sources = ["notion", "slack", "stripe", "hubspot_crm", "linear", "github"]
 
         sources_with_providers = []
         for source_name in supported_sources:

--- a/fern/docs/pages/connectors/github/main.mdx
+++ b/fern/docs/pages/connectors/github/main.mdx
@@ -48,13 +48,6 @@ GitHub authentication credentials schema.
 >
   GitHub PAT with read rights (code, contents, metadata) to the repository
 </ParamField>
-<ParamField
-  path="repo_name"
-  type="str"
-  required={true}
->
-  Repository to sync in owner/repo format (e.g., 'airweave-ai/airweave')
-</ParamField>
 </Card>
 
 ### Configuration Options
@@ -68,6 +61,13 @@ The following configuration options are available for this connector:
 >
 
 Github configuration schema.
+<ParamField
+  path="repo_name"
+  type="str"
+  required={true}
+>
+  Repository to sync in owner/repo format (e.g., 'airweave-ai/airweave')
+</ParamField>
 <ParamField
   path="branch"
   type="str"
@@ -241,7 +241,7 @@ After configuring the permissions, scroll to the bottom of the page and click "G
 ### Step 6: Add Your Token to Airweave
 
 When setting up the GitHub connector in Airweave:
-1. Paste your personal access token in the "Personal Access Token" field
-2. Enter the repository name in the format `owner/repo` (e.g., `airweave-ai/airweave`)
+1. **Authentication**: Paste your personal access token in the "Personal Access Token" field
+2. **Configuration**: Enter the repository name in the format `owner/repo` (e.g., `airweave-ai/airweave`) in the "Repository Name" configuration field
 
 Your GitHub repository is now connected to Airweave and ready for synchronization.

--- a/frontend/src/components/creation-views/SourceConfigView.tsx
+++ b/frontend/src/components/creation-views/SourceConfigView.tsx
@@ -530,7 +530,7 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
                   {authMode === 'direct_auth' && sourceDetails?.auth_fields?.fields && (
                     <div className="space-y-3">
                       <label className="block text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                        Configuration
+                        Direct Credentials Configuration
                       </label>
                       {sourceDetails.auth_fields.fields.map((field) => (
                         <div key={field.name}>
@@ -587,11 +587,14 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
                     </div>
                   )}
 
-                  {/* Config fields */}
+                  {/* Config fields (additional configuration) */}
                   {sourceDetails?.config_fields?.fields && sourceDetails.config_fields.fields.length > 0 && (
                     <div className="space-y-3">
                       <label className="block text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                        Additional Configuration
+                        {(() => {
+                          const hasRequiredFields = sourceDetails.config_fields.fields.some((field: any) => field.required);
+                          return hasRequiredFields ? "Additional Configuration" : "Additional Configuration (optional)";
+                        })()}
                       </label>
                       {sourceDetails.config_fields.fields.map((field) => (
                         <div key={field.name}>

--- a/monke/configs/github.yaml
+++ b/monke/configs/github.yaml
@@ -8,8 +8,8 @@ connector:
   auth_mode: direct
   auth_fields:
     personal_access_token: MONKE_GITHUB_PERSONAL_ACCESS_TOKEN
-    repo_name: MONKE_GITHUB_REPO_NAME
   config_fields:
+    repo_name: MONKE_GITHUB_REPO_NAME  # Moved from auth_fields after migration
     branch: "main"
     openai_model: "gpt-4.1-mini"
     post_create_sleep_seconds: 15


### PR DESCRIPTION
Enables GitHub, Jira, Confluence & BitBucket source connections to use auth providers (Pipedream, Composio) instead of requiring direct authentication credentials. First step toward supporting auth providers for other sources (Jira, PostgreSQL, etc.). This change serves as a proof of concept for the next sources.

## Important Changes
- **GitHub source connections** now require `repo_name` in `config_fields` instead of `auth_fields`
- **New connections** work correctly with this structure
- **Existing connections** need migration
- **Renaming**: Renamed `Configuration` to `Direct Credentials Configuration`
- **Renaming**: Renamed `Additional Configuration (Optional)` to `Additional Configuration` and mark non-optional fields with red star

<img width="610" height="680" alt="Screenshot 2025-09-28 at 23 56 26" src="https://github.com/user-attachments/assets/91ad38f8-360f-4eae-a6ea-c42377ed8d82" />

## Migration Required!
A database migration is still needed to handle existing GitHub source connections:

- **Migration needed**: Move `repo_name` from encrypted credentials to `config_fields` for existing connections
- **Impact**: Existing connections will fail to sync without migration

## Testing Plan
### Migration
1. Set up GitHub connection on main branch
2. Ran migrations and ensured syncing still works on new branch with repo_name in config rather than authconfig

### Auth provider
1. Composio integration works 

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable GitHub source connections to use external auth providers (Composio, Pipedream). repo_name is now part of source configuration and required; UI labels updated to clarify direct credentials vs additional config.

- **Migration**
  - Adds Alembic migration to move repo_name from encrypted credentials to config_fields for existing GitHub connections.
  - Existing connections will not sync until migrated; a placeholder is used if repo_name is missing or credentials are unavailable.

<!-- End of auto-generated description by cubic. -->