### PR TITLE
feat(frontend): Redesign entity search results

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -74,8 +74,10 @@
     --radius: 0.5rem;
 
     /* Brand colors */
-    --brand-lime: 92 80% 45%; /* #C1F297 - Tertiary Brand Color */
-    --brand-yellow: 54 100% 45%; /* #F1EEEA - Secondary Brand Color */
+    --brand-lime: 92 80% 45%;
+    /* #C1F297 - Tertiary Brand Color */
+    --brand-yellow: 54 100% 45%;
+    /* #F1EEEA - Secondary Brand Color */
 
     --highlight: 0 0% 75%;
     --highlight-foreground: 0 0% 2.4%;
@@ -167,8 +169,10 @@
     --ring: 210 67% 98.8% / 0.6;
 
     /* Brand colors */
-    --brand-lime: 92 78% 77%; /* #C1F297 - True brand color for dark mode */
-    --brand-yellow: 54 100% 45%; /* #F1EEEA - True brand color for dark mode */
+    --brand-lime: 92 78% 77%;
+    /* #C1F297 - True brand color for dark mode */
+    --brand-yellow: 54 100% 45%;
+    /* #F1EEEA - True brand color for dark mode */
 
     --highlight: 0 0% 20%;
     --highlight-foreground: 210 67% 98.8%;
