### PR TITLE
feat: feature flags

### DIFF
--- a/.cursor/rules/feature-flags.mdc
+++ b/.cursor/rules/feature-flags.mdc
@@ -1,0 +1,110 @@
+---
+alwaysApply: false
+---
+
+# Feature Flags
+
+## Overview
+Lightweight organization-level feature flags for gating features. Table name is `feature_flag` (org is implied).
+
+## Backend Usage
+
+### Enum (`FeatureFlag`)
+```python
+from airweave.core.shared_models import FeatureFlag
+
+# Check in endpoints via ApiContext
+if not ctx.has_feature(FeatureFlag.S3_DESTINATION):
+    raise HTTPException(403, "Feature not available")
+```
+
+### CRUD Operations
+Integrated into `crud.organization`:
+```python
+from airweave import crud
+
+# Enable/disable flags
+await crud.organization.enable_feature(db, org_id, FeatureFlag.S3_DESTINATION)
+await crud.organization.disable_feature(db, org_id, FeatureFlag.WHITE_LABEL)
+
+# Query flags
+flags = await crud.organization.get_org_features(db, org_id)
+
+# Bulk operations
+await crud.organization.bulk_enable_features(db, org_id, [
+    FeatureFlag.S3_DESTINATION,
+    FeatureFlag.PRIORITY_SUPPORT
+])
+```
+
+### Schema Handling
+Organization schemas automatically extract `enabled_features` from the `feature_flags` relationship using Pydantic validators (handles async context properly).
+
+## Frontend Usage
+```typescript
+import { useOrganizationStore } from '@/lib/stores/organizations';
+import { FeatureFlags } from '@/lib/constants/feature-flags';
+
+const hasFeature = useOrganizationStore((state) => state.hasFeature);
+
+{hasFeature(FeatureFlags.S3_DESTINATION) && <S3DestinationCard />}
+```
+
+## Adding New Flags
+1. Add to `FeatureFlag` enum in `backend/airweave/core/shared_models.py`
+2. Add to `FeatureFlags` constants in `frontend/src/lib/constants/feature-flags.ts`
+3. Enable for organizations via CRUD or admin panel
+
+
+# Feature Flags
+
+## Overview
+Lightweight organization-level feature flags for gating features. Table name is `feature_flag` (org is implied).
+
+## Backend Usage
+
+### Enum (`FeatureFlag`)
+```python
+from airweave.core.shared_models import FeatureFlag
+
+# Check in endpoints via ApiContext
+if not ctx.has_feature(FeatureFlag.S3_DESTINATION):
+    raise HTTPException(403, "Feature not available")
+```
+
+### CRUD Operations
+Integrated into `crud.organization`:
+```python
+from airweave import crud
+
+# Enable/disable flags
+await crud.organization.enable_feature(db, org_id, FeatureFlag.S3_DESTINATION)
+await crud.organization.disable_feature(db, org_id, FeatureFlag.WHITE_LABEL)
+
+# Query flags
+flags = await crud.organization.get_org_features(db, org_id)
+
+# Bulk operations
+await crud.organization.bulk_enable_features(db, org_id, [
+    FeatureFlag.S3_DESTINATION,
+    FeatureFlag.PRIORITY_SUPPORT
+])
+```
+
+### Schema Handling
+Organization schemas automatically extract `enabled_features` from the `feature_flags` relationship using Pydantic validators (handles async context properly).
+
+## Frontend Usage
+```typescript
+import { useOrganizationStore } from '@/lib/stores/organizations';
+import { FeatureFlags } from '@/lib/constants/feature-flags';
+
+const hasFeature = useOrganizationStore((state) => state.hasFeature);
+
+{hasFeature(FeatureFlags.S3_DESTINATION) && <S3DestinationCard />}
+```
+
+## Adding New Flags
+1. Add to `FeatureFlag` enum in `backend/airweave/core/shared_models.py`
+2. Add to `FeatureFlags` constants in `frontend/src/lib/constants/feature-flags.ts`
+3. Enable for organizations via CRUD or admin panel

