### PR TITLE
fix: change QueryExpansions schema from Tuple to List for OpenAI compatibility

### DIFF
--- a/backend/airweave/search/operations/query_expansion.py
+++ b/backend/airweave/search/operations/query_expansion.py
@@ -23,10 +23,11 @@ _NUMBER_OF_EXPANSIONS = 4
 class QueryExpansions(BaseModel):
     """Structured output schema for LLM-generated query expansions."""
 
-    # Use a fixed-size tuple to generate Cerebras-compatible prefixItems schema
     model_config = {"extra": "forbid"}
 
-    alternatives: Tuple[str, str, str, str] = Field(
+    alternatives: List[str] = Field(
+        min_length=_NUMBER_OF_EXPANSIONS,
+        max_length=_NUMBER_OF_EXPANSIONS,
         description=(
             f"Exactly {_NUMBER_OF_EXPANSIONS} UNIQUE and DISTINCT alternative query "
             f"phrasings. Each alternative MUST be different from all others AND "


### PR DESCRIPTION
## Summary

Fixes OpenAI structured output API failure in query expansion operation.

## Problem

The `QueryExpansions` schema used `Tuple[str, str, str, str]` which generates a `prefixItems` JSON schema. This works for Cerebras but fails with OpenAI's structured output API, which requires array schemas to have `items` defined.

**Error:**
```
OpenAI structured output API call failed: Invalid schema for 
response_format 'QueryExpansions': array schema missing items
```

## Solution

Changed `alternatives` field from `Tuple[str, str, str, str]` to `List[str]` with `min_length` and `max_length` constraints. This generates a compatible JSON schema with `items` that works for both OpenAI and Cerebras providers.

## Changes

- Updated `backend/airweave/search/operations/query_expansion.py`:
  - Changed `alternatives: Tuple[str, str, str, str]` to `alternatives: List[str]`
  - Added `min_length=4` and `max_length=4` constraints
  - Removed Cerebras-specific comment

## Testing

- [x] Tested with OpenAI provider - query expansion now works
- [x] Schema maintains exactly 4 alternatives requirement
- [x] Compatible with both OpenAI and Cerebras providers

## Related Issue

This fixes the regression introduced in PR #952 (Cerebras integration).
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched QueryExpansions.alternatives from a fixed tuple to a list with length constraints to produce an items-based JSON schema. This fixes OpenAI structured output failures and keeps Cerebras compatibility.

- **Bug Fixes**
  - Replaced Tuple[str, str, str, str] with List[str] and min_length=max_length=4.
  - Resolves “array schema missing items” error; query expansion works with OpenAI and Cerebras.

<!-- End of auto-generated description by cubic. -->

