### PR TITLE
feat: fix file deletion not removing main entities from Qdrant

### DIFF
--- a/backend/airweave/platform/sync/entity_processor.py
+++ b/backend/airweave/platform/sync/entity_processor.py
@@ -1006,6 +1006,11 @@ class EntityProcessor:
                     else:
                         for pid in parent_ids_to_clear:
                             await dest.bulk_delete_by_parent_id(pid, sync_context.sync.id)
+
+                # Also delete main entities by their entity_id
+                if deletes:
+                    entity_ids_to_delete = [d.entity_id for d in deletes]
+                    await dest.bulk_delete(entity_ids_to_delete, sync_context.sync.id)
                 if to_insert:
                     await dest.bulk_insert(to_insert)
             except NotImplementedError:


### PR DESCRIPTION
When files were deleted in GitHub, they were still appearing in search results even though the sync showed successful deletion. The issue was that the deletion process was only targeting entities with `parent_entity_id` matching the deleted file's `entity_id`, but main file entities don't have a `parent_entity_id` field set.

- Main file entities don't have `parent_entity_id` field
- Only chunk entities have `parent_entity_id` pointing to their parent file
- Deletion was only using `bulk_delete_by_parent_ids()` which targets `parent_entity_id`
- Main file entities were never being deleted
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix file deletion in Qdrant by also removing main file entities using their entity_id, not just chunks via parent_entity_id. This stops deleted files from appearing in search results.

<!-- End of auto-generated description by cubic. -->

