### PR TITLE
fix: periodically clean up stale sync jobs

### DIFF
--- a/backend/airweave/crud/crud_entity.py
+++ b/backend/airweave/crud/crud_entity.py
@@ -309,5 +309,23 @@ class CRUDEntity(CRUDBaseOrganization[Entity, EntityCreate, EntityUpdate]):
         result = await db.execute(stmt)
         return list(result.unique().scalars().all())
 
+    async def get_latest_entity_time_for_job(
+        self,
+        db: AsyncSession,
+        sync_job_id: UUID,
+    ) -> Optional[datetime]:
+        """Get the most recent entity created_at timestamp for a sync job.
+
+        Args:
+            db: Database session
+            sync_job_id: The sync job ID to check
+
+        Returns:
+            The most recent created_at timestamp, or None if no entities exist
+        """
+        stmt = select(func.max(Entity.created_at)).where(Entity.sync_job_id == sync_job_id)
+        result = await db.execute(stmt)
+        return result.scalar()
+
 
 entity = CRUDEntity()

--- a/backend/airweave/crud/crud_sync_job.py
+++ b/backend/airweave/crud/crud_sync_job.py
@@ -1,5 +1,6 @@
 """CRUD operations for sync jobs."""
 
+from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
@@ -103,6 +104,35 @@ class CRUDSyncJob(CRUDBaseOrganization[SyncJob, SyncJobCreate, SyncJobUpdate]):
         # Add the sync name to the job object
         job.sync_name = sync_name
         return job
+
+    async def get_stuck_jobs_by_status(
+        self,
+        db: AsyncSession,
+        status: list[str],
+        modified_before: Optional[datetime] = None,
+        started_before: Optional[datetime] = None,
+    ) -> list[SyncJob]:
+        """Get sync jobs stuck in specific statuses based on timestamps.
+
+        Args:
+            db: Database session
+            status: List of statuses to filter by
+            modified_before: For CANCELLING/PENDING jobs - modified_at before this time
+            started_before: For RUNNING jobs - started_at before this time
+
+        Returns:
+            List of stuck sync jobs
+        """
+        stmt = select(SyncJob).where(SyncJob.status.in_(status))
+
+        # Apply timestamp filters based on what's provided
+        if modified_before is not None:
+            stmt = stmt.where(SyncJob.modified_at < modified_before)
+        if started_before is not None:
+            stmt = stmt.where(SyncJob.started_at < started_before)
+
+        result = await db.execute(stmt)
+        return list(result.scalars().all())
 
 
 sync_job = CRUDSyncJob(SyncJob)

--- a/backend/airweave/main.py
+++ b/backend/airweave/main.py
@@ -69,6 +69,19 @@ async def lifespan(app: FastAPI):
             await sync_platform_components("airweave/platform", db)
         await init_db(db)
 
+    # Initialize cleanup schedule for stuck sync jobs (if Temporal is enabled)
+    if settings.TEMPORAL_ENABLED:
+        try:
+            from airweave.platform.temporal.schedule_service import temporal_schedule_service
+
+            logger.info("Initializing cleanup schedule for stuck sync jobs...")
+            await temporal_schedule_service.create_cleanup_schedule()
+            logger.info("Cleanup schedule initialized successfully")
+        except Exception as e:
+            logger.warning(
+                f"Failed to initialize cleanup schedule (Temporal may not be available): {e}"
+            )
+
     yield
 
 

--- a/backend/airweave/models/sync_job.py
+++ b/backend/airweave/models/sync_job.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
-from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String
+from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from airweave.core.shared_models import SyncJobStatus
@@ -48,4 +48,13 @@ class SyncJob(OrganizationBase, UserMixin):
         lazy="noload",
         cascade="all, delete-orphan",
         passive_deletes=True,
+    )
+
+    __table_args__ = (
+        # Index for filtering by status (used in cleanup queries)
+        Index("idx_sync_job_status", "status"),
+        # Composite index for finding stuck jobs by status and last modification time
+        Index("idx_sync_job_status_modified_at", "status", "modified_at"),
+        # Index for finding long-running jobs by status and start time
+        Index("idx_sync_job_status_started_at", "status", "started_at"),
     )

