### PR TITLE
fix(defaults): set correct defaults for reranking step

### DIFF
--- a/backend/airweave/search/defaults.yml
+++ b/backend/airweave/search/defaults.yml
@@ -112,11 +112,11 @@ operation_preferences:
         embedding: null
         rerank: rerank
       - provider: groq
-        llm: null
+        llm: llm_small
         embedding: null
         rerank: rerank
       - provider: openai
-        llm: null
+        llm: llm_small
         embedding: null
         rerank: rerank
 

--- a/backend/airweave/search/operations/query_expansion.py
+++ b/backend/airweave/search/operations/query_expansion.py
@@ -5,7 +5,7 @@ Uses LLM to generate semantic alternatives that might match relevant documents
 using different terminology while preserving the original search intent.
 """
 
-from typing import Any, List, Tuple
+from typing import Any, List
 
 from pydantic import BaseModel, Field
 
@@ -26,13 +26,15 @@ class QueryExpansions(BaseModel):
     # Use a fixed-size tuple to generate Cerebras-compatible prefixItems schema
     model_config = {"extra": "forbid"}
 
-    alternatives: Tuple[str, str, str, str] = Field(
+    alternatives: List[str] = Field(
+        min_length=_NUMBER_OF_EXPANSIONS,
+        max_length=_NUMBER_OF_EXPANSIONS,
         description=(
             f"Exactly {_NUMBER_OF_EXPANSIONS} UNIQUE and DISTINCT alternative query "
             f"phrasings. Each alternative MUST be different from all others AND "
             f"different from the original query. No duplicates, no repetitions, "
             f"no variations that differ only in punctuation or capitalization."
-        )
+        ),
     )
 
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Set llm_small as the default LLM for the reranking step (OpenAI and Groq). Also make query expansions a fixed-size list to ensure exactly N alternatives and avoid schema issues.

- **Bug Fixes**
  - Reranking defaults: change llm from null to llm_small for OpenAI and Groq.
  - Query expansion: switch Tuple[str, ...] to List[str] with min/max length = _NUMBER_OF_EXPANSIONS (and drop Tuple import).

<!-- End of auto-generated description by cubic. -->