--- a/backend/airweave/api/context.py
+++ b/backend/airweave/api/context.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from airweave import schemas
 from airweave.core.logging import ContextualLogger
+from airweave.core.shared_models import FeatureFlag as FeatureFlagEnum
 
 
 class ApiContext(BaseModel):
@@ -62,6 +63,22 @@ class ApiContext(BaseModel):
     def is_user_auth(self) -> bool:
         """Whether this is user authentication (Auth0)."""
         return self.auth_method == "auth0"
+
+    def has_feature(self, flag: FeatureFlagEnum) -> bool:
+        """Check if organization has a feature enabled.
+
+        Args:
+            flag: Feature flag to check (use FeatureFlag enum from core.shared_models)
+
+        Returns:
+            True if enabled, False otherwise
+
+        Example:
+            from airweave.core.shared_models import FeatureFlag
+            if ctx.has_feature(FeatureFlag.S3_DESTINATION):
+                # Feature is enabled for this organization
+        """
+        return flag in self.organization.enabled_features
 
     def __str__(self) -> str:
         """String representation for logging."""

--- a/backend/airweave/core/shared_models.py
+++ b/backend/airweave/core/shared_models.py
@@ -66,3 +66,13 @@ class ActionType(str, Enum):
     QUERIES = "queries"
     SOURCE_CONNECTIONS = "source_connections"
     TEAM_MEMBERS = "team_members"
+
+
+class FeatureFlag(str, Enum):
+    """Available feature flags in Airweave.
+
+    Add new flags here to enable feature gating at the organization level.
+    """
+
+    S3_DESTINATION = "s3_destination"
+    PRIORITY_SUPPORT = "priority_support"

--- a/backend/airweave/models/__init__.py
+++ b/backend/airweave/models/__init__.py
@@ -13,6 +13,7 @@ from .entity import Entity
 from .entity_count import EntityCount
 from .entity_definition import EntityDefinition
 from .entity_relation import EntityRelation
+from .feature_flag import FeatureFlag
 from .integration_credential import IntegrationCredential
 from .organization import Organization
 from .organization_billing import OrganizationBilling
