### PR TITLE
hotfix(pipedream): github access token mapping

### DIFF
--- a/backend/airweave/platform/auth_providers/pipedream.py
+++ b/backend/airweave/platform/auth_providers/pipedream.py
@@ -67,7 +67,7 @@ class PipedreamAuthProvider(BaseAuthProvider):
         "refresh_token": "oauth_refresh_token",
         "client_id": "oauth_client_id",
         "client_secret": "oauth_client_secret",
-        "personal_access_token": "access_token",  # GitHub PAT mapping
+        "personal_access_token": "oauth_access_token",  # GitHub PAT mapping
         # Add more mappings as discovered
     }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed GitHub personal access token mapping in the Pipedream auth provider to use oauth_access_token instead of access_token, ensuring tokens are stored and retrieved correctly.

<!-- End of auto-generated description by cubic. -->

