### PR TITLE
fix: correct boolean default value formatting in docs generation

### DIFF
--- a/fern/docs/pages/connectors/zendesk/main.mdx
+++ b/fern/docs/pages/connectors/zendesk/main.mdx
@@ -64,7 +64,7 @@ Zendesk configuration schema.
   path="exclude_closed_tickets"
   type="Optional[bool]"
   required={false}
-  default={False}
+  default={false}
 >
   Skip closed tickets during sync (recommended for faster syncing)
 </ParamField>

--- a/fern/scripts/update_connector_docs/generators/mdx_generator.py
+++ b/fern/scripts/update_connector_docs/generators/mdx_generator.py
@@ -227,15 +227,16 @@ def generate_mdx_content(
                             # Properly format default value for JSX
                             default_value = field["default"]
 
-                            if isinstance(default_value, str):
+                            # Check bool before int/float because bool is a subclass of int in Python
+                            if isinstance(default_value, bool):
+                                # Booleans need curly braces and proper JS boolean values
+                                default_attr = f"  default={{{str(default_value).lower()}}}\n"
+                            elif isinstance(default_value, str):
                                 # String values need quotes
                                 default_attr = f'  default="{default_value}"\n'
                             elif isinstance(default_value, (int, float)):
                                 # Numbers need curly braces
                                 default_attr = f"  default={{{default_value}}}\n"
-                            elif isinstance(default_value, bool):
-                                # Booleans need curly braces and proper JS boolean values
-                                default_attr = f"  default={{{str(default_value).lower()}}}\n"
                             elif isinstance(default_value, list):
                                 # Arrays need curly braces and proper formatting
                                 default_attr = f"  default={{{str(default_value)}}}\n"

--- a/fern/scripts/update_connector_docs/parsers/config_parser.py
+++ b/fern/scripts/update_connector_docs/parsers/config_parser.py
@@ -94,8 +94,16 @@ def parse_config_file():
                                     elif isinstance(keyword.value, ast.Constant):
                                         default_value = keyword.value.value
                                     elif isinstance(keyword.value, ast.Name):
-                                        # For constants like True, False, None
-                                        default_value = keyword.value.id
+                                        # For constants like True, False, None - convert to actual Python values
+                                        name = keyword.value.id
+                                        if name == "True":
+                                            default_value = True
+                                        elif name == "False":
+                                            default_value = False
+                                        elif name == "None":
+                                            default_value = None
+                                        else:
+                                            default_value = name  # For other named constants
                                     elif isinstance(keyword.value, ast.List):
                                         default_value = "[]"  # Simplified for lists
                                     elif isinstance(keyword.value, ast.Dict):


### PR DESCRIPTION
correct boolean default value formatting in docs generation and update parsing logic for constants in order to fix broken zendesk docs downstream ( fixes #934 ).
    
<img width="1206" height="613" alt="image" src="https://github.com/user-attachments/assets/83fd9efc-4dc9-4f66-ae08-6e8f2bcee4f4" />

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix boolean default formatting in generated MDX and correct constant parsing so Zendesk docs show the right defaults and stop breaking downstream.

- **Bug Fixes**
  - Parse ast.Name constants (True/False/None) into real Python values.
  - In MDX generator, handle bools before numbers and output default={true|false}.
  - Update Zendesk connector page to use default={false} for exclude_closed_tickets.

<!-- End of auto-generated description by cubic. -->