@@ -255,4 +259,42 @@
 
 .dark .sidebar-nav-item:hover::before {
   @apply opacity-100;
+}
+
+/* Custom scrollbar styles for raw data viewer */
+.raw-data-scrollbar ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.raw-data-scrollbar ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.raw-data-scrollbar ::-webkit-scrollbar-thumb {
+  background: rgba(156, 163, 175, 0.3);
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.raw-data-scrollbar ::-webkit-scrollbar-thumb:hover {
+  background: rgba(156, 163, 175, 0.5);
+}
+
+.dark .raw-data-scrollbar ::-webkit-scrollbar-thumb {
+  background: rgba(107, 114, 128, 0.4);
+}
+
+.dark .raw-data-scrollbar ::-webkit-scrollbar-thumb:hover {
+  background: rgba(107, 114, 128, 0.6);
+}
+
+/* Firefox scrollbar support */
+.raw-data-scrollbar * {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(156, 163, 175, 0.3) transparent;
+}
+
+.dark .raw-data-scrollbar * {
+  scrollbar-color: rgba(107, 114, 128, 0.4) transparent;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -262,39 +262,48 @@
 }
 
 /* Custom scrollbar styles for raw data viewer */
+/* Target both the element itself and its children */
+.raw-data-scrollbar::-webkit-scrollbar,
 .raw-data-scrollbar ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
+.raw-data-scrollbar::-webkit-scrollbar-track,
 .raw-data-scrollbar ::-webkit-scrollbar-track {
   background: transparent;
 }
 
+.raw-data-scrollbar::-webkit-scrollbar-thumb,
 .raw-data-scrollbar ::-webkit-scrollbar-thumb {
   background: rgba(156, 163, 175, 0.3);
   border-radius: 4px;
   transition: background 0.2s;
 }
 
+.raw-data-scrollbar::-webkit-scrollbar-thumb:hover,
 .raw-data-scrollbar ::-webkit-scrollbar-thumb:hover {
   background: rgba(156, 163, 175, 0.5);
 }
 
+.dark .raw-data-scrollbar::-webkit-scrollbar-thumb,
 .dark .raw-data-scrollbar ::-webkit-scrollbar-thumb {
   background: rgba(107, 114, 128, 0.4);
 }
 
+.dark .raw-data-scrollbar::-webkit-scrollbar-thumb:hover,
 .dark .raw-data-scrollbar ::-webkit-scrollbar-thumb:hover {
   background: rgba(107, 114, 128, 0.6);
 }
 
 /* Firefox scrollbar support */
+.raw-data-scrollbar,
 .raw-data-scrollbar * {
   scrollbar-width: thin;
   scrollbar-color: rgba(156, 163, 175, 0.3) transparent;
 }
 
+.dark .raw-data-scrollbar,
 .dark .raw-data-scrollbar * {
   scrollbar-color: rgba(107, 114, 128, 0.4) transparent;
 }

--- a/frontend/src/search/EntityResultCard.tsx
+++ b/frontend/src/search/EntityResultCard.tsx
@@ -176,6 +176,10 @@ const EntityResultCardComponent: React.FC<EntityResultCardProps> = ({
         typeof b === 'string' ? b : b.name || b.title || ''
     ).filter(Boolean).join(' > ') : '';
 
+    // Extract the most relevant timestamp (updated_at from system metadata)
+    const relevantTimestamp = payload.airweave_system_metadata?.airweave_updated_at ||
+        payload.airweave_system_metadata?.airweave_created_at;
+
     // Get Airweave logo for section headers
     const airweaveLogo = isDark
         ? '/airweave-logo-svg-white-darkbg.svg'
@@ -434,6 +438,57 @@ const EntityResultCardComponent: React.FC<EntityResultCardProps> = ({
                                     )}>
                                         {entityType}
                                     </span>
+
+                                    {/* Last Updated Timestamp */}
+                                    {relevantTimestamp && (
+                                        <TooltipProvider delayDuration={200}>
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <span className={cn(
+                                                        "inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium cursor-help",
+                                                        isDark
+                                                            ? "bg-gray-800/40 text-gray-400 border border-gray-700/40"
+                                                            : "bg-gray-50/60 text-gray-600 border border-gray-200/50"
+                                                    )}>
+                                                        <Clock className="h-3 w-3" strokeWidth={1.5} />
+                                                        {formatDate(relevantTimestamp)}
+                                                    </span>
+                                                </TooltipTrigger>
+                                                <TooltipContent
+                                                    side="top"
+                                                    className={cn(
+                                                        "px-3 py-2 max-w-[280px] backdrop-blur-sm",
+                                                        isDark
+                                                            ? "bg-gray-900/95 border border-gray-700/50 shadow-xl"
+                                                            : "bg-white/95 border border-gray-200 shadow-lg"
+                                                    )}
+                                                >
+                                                    <div className="space-y-1">
+                                                        <div className={cn(
+                                                            "text-[11px] font-bold tracking-wide",
+                                                            isDark ? "text-gray-300" : "text-gray-700"
+                                                        )}>
+                                                            {payload.airweave_system_metadata?.airweave_updated_at ? 'Last Updated' : 'Created'}
+                                                        </div>
+                                                        <div className={cn(
+                                                            "text-[12px] font-mono",
+                                                            isDark ? "text-gray-400" : "text-gray-600"
+                                                        )}>
+                                                            {new Date(relevantTimestamp).toLocaleString('en-US', {
+                                                                year: 'numeric',
+                                                                month: 'short',
+                                                                day: 'numeric',
+                                                                hour: '2-digit',
+                                                                minute: '2-digit',
+                                                                second: '2-digit',
+                                                                hour12: true
+                                                            })}
+                                                        </div>
+                                                    </div>
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        </TooltipProvider>
+                                    )}
                                 </div>
 
                                 {/* URL Link */}

--- a/frontend/src/search/EntityResultCard.tsx
+++ b/frontend/src/search/EntityResultCard.tsx
@@ -16,6 +16,16 @@ interface EntityResultCardProps {
     onEntityIdClick?: (entityId: string) => void;
 }
 
+// Comparison function for React.memo
+const arePropsEqual = (prevProps: EntityResultCardProps, nextProps: EntityResultCardProps) => {
+    return (
+        prevProps.index === nextProps.index &&
+        prevProps.isDark === nextProps.isDark &&
+        prevProps.result.id === nextProps.result.id &&
+        prevProps.result.score === nextProps.result.score
+    );
+};
+
 /**
  * Format embeddable text for nice Markdown display
  * Extracts metadata fields and preserves content markdown structure
@@ -88,7 +98,7 @@ const formatEmbeddableText = (text: string): string => {
 /**
  * EntityResultCard - A human-readable card view for entity search results
  */
-export const EntityResultCard: React.FC<EntityResultCardProps> = ({
+const EntityResultCardComponent: React.FC<EntityResultCardProps> = ({
     result,
     index,
     isDark,
@@ -355,8 +365,8 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
             className={cn(
                 "group relative rounded-xl transition-all duration-300 overflow-hidden raw-data-scrollbar",
                 isDark
-                    ? "bg-gradient-to-br from-gray-900/90 to-gray-900/50 border border-gray-800/50"
-                    : "bg-white border border-gray-200/60",
+                    ? "bg-gradient-to-br from-gray-900/90 to-gray-900/50 border border-gray-800/60"
+                    : "bg-white border border-gray-200/80",
                 "backdrop-blur-sm"
             )}
         >
@@ -925,10 +935,23 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
                                     borderRadius: 0,
                                     fontSize: '0.65rem',
                                     padding: '0.75rem',
-                                    background: isDark ? 'rgba(17, 24, 39, 0.8)' : 'rgba(249, 250, 251, 0.95)',
+                                    background: 'transparent',
+                                    backgroundColor: 'transparent',
                                     maxHeight: '300px',
-                                    overflow: 'auto'
+                                    overflow: 'auto',
+                                    border: 'none',
+                                    boxShadow: 'none',
+                                    outline: 'none'
                                 }}
+                                showLineNumbers={false}
+                                wrapLines={false}
+                                lineProps={{ style: { backgroundColor: 'transparent', background: 'transparent' } }}
+                                codeTagProps={{ style: { backgroundColor: 'transparent', background: 'transparent' } }}
+                                PreTag={({ children, ...props }) => (
+                                    <pre {...props} style={{ ...props.style, background: 'transparent', backgroundColor: 'transparent', margin: 0, padding: 0 }}>
+                                        {children}
+                                    </pre>
+                                )}
                             >
                                 {JSON.stringify(payload, null, 2)}
                             </SyntaxHighlighter>
@@ -939,3 +962,6 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
         </div>
     );
 };
+
+// Export memoized version for better performance
+export const EntityResultCard = React.memo(EntityResultCardComponent, arePropsEqual);

--- a/frontend/src/search/EntityResultCard.tsx
+++ b/frontend/src/search/EntityResultCard.tsx
@@ -1,0 +1,741 @@
+import React, { useState, useMemo } from 'react';
+import { cn } from '@/lib/utils';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { materialOceanic, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { ChevronDown, ChevronRight, ExternalLink, Copy, Check, Link as LinkIcon, Clock } from 'lucide-react';
+
+interface EntityResultCardProps {
+    result: any;
+    index: number;
+    isDark: boolean;
+    onEntityIdClick?: (entityId: string) => void;
+}
+
+/**
+ * Parse embeddable text to extract structured information
+ * Looks for patterns like "* type: Page", "* Context: ...", etc.
+ */
+const parseEmbeddableText = (text: string) => {
+    const lines = text.split('\n');
+    const structured: Record<string, string> = {};
+    const remainingContent: string[] = [];
+    let inContentSection = false;
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+
+        // Match patterns like "* key: value" or "* key value"
+        const match = trimmed.match(/^\*\s+([^:]+):\s*(.+)$/);
+        if (match && !inContentSection) {
+            const [, key, value] = match;
+            const normalizedKey = key.toLowerCase().trim();
+
+            // Store structured fields
+            if (['type', 'source', 'context', 'title', 'name'].includes(normalizedKey)) {
+                structured[normalizedKey] = value.trim();
+            } else {
+                // Once we hit non-standard fields, consider it content
+                inContentSection = true;
+                remainingContent.push(line);
+            }
+        } else if (trimmed.startsWith('* ') && !inContentSection) {
+            // Handle "* name value" format (without colon)
+            const parts = trimmed.substring(2).split(/\s+/);
+            if (parts.length >= 2) {
+                const key = parts[0].toLowerCase();
+                const value = parts.slice(1).join(' ');
+                if (['type', 'source', 'context', 'title', 'name'].includes(key)) {
+                    structured[key] = value;
+                } else {
+                    inContentSection = true;
+                    remainingContent.push(line);
+                }
+            }
+        } else {
+            // Regular content
+            inContentSection = true;
+            if (trimmed) {
+                remainingContent.push(line);
+            }
+        }
+    }
+
+    return {
+        structured,
+        content: remainingContent.join('\n').trim()
+    };
+};
+
+/**
+ * EntityResultCard - A human-readable card view for entity search results
+ */
+export const EntityResultCard: React.FC<EntityResultCardProps> = ({
+    result,
+    index,
+    isDark,
+    onEntityIdClick
+}) => {
+    const [isMetadataExpanded, setIsMetadataExpanded] = useState(false);
+    const [isContentExpanded, setIsContentExpanded] = useState(false);
+    const [isRawExpanded, setIsRawExpanded] = useState(false);
+    const [copiedField, setCopiedField] = useState<string | null>(null);
+    const [expandedFields, setExpandedFields] = useState<Set<string>>(new Set());
+
+    // Extract payload from result
+    const payload = result.payload || result;
+    const score = result.score;
+
+    // Determine if score looks like cosine similarity (0-1 range) or something else
+    const isNormalizedScore = score !== undefined && score >= 0 && score <= 1;
+
+    // Format score for display
+    const getScoreDisplay = () => {
+        if (score === undefined) return null;
+
+        // For scores in 0-1 range (cosine similarity), show as percentage
+        if (isNormalizedScore) {
+            return {
+                value: `${(score * 100).toFixed(1)}%`,
+                color: score >= 0.7 ? 'green' : score >= 0.5 ? 'yellow' : 'gray'
+            };
+        }
+
+        // For other scores (e.g., BM25), show raw value
+        return {
+            value: score.toFixed(3),
+            color: score >= 10 ? 'green' : score >= 5 ? 'yellow' : 'gray'
+        };
+    };
+
+    const scoreDisplay = getScoreDisplay();
+
+    // Extract key fields
+    const entityId = payload.entity_id || payload.id || payload._id;
+    const sourceName = payload.airweave_system_metadata?.source_name || payload.source_name || 'Unknown Source';
+    const embeddableText = payload.embeddable_text || '';
+    const breadcrumbs = payload.breadcrumbs || [];
+    const url = payload.url;
+    const mdContent = payload.md_content;
+
+    // Parse embeddable text for structured information
+    const { structured, content } = useMemo(() => parseEmbeddableText(embeddableText), [embeddableText]);
+
+    // Extract title from structured data or fallback
+    const title = structured.title || structured.name || payload.md_title || payload.title || payload.name || 'Untitled';
+    const entityType = structured.type || 'Document';
+    const context = structured.context || (breadcrumbs.length > 0 ? breadcrumbs.map((b: any) =>
+        typeof b === 'string' ? b : b.name || b.title || ''
+    ).filter(Boolean).join(' > ') : '');
+
+    // Get icon based on entity type
+    const getTypeIcon = () => {
+        const type = entityType.toLowerCase();
+        if (type.includes('page')) return '📄';
+        if (type.includes('file')) return '📎';
+        if (type.includes('issue')) return '🎯';
+        if (type.includes('task')) return '✅';
+        if (type.includes('note')) return '📝';
+        if (type.includes('message')) return '💬';
+        if (type.includes('comment')) return '💭';
+        return '📄';
+    };
+
+    // Format source name (capitalize first letter of each word)
+    const formattedSourceName = sourceName
+        .split('_')
+        .map((word: string) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+        .join(' ');
+
+    // Extract metadata (exclude system fields and already displayed fields)
+    const metadata = useMemo(() => {
+        const filtered: Record<string, any> = {};
+        const excludeKeys = [
+            'entity_id', 'id', '_id',
+            'embeddable_text', 'md_content', 'md_title',
+            'title', 'name', 'breadcrumbs', 'url',
+            'airweave_system_metadata', 'source_name',
+            'download_url', 'local_path', 'file_uuid', 'checksum',
+            'vector', 'vectors'
+        ];
+
+        Object.entries(payload).forEach(([key, value]) => {
+            if (!excludeKeys.includes(key) && value !== null && value !== undefined && value !== '') {
+                // Format key names nicely
+                const formattedKey = key
+                    .split('_')
+                    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                    .join(' ');
+                filtered[formattedKey] = value;
+            }
+        });
+
+        return filtered;
+    }, [payload]);
+
+    const hasMetadata = Object.keys(metadata).length > 0;
+
+    // Prioritize important fields and limit display
+    const IMPORTANT_FIELDS = ['Owner', 'Assignee', 'Status', 'Priority', 'Due Date', 'Created At', 'Updated At', 'Author', 'Completion', 'Tags', 'Labels'];
+    const MAX_FIELDS_DEFAULT = 4; // Show max 4 fields by default
+
+    const { importantMetadata, remainingMetadata } = useMemo(() => {
+        const important: Record<string, any> = {};
+        const remaining: Record<string, any> = {};
+
+        // First, collect important fields
+        Object.entries(metadata).forEach(([key, value]) => {
+            if (IMPORTANT_FIELDS.some(field => key.toLowerCase().includes(field.toLowerCase()))) {
+                important[key] = value;
+            } else {
+                remaining[key] = value;
+            }
+        });
+
+        // If we have fewer than MAX_FIELDS_DEFAULT important fields, add some remaining ones
+        const importantCount = Object.keys(important).length;
+        if (importantCount < MAX_FIELDS_DEFAULT) {
+            const remainingEntries = Object.entries(remaining);
+            const toAdd = remainingEntries.slice(0, MAX_FIELDS_DEFAULT - importantCount);
+            toAdd.forEach(([key, value]) => {
+                important[key] = value;
+                delete remaining[key];
+            });
+        }
+
+        return { importantMetadata: important, remainingMetadata: remaining };
+    }, [metadata]);
+
+    const hasRemainingMetadata = Object.keys(remainingMetadata).length > 0;
+
+    // Copy to clipboard handler
+    const handleCopy = async (text: string, fieldName: string) => {
+        try {
+            await navigator.clipboard.writeText(text);
+            setCopiedField(fieldName);
+            setTimeout(() => setCopiedField(null), 2000);
+        } catch (error) {
+            console.error('Failed to copy:', error);
+        }
+    };
+
+    // Toggle field expansion
+    const toggleFieldExpansion = (fieldKey: string) => {
+        setExpandedFields(prev => {
+            const newSet = new Set(prev);
+            if (newSet.has(fieldKey)) {
+                newSet.delete(fieldKey);
+            } else {
+                newSet.add(fieldKey);
+            }
+            return newSet;
+        });
+    };
+
+    // Format date/timestamp values
+    const formatDate = (dateString: string): string => {
+        try {
+            const date = new Date(dateString);
+            if (isNaN(date.getTime())) {
+                return dateString; // Not a valid date
+            }
+
+            // Format as: "Jan 5, 2025 at 12:17 PM"
+            const formatted = date.toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+            }) + ' at ' + date.toLocaleTimeString('en-US', {
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+            });
+
+            // Add relative time for recent dates
+            const now = new Date();
+            const diffMs = now.getTime() - date.getTime();
+            const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+            if (diffDays === 0) {
+                return `Today at ${date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}`;
+            } else if (diffDays === 1) {
+                return `Yesterday at ${date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}`;
+            } else if (diffDays < 7) {
+                return `${diffDays} days ago`;
+            }
+
+            return formatted;
+        } catch (error) {
+            return dateString;
+        }
+    };
+
+    // Check if a value is a date/timestamp
+    const isDateField = (key: string, value: any): boolean => {
+        if (typeof value !== 'string') return false;
+
+        // Check if field name suggests it's a date
+        const dateFieldPatterns = ['date', 'time', 'created', 'updated', 'modified', 'deleted', 'scheduled'];
+        const lowerKey = key.toLowerCase();
+        if (!dateFieldPatterns.some(pattern => lowerKey.includes(pattern))) {
+            return false;
+        }
+
+        // Check if value matches ISO date format
+        const isoDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+        return isoDateRegex.test(value);
+    };
+
+    // Format and truncate field value
+    const formatFieldValue = (value: any, key: string, maxLength: number = 150) => {
+        let stringValue: string;
+
+        // Check if it's a date field and format it nicely
+        if (isDateField(key, value)) {
+            stringValue = formatDate(value);
+        } else if (typeof value === 'object' && value !== null) {
+            stringValue = JSON.stringify(value, null, 2);
+        } else {
+            stringValue = String(value);
+        }
+
+        const isExpanded = expandedFields.has(key);
+        const needsTruncation = stringValue.length > maxLength;
+
+        if (!needsTruncation) {
+            return { displayValue: stringValue, needsTruncation: false, isDate: isDateField(key, value) };
+        }
+
+        if (isExpanded) {
+            return { displayValue: stringValue, needsTruncation: true, isDate: isDateField(key, value) };
+        }
+
+        return {
+            displayValue: stringValue.substring(0, maxLength) + '...',
+            needsTruncation: true,
+            isDate: isDateField(key, value)
+        };
+    };
+
+    // Memoized syntax style
+    const syntaxStyle = useMemo(() => isDark ? materialOceanic : oneLight, [isDark]);
+
+    return (
+        <div
+            className={cn(
+                "group relative rounded-xl transition-all duration-300 overflow-hidden",
+                isDark
+                    ? "bg-gradient-to-br from-gray-900/90 to-gray-900/50 border border-gray-800/50 hover:border-gray-700/70 hover:shadow-2xl hover:shadow-blue-900/10"
+                    : "bg-white border border-gray-200/60 hover:border-gray-300/80 hover:shadow-lg hover:shadow-gray-200/50",
+                "backdrop-blur-sm"
+            )}
+        >
+            {/* Header Section */}
+            <div className={cn(
+                "px-5 py-4",
+                isDark ? "border-b border-gray-800/50" : "border-b border-gray-100"
+            )}>
+                <div className="flex items-start justify-between gap-4">
+                    {/* Title with Icon */}
+                    <div className="flex-1 min-w-0">
+                        <div className="flex items-start gap-3">
+                            <div className={cn(
+                                "flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center text-lg",
+                                isDark ? "bg-gray-800/50" : "bg-gray-50"
+                            )}>
+                                {getTypeIcon()}
+                            </div>
+                            <div className="flex-1 min-w-0 pt-0.5">
+                                <h3 className={cn(
+                                    "text-[15px] font-semibold mb-2 break-words leading-snug tracking-tight",
+                                    isDark ? "text-gray-50" : "text-gray-900"
+                                )}>
+                                    {title}
+                                </h3>
+
+                                {/* Context and Type */}
+                                <div className="flex flex-wrap items-center gap-2 mb-2">
+                                    {context && (
+                                        <span className={cn(
+                                            "inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium",
+                                            isDark
+                                                ? "bg-gray-800/60 text-gray-300 border border-gray-700/50"
+                                                : "bg-gray-50 text-gray-600 border border-gray-200/60"
+                                        )}>
+                                            {context}
+                                        </span>
+                                    )}
+                                    <span className={cn(
+                                        "inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium",
+                                        isDark
+                                            ? "bg-blue-950/40 text-blue-300 border border-blue-900/50"
+                                            : "bg-blue-50/80 text-blue-700 border border-blue-200/60"
+                                    )}>
+                                        {entityType}
+                                    </span>
+                                </div>
+
+                                {/* URL Link */}
+                                {url && (
+                                    <a
+                                        href={url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className={cn(
+                                            "inline-flex items-center gap-1.5 text-[12px] font-medium transition-all duration-200 hover:gap-2",
+                                            isDark
+                                                ? "text-blue-400 hover:text-blue-300"
+                                                : "text-blue-600 hover:text-blue-700"
+                                        )}
+                                    >
+                                        <ExternalLink className="h-3 w-3" />
+                                        Open in {formattedSourceName}
+                                    </a>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Score Badge */}
+                    {scoreDisplay && (
+                        <div
+                            className={cn(
+                                "flex-shrink-0 px-2.5 py-1 rounded-lg text-[11px] font-semibold font-mono whitespace-nowrap transition-colors cursor-help",
+                                // Green for high scores
+                                scoreDisplay.color === 'green' && (
+                                    isDark
+                                        ? "bg-green-950/40 text-green-400 border border-green-900/50"
+                                        : "bg-green-50 text-green-700 border border-green-200/60"
+                                ),
+                                // Yellow for medium scores
+                                scoreDisplay.color === 'yellow' && (
+                                    isDark
+                                        ? "bg-yellow-950/40 text-yellow-400 border border-yellow-900/50"
+                                        : "bg-yellow-50 text-yellow-700 border border-yellow-200/60"
+                                ),
+                                // Gray for low scores
+                                scoreDisplay.color === 'gray' && (
+                                    isDark
+                                        ? "bg-gray-800/60 text-gray-400 border border-gray-700/50"
+                                        : "bg-gray-100 text-gray-600 border border-gray-300/60"
+                                )
+                            )}
+                            title={
+                                isNormalizedScore
+                                    ? `Similarity score: ${score.toFixed(4)} (${score >= 0.7 ? 'Excellent' : score >= 0.5 ? 'Good' : 'Fair'} match)`
+                                    : `Relevance score: ${score.toFixed(3)}`
+                            }
+                        >
+                            {scoreDisplay.value}
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {/* Important Metadata Fields - Always visible (max 4) */}
+            {Object.keys(importantMetadata).length > 0 && (
+                <div className={cn(
+                    "px-5 py-4",
+                    isDark ? "bg-gray-900/20 border-y border-gray-800/50" : "bg-gray-50/50 border-y border-gray-100"
+                )}>
+                    <div className="grid grid-cols-2 gap-x-8 gap-y-4">
+                        {Object.entries(importantMetadata).map(([key, value]) => {
+                            const { displayValue, needsTruncation, isDate } = formatFieldValue(value, key);
+                            const isExpanded = expandedFields.has(key);
+
+                            return (
+                                <div key={key} className="flex flex-col gap-1.5">
+                                    <div className="flex items-start gap-3">
+                                        <span className={cn(
+                                            "text-[11px] font-semibold uppercase tracking-wider min-w-[90px] pt-0.5",
+                                            isDark ? "text-gray-500" : "text-gray-500"
+                                        )}>
+                                            {key}
+                                        </span>
+                                        <span className={cn(
+                                            "text-[13px] break-words flex-1 leading-relaxed",
+                                            isDate && "inline-flex items-center gap-1.5",
+                                            isDark ? "text-gray-200" : "text-gray-700"
+                                        )}>
+                                            {isDate && <Clock className="h-3.5 w-3.5 opacity-60 flex-shrink-0" />}
+                                            {displayValue}
+                                        </span>
+                                    </div>
+                                    {needsTruncation && (
+                                        <button
+                                            onClick={() => toggleFieldExpansion(key)}
+                                            className={cn(
+                                                "text-[11px] font-medium self-start ml-[90px] transition-all duration-200 hover:translate-x-0.5",
+                                                isDark
+                                                    ? "text-blue-400 hover:text-blue-300"
+                                                    : "text-blue-600 hover:text-blue-700"
+                                            )}
+                                        >
+                                            {isExpanded ? '← Show Less' : 'Show More →'}
+                                        </button>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
+
+                    {/* Show More/Less Button for Additional Metadata */}
+                    {hasRemainingMetadata && (
+                        <>
+                            <button
+                                onClick={() => setIsMetadataExpanded(!isMetadataExpanded)}
+                                className={cn(
+                                    "mt-4 inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-[11px] font-semibold transition-all duration-200",
+                                    isDark
+                                        ? "text-blue-400 hover:text-blue-300 bg-blue-950/30 hover:bg-blue-950/50 border border-blue-900/50"
+                                        : "text-blue-600 hover:text-blue-700 bg-blue-50/50 hover:bg-blue-50 border border-blue-200/60"
+                                )}
+                            >
+                                {isMetadataExpanded ? (
+                                    <>
+                                        <ChevronDown className="h-3.5 w-3.5" />
+                                        Show Less
+                                    </>
+                                ) : (
+                                    <>
+                                        <ChevronRight className="h-3.5 w-3.5" />
+                                        {Object.keys(remainingMetadata).length} More Field{Object.keys(remainingMetadata).length !== 1 ? 's' : ''}
+                                    </>
+                                )}
+                            </button>
+
+                            {/* Additional Metadata - Collapsible */}
+                            {isMetadataExpanded && (
+                                <div className={cn(
+                                    "grid grid-cols-2 gap-x-8 gap-y-4 mt-4 pt-4",
+                                    isDark ? "border-t border-gray-800/50" : "border-t border-gray-200/50"
+                                )}>
+                                    {Object.entries(remainingMetadata).map(([key, value]) => {
+                                        const { displayValue, needsTruncation, isDate } = formatFieldValue(value, key);
+                                        const isExpanded = expandedFields.has(key);
+
+                                        return (
+                                            <div key={key} className="flex flex-col gap-1.5">
+                                                <div className="flex items-start gap-3">
+                                                    <span className={cn(
+                                                        "text-[11px] font-semibold uppercase tracking-wider min-w-[90px] pt-0.5",
+                                                        isDark ? "text-gray-500" : "text-gray-500"
+                                                    )}>
+                                                        {key}
+                                                    </span>
+                                                    <span className={cn(
+                                                        "text-[13px] break-words flex-1 leading-relaxed",
+                                                        isDate && "inline-flex items-center gap-1.5",
+                                                        isDark ? "text-gray-200" : "text-gray-700"
+                                                    )}>
+                                                        {isDate && <Clock className="h-3.5 w-3.5 opacity-60 flex-shrink-0" />}
+                                                        {displayValue}
+                                                    </span>
+                                                </div>
+                                                {needsTruncation && (
+                                                    <button
+                                                        onClick={() => toggleFieldExpansion(key)}
+                                                        className={cn(
+                                                            "text-[11px] font-medium self-start ml-[90px] transition-all duration-200 hover:translate-x-0.5",
+                                                            isDark
+                                                                ? "text-blue-400 hover:text-blue-300"
+                                                                : "text-blue-600 hover:text-blue-700"
+                                                        )}
+                                                    >
+                                                        {isExpanded ? '← Show Less' : 'Show More →'}
+                                                    </button>
+                                                )}
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </>
+                    )}
+                </div>
+            )}
+
+            {/* Main Content - Parsed content from embeddable text */}
+            {content && (
+                <div className={cn(
+                    "px-5 py-4",
+                    isDark ? "text-gray-200" : "text-gray-800"
+                )}>
+                    <div className="relative">
+                        <button
+                            onClick={() => handleCopy(content, 'content')}
+                            className={cn(
+                                "absolute top-0 right-0 p-1.5 rounded-lg transition-all duration-200 z-10",
+                                isDark
+                                    ? "hover:bg-gray-800/80 text-gray-400 hover:text-gray-300"
+                                    : "hover:bg-gray-100 text-gray-600 hover:text-gray-700"
+                            )}
+                            title="Copy content"
+                        >
+                            {copiedField === 'content' ? (
+                                <Check className="h-3.5 w-3.5" />
+                            ) : (
+                                <Copy className="h-3.5 w-3.5" />
+                            )}
+                        </button>
+
+                        {/* Container for content with truncation */}
+                        <div className="relative">
+                            <div className={cn(
+                                !isContentExpanded && content.length > 500 && "max-h-[200px] overflow-hidden"
+                            )}>
+                                <ReactMarkdown
+                                    remarkPlugins={[remarkGfm]}
+                                    components={{
+                                        h1: ({ node, ...props }) => <h1 className="text-base font-bold mt-4 mb-2 first:mt-0" {...props} />,
+                                        h2: ({ node, ...props }) => <h2 className="text-sm font-bold mt-3 mb-2 first:mt-0" {...props} />,
+                                        h3: ({ node, ...props }) => <h3 className="text-sm font-semibold mt-3 mb-1.5 first:mt-0" {...props} />,
+                                        p: ({ node, ...props }) => <p className="text-[13px] leading-relaxed mb-2" {...props} />,
+                                        ul: ({ node, ...props }) => <ul className="list-disc pl-5 mb-2 space-y-1 text-[13px]" {...props} />,
+                                        ol: ({ node, ...props }) => <ol className="list-decimal pl-5 mb-2 space-y-1 text-[13px]" {...props} />,
+                                        li: ({ node, ...props }) => <li className="text-[13px] leading-relaxed" {...props} />,
+                                        blockquote: ({ node, ...props }) => (
+                                            <blockquote className={cn(
+                                                "border-l-4 pl-3 my-2 italic text-[13px]",
+                                                isDark ? "border-gray-600 text-gray-400" : "border-gray-300 text-gray-600"
+                                            )} {...props} />
+                                        ),
+                                        code(props) {
+                                            const { children, className, node, ...rest } = props;
+                                            const match = /language-(\w+)/.exec(className || '');
+                                            return match ? (
+                                                <SyntaxHighlighter
+                                                    language={match[1]}
+                                                    style={syntaxStyle}
+                                                    customStyle={{
+                                                        margin: '0.5rem 0',
+                                                        borderRadius: '0.375rem',
+                                                        fontSize: '0.75rem',
+                                                        padding: '0.75rem',
+                                                        background: isDark ? 'rgba(17, 24, 39, 0.8)' : 'rgba(249, 250, 251, 0.95)'
+                                                    }}
+                                                >
+                                                    {String(children).replace(/\n$/, '')}
+                                                </SyntaxHighlighter>
+                                            ) : (
+                                                <code className={cn(
+                                                    "px-1.5 py-0.5 rounded text-[11px] font-mono",
+                                                    isDark
+                                                        ? "bg-gray-800 text-gray-300"
+                                                        : "bg-gray-100 text-gray-800"
+                                                )} {...rest}>
+                                                    {children}
+                                                </code>
+                                            );
+                                        },
+                                        strong: ({ node, ...props }) => <strong className="font-semibold" {...props} />,
+                                        em: ({ node, ...props }) => <em className="italic" {...props} />,
+                                    }}
+                                >
+                                    {content}
+                                </ReactMarkdown>
+                            </div>
+
+                            {/* Fade overlay when content is truncated */}
+                            {!isContentExpanded && content.length > 500 && (
+                                <div className={cn(
+                                    "absolute bottom-0 left-0 right-0 h-16 pointer-events-none",
+                                    isDark
+                                        ? "bg-gradient-to-t from-gray-900 to-transparent"
+                                        : "bg-gradient-to-t from-white to-transparent"
+                                )} />
+                            )}
+                        </div>
+
+                        {/* Show More/Less button for long content */}
+                        {content.length > 500 && (
+                            <button
+                                onClick={() => setIsContentExpanded(!isContentExpanded)}
+                                className={cn(
+                                    "mt-4 inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-[11px] font-semibold transition-all duration-200",
+                                    isDark
+                                        ? "text-blue-400 hover:text-blue-300 bg-blue-950/30 hover:bg-blue-950/50 border border-blue-900/50"
+                                        : "text-blue-600 hover:text-blue-700 bg-blue-50/50 hover:bg-blue-50 border border-blue-200/60"
+                                )}
+                            >
+                                {isContentExpanded ? (
+                                    <>
+                                        <ChevronDown className="h-3.5 w-3.5" />
+                                        Show Less
+                                    </>
+                                ) : (
+                                    <>
+                                        <ChevronRight className="h-3.5 w-3.5" />
+                                        Show Full Content
+                                    </>
+                                )}
+                            </button>
+                        )}
+                    </div>
+                </div>
+            )}
+
+
+            {/* Raw JSON View - Collapsible (for debugging) */}
+            <div className={cn(
+                "border-t",
+                isDark ? "border-gray-800/50" : "border-gray-100"
+            )}>
+                <button
+                    onClick={() => setIsRawExpanded(!isRawExpanded)}
+                    className={cn(
+                        "w-full px-5 py-3 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-wider transition-all duration-200",
+                        isDark
+                            ? "text-gray-500 hover:text-gray-400 hover:bg-gray-900/30"
+                            : "text-gray-500 hover:text-gray-600 hover:bg-gray-50/50"
+                    )}
+                >
+                    {isRawExpanded ? (
+                        <ChevronDown className="h-3 w-3" />
+                    ) : (
+                        <ChevronRight className="h-3 w-3" />
+                    )}
+                    View Raw Data
+                </button>
+
+                {isRawExpanded && (
+                    <div className="px-4 pb-3">
+                        <div className="relative">
+                            <button
+                                onClick={() => handleCopy(JSON.stringify(payload, null, 2), 'raw')}
+                                className={cn(
+                                    "absolute top-2 right-2 p-1 rounded transition-colors z-10",
+                                    isDark
+                                        ? "hover:bg-gray-800 text-gray-400"
+                                        : "hover:bg-gray-100 text-gray-600"
+                                )}
+                            >
+                                {copiedField === 'raw' ? (
+                                    <Check className="h-3 w-3" />
+                                ) : (
+                                    <Copy className="h-3 w-3" />
+                                )}
+                            </button>
+                            <SyntaxHighlighter
+                                language="json"
+                                style={syntaxStyle}
+                                customStyle={{
+                                    margin: 0,
+                                    borderRadius: '0.375rem',
+                                    fontSize: '0.65rem',
+                                    padding: '0.75rem',
+                                    background: isDark ? 'rgba(17, 24, 39, 0.8)' : 'rgba(249, 250, 251, 0.95)',
+                                    maxHeight: '300px',
+                                    overflow: 'auto'
+                                }}
+                            >
+                                {JSON.stringify(payload, null, 2)}
+                            </SyntaxHighlighter>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/frontend/src/search/EntityResultCard.tsx
+++ b/frontend/src/search/EntityResultCard.tsx
@@ -362,17 +362,17 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
         >
             {/* Header Section */}
             <div className={cn(
-                "px-5 py-4",
+                "px-4 py-3",
                 isDark ? "border-b border-gray-800/50" : "border-b border-gray-100"
             )}>
-                <div className="flex items-start justify-between gap-4">
+                <div className="flex items-start justify-between gap-3">
                     {/* Title with Icon */}
                     <div className="flex-1 min-w-0">
-                        <div className="flex items-start gap-3">
+                        <div className="flex items-start gap-2.5">
                             {/* Source Icon */}
                             <div
                                 className={cn(
-                                    "flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center overflow-hidden",
+                                    "flex-shrink-0 w-8 h-8 rounded-lg flex items-center justify-center overflow-hidden",
                                     isDark ? "bg-gray-800/50" : "bg-gray-50"
                                 )}
                                 title={formattedSourceName}
@@ -388,14 +388,14 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
                             </div>
                             <div className="flex-1 min-w-0 pt-0.5">
                                 <h3 className={cn(
-                                    "text-[15px] font-semibold mb-2 break-words leading-snug tracking-tight",
+                                    "text-[14px] font-semibold mb-1.5 break-words leading-snug tracking-tight",
                                     isDark ? "text-gray-50" : "text-gray-900"
                                 )}>
                                     {title}
                                 </h3>
 
                                 {/* Context and Type */}
-                                <div className="flex flex-wrap items-center gap-2 mb-2">
+                                <div className="flex flex-wrap items-center gap-1.5 mb-1.5">
                                     {/* Source Badge */}
                                     <span className={cn(
                                         "inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium",
@@ -551,7 +551,7 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
                     <button
                         onClick={() => setIsPreviewExpanded(!isPreviewExpanded)}
                         className={cn(
-                            "w-full px-5 py-3 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-wider transition-all duration-200",
+                            "w-full px-4 py-2 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-wider transition-all duration-200",
                             isDark
                                 ? "text-gray-500 hover:text-gray-400 hover:bg-gray-900/30"
                                 : "text-gray-500 hover:text-gray-600 hover:bg-gray-50/50"
@@ -575,7 +575,7 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
 
                     {isPreviewExpanded && (
                         <div className={cn(
-                            "px-5 pb-4",
+                            "px-4 pb-3",
                             isDark ? "text-gray-200" : "text-gray-800"
                         )}>
                             <div className="relative">
@@ -704,7 +704,7 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
                     <button
                         onClick={() => setIsPropertiesExpanded(!isPropertiesExpanded)}
                         className={cn(
-                            "w-full px-5 py-3 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-wider transition-all duration-200",
+                            "w-full px-4 py-2 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-wider transition-all duration-200",
                             isDark
                                 ? "text-gray-500 hover:text-gray-400 hover:bg-gray-900/30"
                                 : "text-gray-500 hover:text-gray-600 hover:bg-gray-50/50"
@@ -728,7 +728,7 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
 
                     {isPropertiesExpanded && (
                         <div className={cn(
-                            "px-5 pb-3",
+                            "px-4 pb-2.5",
                             isDark ? "bg-gray-900/20" : "bg-gray-50/50"
                         )}>
                             <div className="grid grid-cols-2 gap-x-6 gap-y-2.5">
@@ -858,7 +858,7 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
                 <button
                     onClick={() => setIsRawExpanded(!isRawExpanded)}
                     className={cn(
-                        "w-full px-5 py-3 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-wider transition-all duration-200",
+                        "w-full px-4 py-2 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-wider transition-all duration-200",
                         isDark
                             ? "text-gray-500 hover:text-gray-400 hover:bg-gray-900/30"
                             : "text-gray-500 hover:text-gray-600 hover:bg-gray-50/50"

--- a/frontend/src/search/EntityResultCard.tsx
+++ b/frontend/src/search/EntityResultCard.tsx
@@ -355,8 +355,8 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
             className={cn(
                 "group relative rounded-xl transition-all duration-300 overflow-hidden raw-data-scrollbar",
                 isDark
-                    ? "bg-gradient-to-br from-gray-900/90 to-gray-900/50 border border-gray-800/50 hover:border-gray-700/70 hover:shadow-2xl hover:shadow-blue-900/10"
-                    : "bg-white border border-gray-200/60 hover:border-gray-300/80 hover:shadow-lg hover:shadow-gray-200/50",
+                    ? "bg-gradient-to-br from-gray-900/90 to-gray-900/50 border border-gray-800/50"
+                    : "bg-white border border-gray-200/60",
                 "backdrop-blur-sm"
             )}
         >

--- a/frontend/src/search/EntityResultCard.tsx
+++ b/frontend/src/search/EntityResultCard.tsx
@@ -7,6 +7,7 @@ import { materialOceanic, oneLight } from 'react-syntax-highlighter/dist/esm/sty
 import { ChevronDown, ChevronRight, ExternalLink, Copy, Check, Link as LinkIcon, Clock } from 'lucide-react';
 import { getAppIconUrl } from '@/lib/utils/icons';
 import { useTheme } from '@/lib/theme-provider';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface EntityResultCardProps {
     result: any;
@@ -446,84 +447,97 @@ export const EntityResultCard: React.FC<EntityResultCardProps> = ({
                         </div>
                     </div>
 
-                    {/* Top-right badges: Result number + Score */}
-                    <div className="flex flex-col items-end gap-1.5">
-                        {/* Result Number Badge - Clean and minimal */}
-                        <div className={cn(
-                            "flex-shrink-0 px-2.5 py-1 rounded-full text-[10px] font-bold tracking-wide",
-                            isDark
-                                ? "bg-gray-800/80 text-gray-300 border border-gray-700/60 shadow-sm"
-                                : "bg-white text-gray-600 border border-gray-200 shadow-sm"
-                        )}>
-                            #{index + 1}
-                        </div>
+                    {/* Unified badge: Result number + Score */}
+                    {scoreDisplay && (
+                        <TooltipProvider delayDuration={200}>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <div
+                                        className={cn(
+                                            "flex-shrink-0 flex items-center gap-2 px-3 py-1 rounded-full text-[11px] font-semibold whitespace-nowrap transition-all duration-200 cursor-help shadow-sm hover:shadow-md",
+                                            // Green for high scores - vibrant and clean
+                                            scoreDisplay.color === 'green' && (
+                                                isDark
+                                                    ? "bg-emerald-500/15 text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/20"
+                                                    : "bg-emerald-50 text-emerald-700 border border-emerald-200 hover:bg-emerald-100"
+                                            ),
+                                            // Yellow for medium scores - warm and inviting
+                                            scoreDisplay.color === 'yellow' && (
+                                                isDark
+                                                    ? "bg-amber-500/15 text-amber-400 border border-amber-500/30 hover:bg-amber-500/20"
+                                                    : "bg-amber-50 text-amber-700 border border-amber-200 hover:bg-amber-100"
+                                            ),
+                                            // Gray for low scores - subtle and professional
+                                            scoreDisplay.color === 'gray' && (
+                                                isDark
+                                                    ? "bg-gray-700/40 text-gray-400 border border-gray-600/50 hover:bg-gray-700/50"
+                                                    : "bg-gray-100 text-gray-600 border border-gray-300 hover:bg-gray-150"
+                                            )
+                                        )}
+                                    >
+                                        {/* Result number */}
+                                        <span className="font-bold tracking-wider opacity-70">#{index + 1}</span>
 
-                        {/* Score Badge - Modern with icon and better visual hierarchy */}
-                        {scoreDisplay && (
-                            <div
-                                className={cn(
-                                    "flex-shrink-0 flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-semibold whitespace-nowrap transition-all duration-200 cursor-help shadow-sm hover:shadow-md",
-                                    // Green for high scores - vibrant and clean
-                                    scoreDisplay.color === 'green' && (
-                                        isDark
-                                            ? "bg-emerald-500/15 text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/20"
-                                            : "bg-emerald-50 text-emerald-700 border border-emerald-200 hover:bg-emerald-100"
-                                    ),
-                                    // Yellow for medium scores - warm and inviting
-                                    scoreDisplay.color === 'yellow' && (
-                                        isDark
-                                            ? "bg-amber-500/15 text-amber-400 border border-amber-500/30 hover:bg-amber-500/20"
-                                            : "bg-amber-50 text-amber-700 border border-amber-200 hover:bg-amber-100"
-                                    ),
-                                    // Gray for low scores - subtle and professional
-                                    scoreDisplay.color === 'gray' && (
-                                        isDark
-                                            ? "bg-gray-700/40 text-gray-400 border border-gray-600/50 hover:bg-gray-700/50"
-                                            : "bg-gray-100 text-gray-600 border border-gray-300 hover:bg-gray-150"
-                                    )
-                                )}
-                                title={
-                                    isNormalizedScore
-                                        ? `Vector similarity: ${score.toFixed(4)} (${score >= 0.7 ? 'Excellent' : score >= 0.5 ? 'Good' : 'Fair'} match)\n\nNote: Results are reordered by AI to prioritize topical relevance. The position may differ from similarity scores.`
-                                        : `Search score: ${score.toFixed(3)}\n\nNote: Results are reordered by AI to prioritize topical relevance.`
-                                }
-                            >
-                                {/* Sparkle icon for high scores, target for others */}
-                                <svg
+                                        {/* Divider */}
+                                        <div className={cn(
+                                            "w-px h-3 opacity-30",
+                                            isDark ? "bg-gray-400" : "bg-gray-600"
+                                        )} />
+
+                                        {/* Score */}
+                                        <span className="font-mono tracking-tight">{scoreDisplay.value}</span>
+                                    </div>
+                                </TooltipTrigger>
+                                <TooltipContent
+                                    side="left"
                                     className={cn(
-                                        "w-3 h-3 flex-shrink-0",
-                                        scoreDisplay.color === 'green' && "opacity-80"
+                                        "px-3 py-2.5 max-w-[280px] backdrop-blur-sm",
+                                        isDark
+                                            ? "bg-gray-900/95 border border-gray-700/50 shadow-xl"
+                                            : "bg-white/95 border border-gray-200 shadow-lg"
                                     )}
-                                    viewBox="0 0 24 24"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeWidth="2"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
                                 >
-                                    {scoreDisplay.color === 'green' ? (
-                                        // Sparkle icon for high scores
-                                        <>
-                                            <path d="M12 3v18" />
-                                            <path d="M3 12h18" />
-                                            <path d="m19 19-2.5-2.5" />
-                                            <path d="m19 5-2.5 2.5" />
-                                            <path d="m5 19 2.5-2.5" />
-                                            <path d="m5 5 2.5 2.5" />
-                                        </>
-                                    ) : (
-                                        // Target/bullseye icon for medium/low scores
-                                        <>
-                                            <circle cx="12" cy="12" r="10" />
-                                            <circle cx="12" cy="12" r="6" />
-                                            <circle cx="12" cy="12" r="2" />
-                                        </>
-                                    )}
-                                </svg>
-                                <span className="font-mono tracking-tight">{scoreDisplay.value}</span>
-                            </div>
-                        )}
-                    </div>
+                                    <div className="space-y-2">
+                                        {/* Result number */}
+                                        <div className={cn(
+                                            "text-[11px] font-bold tracking-wide",
+                                            isDark ? "text-gray-300" : "text-gray-700"
+                                        )}>
+                                            Result #{index + 1}
+                                        </div>
+
+                                        {/* Similarity score */}
+                                        <div className={cn(
+                                            "text-[12px]",
+                                            isDark ? "text-gray-400" : "text-gray-600"
+                                        )}>
+                                            <span className="font-medium">Similarity:</span>{' '}
+                                            <span className="font-semibold">
+                                                {isNormalizedScore
+                                                    ? `${(score * 100).toFixed(1)}%`
+                                                    : score.toFixed(3)
+                                                }
+                                            </span>
+                                        </div>
+
+                                        {/* Divider */}
+                                        <div className={cn(
+                                            "h-px w-full",
+                                            isDark ? "bg-gray-700/50" : "bg-gray-200"
+                                        )} />
+
+                                        {/* Explanation */}
+                                        <div className={cn(
+                                            "text-[11px] leading-relaxed",
+                                            isDark ? "text-gray-500" : "text-gray-500"
+                                        )}>
+                                            Position determined by semantic reranking to maximize topical relevance.
+                                        </div>
+                                    </div>
+                                </TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
+                    )}
                 </div>
             </div>
 

--- a/frontend/src/search/SearchResponse.tsx
+++ b/frontend/src/search/SearchResponse.tsx
@@ -32,6 +32,7 @@ import { CollapsibleCard } from '@/components/ui/CollapsibleCard';
 import { FiLayers, FiFilter, FiSliders, FiList, FiClock, FiGitMerge, FiType } from "react-icons/fi";
 import { ChartScatter } from 'lucide-react';
 import type { SearchEvent } from '@/search/types';
+import { EntityResultCard } from './EntityResultCard';
 
 interface SearchResponseProps {
     searchResponse: any;
@@ -1679,33 +1680,18 @@ export const SearchResponse: React.FC<SearchResponseProps> = ({
                                         </div>
                                     ) : (
                                         <div className={cn(
-                                            DESIGN_SYSTEM.spacing.padding.compact,
+                                            "px-4 py-3 space-y-4",
                                             DESIGN_SYSTEM.typography.sizes.label
-                                        )} ref={jsonViewerRef}>
-                                            <JsonViewer
-                                                value={results}
-                                                theme={isDark ? "dark" : "light"}
-                                                style={{
-                                                    fontSize: '0.62rem',
-                                                    fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
-                                                }}
-                                                rootName={false}
-                                                displayDataTypes={false}
-                                                enableClipboard={false}
-                                                quotesOnKeys={false}
-                                                indentWidth={2}
-                                                collapseStringsAfterLength={100}
-                                                groupArraysAfterLength={100}
-                                                defaultInspectDepth={10}
-                                                defaultInspectControl={(path, value) => {
-                                                    // Collapse airweave_system_metadata by default
-                                                    if (path.includes('airweave_system_metadata')) {
-                                                        return false;
-                                                    }
-                                                    // Expand all other nodes by default for better entity visibility
-                                                    return true;
-                                                }}
-                                            />
+                                        )}>
+                                            {results.map((result: any, index: number) => (
+                                                <EntityResultCard
+                                                    key={result.payload?.entity_id || result.id || index}
+                                                    result={result}
+                                                    index={index}
+                                                    isDark={isDark}
+                                                    onEntityIdClick={handleEntityClick}
+                                                />
+                                            ))}
                                         </div>
                                     )}
                                 </div>

--- a/frontend/src/search/SearchResponse.tsx
+++ b/frontend/src/search/SearchResponse.tsx
@@ -1680,7 +1680,7 @@ export const SearchResponse: React.FC<SearchResponseProps> = ({
                                         </div>
                                     ) : (
                                         <div className={cn(
-                                            "px-4 py-3 space-y-4",
+                                            "px-4 py-3 space-y-4 raw-data-scrollbar",
                                             DESIGN_SYSTEM.typography.sizes.label
                                         )}>
                                             {results.map((result: any, index: number) => (

--- a/frontend/src/search/SearchResponse.tsx
+++ b/frontend/src/search/SearchResponse.tsx
@@ -1381,7 +1381,7 @@ export const SearchResponse: React.FC<SearchResponseProps> = ({
                         {/* Trace Tab Content */}
                         <div style={{ display: activeTab === 'trace' ? 'block' : 'none' }}>
                             <div ref={traceContainerRef} onScroll={handleTraceScroll} className={cn(
-                                "overflow-auto max-h-[438px]",
+                                "overflow-auto max-h-[700px] raw-data-scrollbar",
                                 DESIGN_SYSTEM.spacing.padding.compact,
                                 isDark ? "bg-gray-950" : "bg-white"
                             )}>
@@ -1437,7 +1437,7 @@ export const SearchResponse: React.FC<SearchResponseProps> = ({
 
 
                                 <div className={cn(
-                                    "overflow-auto max-h-[438px] leading-relaxed",
+                                    "overflow-auto max-h-[700px] leading-relaxed raw-data-scrollbar",
                                     DESIGN_SYSTEM.spacing.padding.compact,
                                     DESIGN_SYSTEM.typography.sizes.body,
                                     isDark ? "bg-gray-900 text-gray-200" : "bg-white text-gray-800"
@@ -1652,7 +1652,7 @@ export const SearchResponse: React.FC<SearchResponseProps> = ({
                         {(results.length > 0 || isSearching) && (
                             <div style={{ display: activeTab === 'entities' ? 'block' : 'none' }}>
                                 <div className={cn(
-                                    "overflow-auto max-h-[438px]",
+                                    "overflow-auto max-h-[700px] raw-data-scrollbar",
                                     isDark ? "bg-gray-900" : "bg-white"
                                 )}>
                                     {isSearching ? (
@@ -1680,7 +1680,7 @@ export const SearchResponse: React.FC<SearchResponseProps> = ({
                                         </div>
                                     ) : (
                                         <div className={cn(
-                                            "px-4 py-3 space-y-4 raw-data-scrollbar",
+                                            "px-4 py-3 space-y-3 raw-data-scrollbar",
                                             DESIGN_SYSTEM.typography.sizes.label
                                         )}>
                                             {results.map((result: any, index: number) => (


### PR DESCRIPTION
<img width="893" height="870" alt="image" src="https://github.com/user-attachments/assets/7da72cc8-91c8-4536-91b0-4702a24812ab" />
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Redesigned the Entities tab to render human-readable cards with Markdown previews and key metadata, and added a new Raw tab for full JSON inspection. This improves clarity, navigation, and reduces unnecessary re-renders.

- **New Features**
  - Entities tab now uses EntityResultCard for each result with Markdown preview, collapsible Properties, and Raw Data.
  - Unified badge shows result index and similarity with a helpful tooltip; color-coded by score.
  - Dynamic source icons, context/type badges, and an external link to open the item in its source.
  - New Raw tab to view the full searchResponse JSON with custom scrollbars and taller panels.
  - Preview text is reformatted for cleaner Markdown display; response time now shows in seconds.

- **Performance**
  - Memoized EntityResultCard with a prop comparison to prevent unnecessary re-renders.
  - Tab changes use startTransition for smoother interactions.
  - Auto-switching respects user selections and avoids overriding after completion.

<!-- End of auto-generated description by cubic. -->

