### PR TITLE
feat(mcp): configure redis for session storage

### DIFF
--- a/.cursor/rules/mcp-server.mdc
+++ b/.cursor/rules/mcp-server.mdc
@@ -42,8 +42,9 @@ The Airweave MCP Server provides search capabilities for AI assistants through t
 - **Express App**: HTTP server with health checks and info endpoints
 - **Streamable HTTP Transport**: Modern MCP 2025-03-26 transport for bidirectional communication
 - **Request Handling**: POST `/mcp` endpoint for all MCP requests
-- **Session Management**: Per-session server instances with independent API keys
+- **Session Management**: Redis-backed distributed sessions with local caching for performance
 - **Authentication**: API key extraction from headers or query parameters per request
+- **Security**: API key hashing, session binding (IP/User-Agent), rate limiting, audit logging
 
 ### Tools
 - **Search Tool**: `search-{collection}` - Main search functionality with natural language queries
@@ -75,6 +76,10 @@ The Airweave MCP Server provides search capabilities for AI assistants through t
 - `AIRWEAVE_COLLECTION`: Target collection name
 - `AIRWEAVE_BASE_URL`: API base URL (default: production)
 - `PORT`: Server port (default: 8080)
+- `REDIS_HOST`: Redis server hostname (default: redis)
+- `REDIS_PORT`: Redis server port (default: 6379)
+- `REDIS_PASSWORD`: Redis authentication password
+- `REDIS_URL`: Complete Redis connection string
 
 ### Client Configuration
 - API key provided by client (not server environment)
@@ -83,27 +88,52 @@ The Airweave MCP Server provides search capabilities for AI assistants through t
 
 ## Implementation Details
 