@@ -45,6 +46,7 @@ __all__ = [
     "EmbeddingModel",
     "EntityDefinition",
     "EntityRelation",
+    "FeatureFlag",
     "IntegrationCredential",
     "Organization",
     "OrganizationBilling",

--- a/backend/airweave/models/feature_flag.py
+++ b/backend/airweave/models/feature_flag.py
@@ -1,0 +1,35 @@
+"""Organization feature flag model."""
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Boolean, ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from airweave.models._base import Base
+
+if TYPE_CHECKING:
+    from airweave.models.organization import Organization
+
+
+class FeatureFlag(Base):
+    """Organization-specific feature flag assignments.
+
+    N-to-1 relationship: Multiple flags per organization.
+    Ensures each flag can only be assigned once per organization.
+    """
+
+    __tablename__ = "feature_flag"
+
+    organization_id: Mapped[UUID] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    flag: Mapped[str] = mapped_column(String(100), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    # Relationships
+    organization: Mapped["Organization"] = relationship(
+        "Organization", back_populates="feature_flags", lazy="noload"
+    )
+
+    __table_args__ = (UniqueConstraint("organization_id", "flag", name="uq_org_flag"),)

--- a/backend/airweave/models/organization.py
+++ b/backend/airweave/models/organization.py
@@ -9,6 +9,7 @@ from airweave.models._base import Base
 
 if TYPE_CHECKING:
     from airweave.models.billing_period import BillingPeriod
+    from airweave.models.feature_flag import FeatureFlag
     from airweave.models.organization_billing import OrganizationBilling
     from airweave.models.usage import Usage
     from airweave.models.user_organization import UserOrganization
@@ -58,4 +59,12 @@ class Organization(Base):
         cascade="all, delete-orphan",
         lazy="noload",
         order_by="desc(BillingPeriod.period_start)",  # Most recent first
+    )
+
+    # Relationship with feature flags (eager loaded for ApiContext)
+    feature_flags: Mapped[List["FeatureFlag"]] = relationship(
+        "FeatureFlag",
+        back_populates="organization",
+        cascade="all, delete-orphan",
+        lazy="selectin",  # Auto-load for feature checking
     )

--- a/backend/airweave/schemas/admin.py
+++ b/backend/airweave/schemas/admin.py
@@ -1,10 +1,12 @@
 """Admin-specific schemas for enhanced dashboard views."""
 
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
+
+from airweave.core.shared_models import FeatureFlag as FeatureFlagEnum
 
 
 class OrganizationMetrics(BaseModel):
@@ -43,6 +45,11 @@ class OrganizationMetrics(BaseModel):
     is_member: bool = Field(False, description="Whether the current admin user is already a member")
     member_role: Optional[str] = Field(
         None, description="Admin's role in this organization (if member)"
+    )
+
+    # Feature flags
+    enabled_features: List[FeatureFlagEnum] = Field(
+        default_factory=list, description="List of enabled feature flags for this organization"
     )
 
     class Config:

--- a/backend/airweave/schemas/organization.py
+++ b/backend/airweave/schemas/organization.py
@@ -1,10 +1,12 @@
 """Organization schemas."""
 
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
+
+from airweave.core.shared_models import FeatureFlag as FeatureFlagEnum
 
 
 class OrganizationBase(BaseModel):
@@ -48,6 +50,10 @@ class Organization(OrganizationInDBBase):
     name: str
     description: Optional[str] = None
     auth0_org_id: Optional[str] = None
+    enabled_features: List[FeatureFlagEnum] = Field(
+        default_factory=list,
+        description="List of enabled feature flags for this organization",
+    )
 
 
 class OrganizationWithRole(BaseModel):
@@ -64,3 +70,7 @@ class OrganizationWithRole(BaseModel):
     is_primary: bool
     auth0_org_id: Optional[str] = None
     org_metadata: Optional[Dict[str, Any]] = None
+    enabled_features: List[FeatureFlagEnum] = Field(
+        default_factory=list,
+        description="List of enabled feature flags for this organization",
+    )

--- a/backend/alembic/versions/18cc66d35bcb_merge_feature_flags_with_existing_head.py
+++ b/backend/alembic/versions/18cc66d35bcb_merge_feature_flags_with_existing_head.py
@@ -1,0 +1,24 @@
+"""merge feature flags with existing head
+
+Revision ID: 18cc66d35bcb
+Revises: 9a977647c5a4, add_feature_flags_001
+Create Date: 2025-10-07 13:17:31.914267
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '18cc66d35bcb'
+down_revision = ('9a977647c5a4', 'add_feature_flags_001')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/backend/alembic/versions/add_organization_feature_flags.py
+++ b/backend/alembic/versions/add_organization_feature_flags.py
@@ -1,0 +1,54 @@
+"""Add organization_feature_flag table for feature flag management
+
+Revision ID: add_feature_flags_001
+Revises: add_yearly_prepay_001
+Create Date: 2025-10-07 12:00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "add_feature_flags_001"
+down_revision = "add_yearly_prepay_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create feature_flag table
+    op.create_table(
+        "feature_flag",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("flag", sa.String(length=100), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("(NOW() AT TIME ZONE 'UTC')"),
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("(NOW() AT TIME ZONE 'UTC')"),
+        ),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("organization_id", "flag", name="uq_org_flag"),
+    )
+
+    # Create index on organization_id for efficient lookups
+    op.create_index("ix_feature_flag_organization_id", "feature_flag", ["organization_id"])
+
+
+def downgrade() -> None:
+    # Drop index
+    op.drop_index("ix_feature_flag_organization_id", table_name="feature_flag")
+
+    # Drop table
+    op.drop_table("feature_flag")

--- a/backend/alembic/versions/cb4843afd172_merge_all_heads.py
+++ b/backend/alembic/versions/cb4843afd172_merge_all_heads.py
@@ -1,0 +1,24 @@
+"""merge all heads
+
+Revision ID: cb4843afd172
+Revises: 18cc66d35bcb, 6e39730bc45b
+Create Date: 2025-10-07 13:29:02.964705
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'cb4843afd172'
+down_revision = ('18cc66d35bcb', '6e39730bc45b')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/frontend/src/lib/constants/feature-flags.ts
+++ b/frontend/src/lib/constants/feature-flags.ts
@@ -1,0 +1,20 @@
+/**
+ * Available feature flags in Airweave.
+ * Must match backend FeatureFlag enum exactly.
+ */
+export const FeatureFlags = {
+  // Storage & Infrastructure
+  S3_DESTINATION: 's3_destination',
+
+  // Search & Query
+  ADVANCED_SEARCH: 'advanced_search',
+
+  // Platform Features
+  CUSTOM_ENTITIES: 'custom_entities',
+  WHITE_LABEL: 'white_label',
+
+  // Support & Services
+  PRIORITY_SUPPORT: 'priority_support',
+} as const;
+
+export type FeatureFlag = typeof FeatureFlags[keyof typeof FeatureFlags];

--- a/frontend/src/lib/stores/organizations.ts
+++ b/frontend/src/lib/stores/organizations.ts
@@ -13,6 +13,7 @@ interface Organization {
   is_primary: boolean;
   created_at?: string;
   modified_at?: string;
+  enabled_features?: string[]; // List of enabled feature flags
   org_metadata?: {
     onboarding?: {
       organizationSize: string;
@@ -70,6 +71,9 @@ interface OrganizationState {
   inviteUserToOrganization: (orgId: string, email: string, role: string) => Promise<boolean>;
   removeUserFromOrganization: (orgId: string, userId: string) => Promise<boolean>;
   leaveOrganization: (orgId: string) => Promise<boolean>;
+
+  // Feature flag actions
+  hasFeature: (flag: string) => boolean;
 }
 
 // Helper function to select the best organization
@@ -446,6 +450,11 @@ export const useOrganizationStore = create<OrganizationState>()(
           set({ isLoading: false });
           throw error;
         }
+      },
+
+      hasFeature: (flag: string) => {
+        const org = get().currentOrganization;
+        return org?.enabled_features?.includes(flag) ?? false;
       },
 
       leaveOrganization: async (orgId: string): Promise<boolean> => {


### PR DESCRIPTION
    
<img width="2038" height="1149" alt="Screenshot 2025-10-07 at 14 54 26" src="https://github.com/user-attachments/assets/82b02589-5336-492f-96e2-0d5807b61a54" />

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add organization-level feature flags with persistence, admin APIs, and frontend wiring so features can be gated per org. Includes a new FeatureFlag model and migrations, CRUD helpers, ApiContext.has_feature, schema updates, and an admin dashboard dialog to toggle flags.

- **New Features**
  - Backend: FeatureFlag enum; feature_flag table and ORM; CRUD to enable/disable/get/bulk; ApiContext.has_feature; admin endpoints to list and toggle flags; org schemas expose enabled_features.
  - Frontend: FeatureFlags constants; org store adds enabled_features and hasFeature(flag); AdminDashboard adds a “Features” dialog to view and toggle flags per org.

- **Migration**
  - Run Alembic upgrade to create feature_flag table and merge heads.
  - Existing orgs start with no flags; enable via admin UI or CRUD.
  - When adding new flags, update the backend enum and frontend constants to keep them in sync.

<!-- End of auto-generated description by cubic. -->

