### PR TITLE
chore(pipedream): disable complicated sources

### DIFF
--- a/backend/airweave/platform/auth_providers/pipedream.py
+++ b/backend/airweave/platform/auth_providers/pipedream.py
@@ -57,6 +57,15 @@ class PipedreamAuthProvider(BaseAuthProvider):
     # Sources that Pipedream does not support
     BLOCKED_SOURCES = [
         "ctti",
+        # Pipedream enforces "proxy mode" where all GitHub API requests must route through
+        # their proxy endpoint, creating heavy bottlenecks
+        "github",
+        # Attlassian constructs the URL using a cloud ID which pipedream does not provide
+        "jira",
+        # Attlassian constructs the URL using a cloud ID which pipedream doesn't provide
+        "confluence",
+        # Workspace needs to be moved to the regular config, which will conflict with composio
+        "bitbucket",
     ]
 
     # Mapping of Airweave field names to Pipedream field names


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Disable GitHub, Jira, Confluence, and Bitbucket sources in the Pipedream auth provider to prevent unsupported configurations and proxy bottlenecks. This avoids failures from Pipedream’s proxy-only GitHub access and missing Atlassian cloud IDs.

<!-- End of auto-generated description by cubic. -->