-### Streamable HTTP Transport Pattern
+### Redis-Backed Session Management Pattern
 ```typescript
-// Session management: Map session IDs to { server, transport, apiKey }
-const sessions = new Map<string, { server: McpServer, transport: StreamableHTTPServerTransport, apiKey: string }>();
+// Local cache: Map session IDs to { server, transport, data }
+// This cache is per-pod and reconstructed from Redis as needed
+const localSessionCache = new Map<string, SessionWithTransport>();
 
-// Handle all MCP requests with per-session isolation
+// Redis session manager for distributed storage
+const sessionManager = new RedisSessionManager({
+    host: process.env.REDIS_HOST || 'redis',
+    port: parseInt(process.env.REDIS_PORT || '6379'),
+    password: process.env.REDIS_PASSWORD
+});
+
+// Handle all MCP requests with Redis-backed session persistence
 app.post('/mcp', async (req, res) => {
-    // Extract API key from request
+    // Extract API key and client metadata
     const apiKey = req.headers['x-api-key'] || req.headers['authorization']?.replace('Bearer ', '');
-    
-    // Get or create session
     const sessionId = req.headers['mcp-session-id'] || generateSessionId();
-    let session = sessions.get(sessionId);
+    const clientIP = req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress;
     
-    if (!session || session.apiKey !== apiKey) {
-        // Create new server instance with API key
-        const server = createMcpServer(apiKey);
-        const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => sessionId });
-        await server.connect(transport);
-        session = { server, transport, apiKey };
-        sessions.set(sessionId, session);
+    // Check local cache first (fastest path)
+    let session = localSessionCache.get(sessionId);
+    
+    if (!session) {
+        // Retrieve from Redis and recreate server instance
+        const sessionData = await sessionManager.getSession(sessionId);
+        if (sessionData) {
+            session = await createSessionObjects(sessionData, apiKey);
+            localSessionCache.set(sessionId, session);
+        } else {
+            // Create new session with rate limiting and security checks
+            const rateLimit = await sessionManager.checkRateLimit(apiKey);
+            if (!rateLimit.allowed) throw new Error('Rate limit exceeded');
+            
+            const newSessionData = {
+                sessionId,
+                apiKeyHash: RedisSessionManager.hashApiKey(apiKey),
+                collection: process.env.AIRWEAVE_COLLECTION,
+                baseUrl: process.env.AIRWEAVE_BASE_URL,
+                clientIP,
+                userAgent: req.headers['user-agent']
+            };
+            await sessionManager.setSession(newSessionData);
+            session = await createSessionObjects(newSessionData, apiKey);
+            localSessionCache.set(sessionId, session);
+        }
     }
     
     // Handle request with session's transport
@@ -127,7 +157,8 @@ app.post('/mcp', async (req, res) => {
 ### Testing
 - **MCP Server Tests** (`tests/mcp-server.test.ts`): Core functionality tests including tool registration, parameter passing, response formatting, and error handling
 - **HTTP Transport Tests** (`tests/http-transport.test.ts`): Session management, API key authentication, and multi-tenant behavior
-- **Test Commands**: `npm run test:mcp`, `npm run test:http`, `npm run test:all`
+- **Redis Session Tests** (`tests/redis-session-manager.test.ts`): Redis connection, session storage/retrieval, rate limiting, and cross-pod session sharing
+- **Test Commands**: `npm run test:mcp`, `npm run test:http`, `npm run test:redis`, `npm run test:all`
 
 ### Deployment
 - Docker containerization

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -12,6 +12,7 @@
         "@airweave/sdk": "^0.6.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "express": "^4.18.2",
+        "redis": "^4.6.13",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -22,6 +23,7 @@
         "@types/node": "^22.10.7",
         "@types/supertest": "^6.0.2",
         "@vitest/coverage-v8": "^2.0.0",
+        "redis-memory-server": "^0.10.0",
         "supertest": "^7.0.0",
         "typescript": "^5.7.3",
         "vitest": "^2.0.0"
@@ -862,6 +864,65 @@
         "node": ">=14"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.50.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.1.tgz",
@@ -1319,6 +1380,17 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
@@ -1478,6 +1550,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1633,6 +1715,16 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1681,6 +1773,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -1706,6 +1811,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -1740,6 +1864,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -1929,6 +2060,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2155,6 +2296,27 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2173,6 +2335,16 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
     },
     "node_modules/finalhandler": {
       "version": "1.3.1",
@@ -2206,6 +2378,71 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/find-package-json": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz",
+      "integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -2277,6 +2514,32 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2299,6 +2562,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2325,6 +2597,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -2336,6 +2621,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob": {
@@ -2442,6 +2743,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -2567,6 +2882,43 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lockfile": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/lodash.defaultsdeep": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -2716,6 +3068,49 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2792,6 +3187,45 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -2806,6 +3240,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -2857,6 +3301,13 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2871,6 +3322,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/postcss": {
@@ -2913,6 +3377,17 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -2961,6 +3436,71 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
+    "node_modules/redis-memory-server": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/redis-memory-server/-/redis-memory-server-0.10.0.tgz",
+      "integrity": "sha512-D0CFfUzAOQv/64iYzRqxUs4MEV2LlaW227qDvuuiq2FR4FXLrxyfENFf7dj6v4IwGTcNSLxhDlNKQthYVncg3Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.3.0",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.3.4",
+        "extract-zip": "^2.0.1",
+        "find-cache-dir": "^3.3.2",
+        "find-package-json": "^1.2.0",
+        "get-port": "^5.1.1",
+        "https-proxy-agent": "^7.0.0",
+        "lockfile": "^1.0.4",
+        "lodash.defaultsdeep": "^4.6.1",
+        "mkdirp": "^3.0.1",
+        "rimraf": "^5.0.1",
+        "semver": "^7.5.3",
+        "tar": "^6.1.15",
+        "tmp": "^0.2.1",
+        "uuid": "^8.3.2"
+      },
+      "bin": {
+        "redis-memory-server": "bin/index.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -3449,6 +3989,47 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -3506,6 +4087,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/toidentifier": {
@@ -3576,6 +4167,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -3871,6 +4472,23 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.28",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -49,6 +49,7 @@
     "@airweave/sdk": "^0.6.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "express": "^4.18.2",
+    "redis": "^4.6.13",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/mcp/src/session/redis-session-manager.ts
+++ b/mcp/src/session/redis-session-manager.ts
@@ -1,0 +1,309 @@
+/**
+ * Redis-based session manager for MCP server
+ * 
+ * Stores session metadata in Redis to enable stateless, horizontally-scalable deployments.
+ * Session state includes: API key hash, collections metadata, last access timestamp.
+ * 
+ * Security measures:
+ * - API keys are hashed (SHA-256) before storage for defense-in-depth
+ * - Session TTL limits exposure window
+ * - Client binding (IP/User-Agent) prevents session hijacking
+ * - Comprehensive audit logging for security monitoring
+ * 
+ * Note: We still need plaintext API keys at runtime to call Airweave API,
+ * but Redis compromise won't expose them.
+ */
+
+import { createClient, RedisClientType } from 'redis';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createHash } from 'crypto';
+
+export interface SessionData {
+    sessionId: string;
+    apiKeyHash: string;  // SHA-256 hash of API key (not the key itself)
+    collection: string;
+    baseUrl: string;
+    createdAt: number;
+    lastAccessedAt: number;
+    // Security: Client binding to prevent session hijacking
+    clientIP?: string;
+    userAgent?: string;
+}
+
+export interface SessionMetadata {
+    clientIP?: string;
+    userAgent?: string;
+}
+
+export interface SessionWithTransport {
+    server: McpServer;
+    transport: StreamableHTTPServerTransport;
+    data: SessionData;
+}
+
+export class RedisSessionManager {
+    private redis: RedisClientType;
+    private connected: boolean = false;
+    private readonly SESSION_PREFIX = 'mcp:session:';
+    private readonly RATE_LIMIT_PREFIX = 'mcp:rate_limit:';
+    private readonly DEFAULT_TTL = 1800; // 30 minutes (reduced from 1 hour for security)
+    private readonly RATE_LIMIT_WINDOW = 3600; // 1 hour
+    private readonly MAX_SESSIONS_PER_HOUR = 100; // Per API key
+
+    constructor(redisUrl?: string) {
+        this.redis = createClient({
+            url: redisUrl || process.env.REDIS_URL || 'redis://localhost:6379',
+            socket: {
+                reconnectStrategy: (retries) => {
+                    if (retries > 10) {
+                        console.error('Redis: Max reconnection attempts reached');
+                        return new Error('Max reconnection attempts reached');
+                    }
+                    const delay = Math.min(retries * 100, 3000);
+                    console.log(`Redis: Reconnecting in ${delay}ms (attempt ${retries})`);
+                    return delay;
+                }
+            }
+        });
+
+        this.redis.on('error', (err) => {
+            console.error('Redis Client Error:', err);
+        });
+
+        this.redis.on('connect', () => {
+            console.log('Redis: Connected');
+            this.connected = true;
+        });
+
+        this.redis.on('disconnect', () => {
+            console.log('Redis: Disconnected');
+            this.connected = false;
+        });
+    }
+
+    async connect(): Promise<void> {
+        if (!this.connected) {
+            await this.redis.connect();
+        }
+    }
+
+    async disconnect(): Promise<void> {
+        if (this.connected) {
+            await this.redis.quit();
+            this.connected = false;
+        }
+    }
+
+    isConnected(): boolean {
+        return this.connected;
+    }
+
+    private getKey(sessionId: string): string {
+        return `${this.SESSION_PREFIX}${sessionId}`;
+    }
+
+    private getRateLimitKey(apiKeyHash: string): string {
+        const hour = Math.floor(Date.now() / (1000 * 60 * 60));
+        return `${this.RATE_LIMIT_PREFIX}${apiKeyHash}:${hour}`;
+    }
+
+    /**
+     * Hash an API key using SHA-256 for secure storage
+     * Note: This is defense-in-depth. We still need the plaintext key at runtime.
+     */
+    static hashApiKey(apiKey: string): string {
+        return createHash('sha256').update(apiKey).digest('hex');
+    }
+
+    /**
+     * Validate that an API key matches the stored hash
+     */
+    static validateApiKey(apiKey: string, apiKeyHash: string): boolean {
+        return RedisSessionManager.hashApiKey(apiKey) === apiKeyHash;
+    }
+
+    /**
+     * Audit log for security monitoring
+     */
+    private auditLog(operation: string, details: Record<string, any>): void {
+        console.log(JSON.stringify({
+            timestamp: new Date().toISOString(),
+            service: 'mcp-redis-session',
+            operation,
+            ...details
+        }));
+    }
+
+    /**
+     * Check rate limit for session creation
+     */
+    async checkRateLimit(apiKey: string): Promise<{ allowed: boolean; count: number }> {
+        try {
+            const apiKeyHash = RedisSessionManager.hashApiKey(apiKey);
+            const rateLimitKey = this.getRateLimitKey(apiKeyHash);
+
+            const count = await this.redis.incr(rateLimitKey);
+
+            // Set expiration on first increment
+            if (count === 1) {
+                await this.redis.expire(rateLimitKey, this.RATE_LIMIT_WINDOW);
+            }
+
+            const allowed = count <= this.MAX_SESSIONS_PER_HOUR;
+
+            if (!allowed) {
+                this.auditLog('rate_limit_exceeded', {
+                    apiKeyHash: apiKeyHash ? apiKeyHash.substring(0, 16) + '...' : 'N/A',
+                    count,
+                    limit: this.MAX_SESSIONS_PER_HOUR
+                });
+            }
+
+            return { allowed, count };
+        } catch (error) {
+            console.error('Error checking rate limit:', error);
+            // Fail open - allow the request if rate limiting fails
+            return { allowed: true, count: 0 };
+        }
+    }
+
+    /**
+     * Get session data from Redis
+     */
+    async getSession(sessionId: string): Promise<SessionData | null> {
+        try {
+            const key = this.getKey(sessionId);
+            const data = await this.redis.get(key);
+
+            if (!data) {
+                this.auditLog('session_miss', { sessionId });
+                return null;
+            }
+
+            const sessionData = JSON.parse(data) as SessionData;
+
+            // Update last accessed time
+            sessionData.lastAccessedAt = Date.now();
+            await this.redis.set(key, JSON.stringify(sessionData), {
+                EX: this.DEFAULT_TTL
+            });
+
+            this.auditLog('session_accessed', {
+                sessionId,
+                apiKeyHash: sessionData.apiKeyHash ? sessionData.apiKeyHash.substring(0, 16) + '...' : 'N/A',
+                age: Date.now() - sessionData.createdAt
+            });
+
+            return sessionData;
+        } catch (error) {
+            console.error(`Error getting session ${sessionId}:`, error);
+            this.auditLog('session_error', { sessionId, error: String(error) });
+            return null;
+        }
+    }
+
+    /**
+     * Create or update session in Redis
+     * Includes rate limiting check for new sessions
+     */
+    async setSession(sessionData: SessionData, isNewSession: boolean = false): Promise<void> {
+        try {
+            const key = this.getKey(sessionData.sessionId);
+            await this.redis.set(key, JSON.stringify(sessionData), {
+                EX: this.DEFAULT_TTL
+            });
+
+            this.auditLog(isNewSession ? 'session_created' : 'session_updated', {
+                sessionId: sessionData.sessionId,
+                apiKeyHash: sessionData.apiKeyHash ? sessionData.apiKeyHash.substring(0, 16) + '...' : 'N/A',
+                clientIP: sessionData.clientIP || 'unknown',
+                hasBinding: !!(sessionData.clientIP && sessionData.userAgent)
+            });
+        } catch (error) {
+            console.error(`Error setting session ${sessionData.sessionId}:`, error);
+            this.auditLog('session_error', {
+                sessionId: sessionData.sessionId,
+                error: String(error),
+                operation: 'set'
+            });
+            throw error;
+        }
+    }
+
+    /**
+     * Delete session from Redis
+     */
+    async deleteSession(sessionId: string): Promise<void> {
+        try {
+            const key = this.getKey(sessionId);
+            await this.redis.del(key);
+
+            this.auditLog('session_deleted', { sessionId });
+        } catch (error) {
+            console.error(`Error deleting session ${sessionId}:`, error);
+            this.auditLog('session_error', {
+                sessionId,
+                error: String(error),
+                operation: 'delete'
+            });
+        }
+    }
+
+    /**
+     * Check if a session exists
+     */
+    async sessionExists(sessionId: string): Promise<boolean> {
+        try {
+            const key = this.getKey(sessionId);
+            const exists = await this.redis.exists(key);
+            return exists === 1;
+        } catch (error) {
+            console.error(`Error checking session ${sessionId}:`, error);
+            return false;
+        }
+    }
+
+    /**
+     * Get all session IDs (for debugging/monitoring)
+     */
+    async getAllSessionIds(): Promise<string[]> {
+        try {
+            const keys = await this.redis.keys(`${this.SESSION_PREFIX}*`);
+            return keys.map(key => key.replace(this.SESSION_PREFIX, ''));
+        } catch (error) {
+            console.error('Error getting all session IDs:', error);
+            return [];
+        }
+    }
+
+
+    /**
+     * Clean up expired sessions (manual cleanup, Redis TTL handles this automatically)
+     */
+    async cleanupExpiredSessions(maxAge: number = this.DEFAULT_TTL * 1000): Promise<number> {
+        try {
+            const keys = await this.redis.keys(`${this.SESSION_PREFIX}*`);
+            let deleted = 0;
+
+            for (const key of keys) {
+                const data = await this.redis.get(key);
+                if (data) {
+                    const sessionData = JSON.parse(data) as SessionData;
+                    const age = Date.now() - sessionData.lastAccessedAt;
+
+                    if (age > maxAge) {
+                        await this.redis.del(key);
+                        deleted++;
+                    }
+                }
+            }
+
+            return deleted;
+        } catch (error) {
+            console.error('Error cleaning up expired sessions:', error);
+            return 0;
+        }
+    }
+}
+


### PR DESCRIPTION
Leverage Redis to enable stateless, horizontally-scalable MCP deployments.

## Testing Plan
```
Test Configuration:
  MCP Instance 1: http://localhost:8081/mcp
  MCP Instance 2: http://localhost:8082/mcp
  Session ID: test-session-1760889955

