### PR TITLE
fix: resolve Alembic multiple heads migration conflict

### DIFF
--- a/backend/alembic/versions/dea941855acd_merge_heads_6e39730bc45b_and_ 9a977647c5a4.py
+++ b/backend/alembic/versions/dea941855acd_merge_heads_6e39730bc45b_and_ 9a977647c5a4.py
@@ -1,0 +1,24 @@
+"""merge_heads_6e39730bc45b_and_9a977647c5a4
+
+Revision ID: dea941855acd
+Revises: 6e39730bc45b, 9a977647c5a4
+Create Date: 2025-10-07 16:47:17.086718
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'dea941855acd'
+down_revision = ('6e39730bc45b', '9a977647c5a4')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
merge heads, we merged branches too fast.

at uber, at the time of merge all CI checks are re-run automatically to ensure the merge is safe. could prevent such pains at some point when we grow.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an Alembic merge migration to resolve multiple heads (6e39730bc45b and 9a977647c5a4). This linearizes the migration history and unblocks future upgrades and deployments.

- **Migration**
  - No schema changes; upgrade/downgrade are no-ops.
  - After pulling, run alembic upgrade head to align local databases.

<!-- End of auto-generated description by cubic. -->