--- a/backend/airweave/platform/temporal/worker.py
+++ b/backend/airweave/platform/temporal/worker.py
@@ -11,12 +11,16 @@ from airweave.core.config import settings
 from airweave.core.logging import logger
 from airweave.platform.entities._base import ensure_file_entity_models
 from airweave.platform.temporal.activities import (
+    cleanup_stuck_sync_jobs_activity,
     create_sync_job_activity,
     mark_sync_job_cancelled_activity,
     run_sync_activity,
 )
 from airweave.platform.temporal.client import temporal_client
-from airweave.platform.temporal.workflows import RunSourceConnectionWorkflow
+from airweave.platform.temporal.workflows import (
+    CleanupStuckSyncJobsWorkflow,
+    RunSourceConnectionWorkflow,
+)
 
 
 class TemporalWorker:
@@ -43,11 +47,12 @@ class TemporalWorker:
             self.worker = Worker(
                 client,
                 task_queue=task_queue,
-                workflows=[RunSourceConnectionWorkflow],
+                workflows=[RunSourceConnectionWorkflow, CleanupStuckSyncJobsWorkflow],
                 activities=[
                     run_sync_activity,
                     mark_sync_job_cancelled_activity,
                     create_sync_job_activity,
+                    cleanup_stuck_sync_jobs_activity,
                 ],
                 workflow_runner=sandbox_config,
                 max_concurrent_workflow_task_polls=8,

--- a/backend/alembic/versions/45e94120d9e8_merge_heads.py
+++ b/backend/alembic/versions/45e94120d9e8_merge_heads.py
@@ -1,0 +1,24 @@
+"""merge_heads
+
+Revision ID: 45e94120d9e8
+Revises: c3edd3ce34ce, d5e6f7g8h9i0, dea941855acd
+Create Date: 2025-10-10 16:00:08.531697
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '45e94120d9e8'
+down_revision = ('c3edd3ce34ce', 'd5e6f7g8h9i0', 'dea941855acd')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/backend/alembic/versions/e3a7e8db826c_add_sync_job_cleanup_indexes.py
+++ b/backend/alembic/versions/e3a7e8db826c_add_sync_job_cleanup_indexes.py
@@ -1,0 +1,31 @@
+"""add_sync_job_cleanup_indexes
+
+Revision ID: e3a7e8db826c
+Revises: 45e94120d9e8
+Create Date: 2025-10-10 16:00:14.659486
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e3a7e8db826c"
+down_revision = "45e94120d9e8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create indexes for efficient cleanup queries
+    op.create_index("idx_sync_job_status", "sync_job", ["status"])
+    op.create_index("idx_sync_job_status_modified_at", "sync_job", ["status", "modified_at"])
+    op.create_index("idx_sync_job_status_started_at", "sync_job", ["status", "started_at"])
+
+
+def downgrade():
+    # Drop indexes
+    op.drop_index("idx_sync_job_status_started_at", table_name="sync_job")
+    op.drop_index("idx_sync_job_status_modified_at", table_name="sync_job")
+    op.drop_index("idx_sync_job_status", table_name="sync_job")


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Periodically clean up stale sync jobs by detecting and cancelling stuck PENDING/CANCELLING and long-running RUNNING jobs. Adds a Temporal-scheduled workflow and DB indexes to make detection fast and reliable.

- **New Features**
  - Temporal schedule runs every 150s (CleanupStuckSyncJobsWorkflow).
  - Activity cancels jobs stuck >3m (PENDING/CANCELLING) or RUNNING >10m with no entity updates.
  - Tries Temporal cancellation first, then force-updates DB if needed.
  - Auto-creates the schedule on startup when Temporal is enabled; safe to skip if not.

- **Migration**
  - Run DB migrations to add sync_job indexes (status, status+modified_at, status+started_at).
  - No config changes required; Temporal must be enabled for automatic scheduling.

<!-- End of auto-generated description by cubic. -->