Test 1: Creating session on MCP Instance 1...
✓ Session created successfully on Instance 1
Response: event: message
data: {"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{"listChanged":true},"logging":{}},"serverInfo":{"name":"airweave-search","version":"2.1.0"}},"jsonrpc":"2.0","id":1}

Test 2: Using same session on MCP Instance 2...
✓ Session retrieved from Redis and server initialized on Instance 2
✓ Tools available on Instance 2 (session state maintained across pods)

Test 3: Alternating requests between instances...
  Request 1 to Instance 1...
    ✓ Success
  Request 2 to Instance 2...
    ✓ Success
  Request 3 to Instance 1...
    ✓ Success

Test 4: Checking health endpoints...
✓ Instance 1 connected to Redis
✓ Instance 2 connected to Redis

Test 5: Deleting session...
✓ Session deleted successfully
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds Redis-backed session storage to the MCP HTTP server to make deployments stateless and horizontally scalable. Improves security, rate limiting, and cross-pod session restoration via a per-pod cache.

- **New Features**
  - Store session metadata in Redis with a 30-minute TTL; sessions can be served by any pod.
  - Per-pod in-memory cache rebuilt from Redis; API key changes trigger session recreation.
  - Client binding (IP/User-Agent) to prevent session hijacking; API keys stored as hashes.
  - Rate limit session creation to 100/hour per API key with audit logs.
  - Health endpoint shows Redis status and active session count.
  - DELETE /mcp terminates sessions across pods; graceful shutdown closes sessions and disconnects Redis.

- **Dependencies**
  - Add redis and redis-memory-server; new test script: test:redis.

<!-- End of auto-generated description by cubic. -->

