### PR TITLE
feat(analytics): implement automatic API call tracking via middleware

### DIFF
--- a/backend/airweave/api/deps.py
+++ b/backend/airweave/api/deps.py
@@ -359,6 +359,9 @@ async def get_context(
     if user_context:
         analytics_service.identify_user()
 
+    # Store context in request state for middleware access
+    request.state.api_context = ctx
+
     await _check_and_enforce_rate_limit(request, ctx)
     return ctx
 

--- a/backend/airweave/main.py
+++ b/backend/airweave/main.py
@@ -18,6 +18,7 @@ from airweave.api.middleware import (
     DynamicCORSMiddleware,
     add_request_id,
     airweave_exception_handler,
+    analytics_middleware,
     exception_logging_middleware,
     invalid_state_exception_handler,
     log_requests,
@@ -108,6 +109,7 @@ app.middleware("http")(request_body_size_middleware)
 app.middleware("http")(request_timeout_middleware)
 app.middleware("http")(rate_limit_headers_middleware)
 app.middleware("http")(log_requests)
+app.middleware("http")(analytics_middleware)
 app.middleware("http")(exception_logging_middleware)
 
 # Register exception handlers


### PR DESCRIPTION
Implements automatic API call tracking via FastAPI middleware, eliminating the need for manual `track_api_call` calls in endpoints while providing comprehensive analytics data for PostHog.

```
HTTP Request                                           HTTP Response
     ↓                                                       ↑
┌───────────────┐                                    ┌─────────────────┐
│ Analytics     │ ← Start timing                     │ Analytics       │ ← Extract context
│ Middleware    │                                    │ Middleware      │ Track to PostHog
└───────────────┘                                    └─────────────────┘
     ↓                                                       ↑
┌─────────────────┐                                                        
│ Dependency      │ ← Creates ApiContext             ┌─────────────────┐
│ Injection       │   Stores in request.state        │ API Endpoint    │ ← Business logic
│ (get_context)   │   ────────────────────────────>  │ (your code)     │
└─────────────────┘                                  └─────────────────┘
     
```

- Middleware runs after dependency injection to access full `ApiContext`
- Skips analytics for health checks, docs, and static assets
- Uses `time.monotonic()` for accurate duration measurement
- Graceful error handling with warning logs
- all headers taken from https://github.com/airweave-ai/airweave/pull/906

<img width="565" height="805" alt="Screenshot 2025-10-16 at 20 39 26" src="https://github.com/user-attachments/assets/cf28a982-bfd5-43c1-82fa-a5b878d44677" />
