### PR TITLE
docs(connectors): fix outdated OAuth redirect callback URIs

### DIFF
--- a/fern/docs/pages/connectors/dropbox/main.mdx
+++ b/fern/docs/pages/connectors/dropbox/main.mdx
@@ -150,10 +150,18 @@ Airweave will access Dropbox on behalf of your users. You'll need to have each
 Dropbox provides [documentation](https://developers.dropbox.com/oauth-guide) on how to implement OAuth 2.0.
 This guide will walk you through connecting Dropbox APIs to Airweave when running locally.
 1. Go [here](https://www.dropbox.com/developers/apps/create) to create the "Airweave integration" application
-2. Under `Settings`, add the following Redirect URI:
-  ```
-  http://localhost:8080/auth/callback/dropbox
-  ```
+2. Under `Settings`, add the Redirect URI. Use the appropriate URL for your environment:
+
+    **Production (Airweave Cloud):**
+        ```
+        https://api.airweave.ai/source-connections/callback
+        ```
+
+    **Local:**
+        ```
+        http://localhost:8001/source-connections/callback
+        ```
+
 3.Under `Permissions`, select the following scopes:
   ```
   account_info.read

--- a/fern/docs/pages/connectors/gmail/main.mdx
+++ b/fern/docs/pages/connectors/gmail/main.mdx
@@ -199,14 +199,16 @@ https://www.googleapis.com/auth/calendar.events.owned.readonly
 https://www.googleapis.com/auth/calendar.events.readonly
 ```
 6. [Create OAuth client ID credentials](https://developers.google.com/workspace/guides/create-credentials#oauth-client-id)
-7. Under "Authorized redirect URIs," click "+ Add URI" and add the following URIs:
-   ```
-   http://localhost:8080/auth/callback/gmail
-   ```
-   ```
-   http://localhost:8080/auth/callback/google_calendar
-   ```
-   ```
-   http://localhost:8080/auth/callback/google_drive
-   ```
+7. Under "Authorized redirect URIs," click "+ Add URI" and add the Redirect URI. Use the appropriate URL for your environment:
+
+    **Production (Airweave Cloud):**
+        ```
+        https://api.airweave.ai/source-connections/callback
+        ```
+
+    **Local:**
+        ```
+        http://localhost:8001/source-connections/callback
+        ```
+
 8. Locate the client ID and client secret from your newly created OAuth client. Add these credentials to the `dev.integrations.yml` file to enable Google API integration.

--- a/fern/docs/pages/connectors/google_calendar/main.mdx
+++ b/fern/docs/pages/connectors/google_calendar/main.mdx
@@ -167,14 +167,15 @@ https://www.googleapis.com/auth/calendar.events.owned.readonly
 https://www.googleapis.com/auth/calendar.events.readonly
 ```
 6. [Create OAuth client ID credentials](https://developers.google.com/workspace/guides/create-credentials#oauth-client-id)
-7. Under "Authorized redirect URIs," click "+ Add URI" and add the following URIs:
-   ```
-   http://localhost:8080/auth/callback/gmail
-   ```
-   ```
-   http://localhost:8080/auth/callback/google_calendar
-   ```
-   ```
-   http://localhost:8080/auth/callback/google_drive
-   ```
+7. Under "Authorized redirect URIs," click "+ Add URI" add the Redirect URI. Use the appropriate URL for your environment:
+
+    **Production (Airweave Cloud):**
+        ```
+        https://api.airweave.ai/source-connections/callback
+        ```
+
+    **Local:**
+        ```
+        http://localhost:8001/source-connections/callback
+        ```
 8. Locate the client ID and client secret from your newly created OAuth client. Add these credentials to the `dev.integrations.yml` file to enable Google API integration.

--- a/fern/docs/pages/connectors/google_drive/main.mdx
+++ b/fern/docs/pages/connectors/google_drive/main.mdx
@@ -162,14 +162,14 @@ https://www.googleapis.com/auth/calendar.events.owned.readonly
 https://www.googleapis.com/auth/calendar.events.readonly
 ```
 6. [Create OAuth client ID credentials](https://developers.google.com/workspace/guides/create-credentials#oauth-client-id)
-7. Under "Authorized redirect URIs," click "+ Add URI" and add the following URIs:
-   ```
-   http://localhost:8080/auth/callback/gmail
-   ```
-   ```
-   http://localhost:8080/auth/callback/google_calendar
-   ```
-   ```
-   http://localhost:8080/auth/callback/google_drive
-   ```
+7. Under "Authorized redirect URIs," click "+ Add URI" and add the Redirect URI. Use the appropriate URL for your environment:
+    **Production (Airweave Cloud):**
+        ```
+        https://api.airweave.ai/source-connections/callback
+        ```
+
+    **Local:**
+        ```
+        http://localhost:8001/source-connections/callback
+        ```
 8. Locate the client ID and client secret from your newly created OAuth client. Add these credentials to the `dev.integrations.yml` file to enable Google API integration.

--- a/fern/docs/pages/connectors/zendesk/main.mdx
+++ b/fern/docs/pages/connectors/zendesk/main.mdx
@@ -241,7 +241,6 @@ Fill out the OAuth client form with the following details:
   Enter your Airweave callback URL. Use the appropriate URL for your environment:
 
   - **Production:** `https://api.airweave.ai/source-connections/callback`
-  - **Development:** `https://api.dev-airweave.com/source-connections/callback`
   - **Local:** `http://localhost:8001/source-connections/callback`
 
   <Note>


### PR DESCRIPTION
Update redirect callback URIs in Google Drive, Zendesk, Dropbox, Google Calendar, and Gmail connector documentation
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized OAuth redirect callback URIs in connector docs to fix outdated values and prevent failed auth flows. Applies to Google Drive, Google Calendar, Gmail, Dropbox, and Zendesk.

- **Bug Fixes**
  - Replaced old callbacks with: Production https://api.airweave.ai/source-connections/callback, Local http://localhost:8001/source-connections/callback
  - Removed deprecated dev URL from Zendesk instructions

<!-- End of auto-generated description by cubic. -->

