### PR TITLE
Per-sync /tmp dir + automatic cleanup to prevent DiskPressure in sync workers

### DIFF
--- a/backend/airweave/platform/transformers/web_fetcher.py
+++ b/backend/airweave/platform/transformers/web_fetcher.py
@@ -544,8 +544,8 @@ async def _create_and_store_file_entity(
     safe_title = title.replace("/", "_").replace("\\", "_")[:100]  # Limit title length
     safe_filename = f"{file_uuid}-{safe_title}.md"
 
-    # Use storage manager's temp directory
-    base_temp_dir = "/tmp/airweave/processing"
+    # Use per-sync temp dir if provided via env; fallback to default
+    base_temp_dir = os.environ.get("AIRWEAVE_TMP_DIR", "/tmp/airweave/processing")
     os.makedirs(base_temp_dir, exist_ok=True)
     temp_file_path = os.path.join(base_temp_dir, safe_filename)
 


### PR DESCRIPTION
1. Introduces per-sync tmp dir at `/tmp/airweave/processing/<sync_id>` and exposes `sync_context.tmp_processing_dir.`
2. Ensures all tmp writes respect `AIRWEAVE_TMP_DIR` (used by FileManager and web_fetcher).
3. Cleans the per-sync tmp dir in `run()` finally block to avoid residual large files.
4. Mitigates node DiskPressure from large transient media (MP4/PDF) produced during syncs.

We use `os.environ.get("AIRWEAVE_TMP_DIR", "/tmp/airweave/processing")` so the temp path can be overridden at runtime while defaulting safely when no override is provided. Some utilities (e.g., file handling/transformers) don’t get SyncContext injected.

## Testing 

```
Runtime verification (local Docker):

2025-10-20 10:25:09,404 - airweave.platform.sync - INFO - Starting sync job
2025-10-20 10:25:09,405 - airweave.platform.sync - INFO - Prepared tmp processing directory: /tmp/airweave/processing/afc9bd87-8484-4757-9202-801d7fbfe4f8
2025-10-20 10:25:10,087 - airweave.platform.sync - INFO - Completed sync job 4067c63b-9ae1-40e3-afd1-c337b1c829c3 successfully. Stats: inserted=0 updated=0 deleted=0 kept=1 skipped=0 entities_encountered={'GitHubDirectoryEntity': 0, 'GitHubCodeFileEntity': 0, 'GitHubFileDeletionEntity': 0, 'GitHubRepositoryEntity': 1, 'GithubContentEntity': 0, 'GithubRepoEntity': 0} status=None
2025-10-20 10:25:10,087 - airweave.platform.sync - INFO - 🧹 Cleaning tmp processing directory: /tmp/airweave/processing/afc9bd87-8484-4757-9202-801d7fbfe4f8

2025-10-20 10:26:36,461 - airweave.platform.sync - INFO - Starting sync job
2025-10-20 10:26:36,462 - airweave.platform.sync - INFO - Prepared tmp processing directory: /tmp/airweave/processing/afc9bd87-8484-4757-9202-801d7fbfe4f8
2025-10-20 10:26:37,112 - airweave.platform.sync - INFO - Completed sync job 81bbd3df-385e-4e22-85db-fe5e3af103ad successfully. Stats: inserted=0 updated=0 deleted=0 kept=1 skipped=0 entities_encountered={'GitHubDirectoryEntity': 0, 'GitHubCodeFileEntity': 0, 'GitHubFileDeletionEntity': 0, 'GitHubRepositoryEntity': 1, 'GithubContentEntity': 0, 'GithubRepoEntity': 0} status=None
2025-10-20 10:26:37,112 - airweave.platform.sync - INFO - 🧹 Cleaning tmp processing directory: /tmp/airweave/processing/afc9bd87-8484-4757-9202-801d7fbfe4f8

2025-10-20 10:27:04,366 - airweave.platform.sync - INFO - Starting sync job
2025-10-20 10:27:04,366 - airweave.platform.sync - INFO - Prepared tmp processing directory: /tmp/airweave/processing/e80c1877-4c1e-4e5a-a981-83610b88090f
2025-10-20 10:28:23,194 - airweave.platform.sync - INFO - Completed sync job 74fd7a1a-cc1f-45f9-b613-a6520cb71f9f successfully. Stats: inserted=349 updated=0 deleted=0 kept=0 skipped=0 entities_encountered={'GitHubDirectoryEntity': 5, 'GitHubCodeFileEntity': 343, 'GitHubFileDeletionEntity': 0, 'GitHubRepositoryEntity': 1, 'GithubContentEntity': 0, 'GithubRepoEntity': 0} status=None
2025-10-20 10:28:23,194 - airweave.platform.sync - INFO - 🧹 Cleaning tmp processing directory: /tmp/airweave/processing/e80c1877-4c1e-4e5a-a981-83610b88090f

Container state after runs:
- /tmp/airweave/processing exists, no per-sync subdirs remain (cleaned).
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a per-sync temp directory and automatic cleanup in sync workers to prevent DiskPressure from large transient files. FileManager and web_fetcher now honor AIRWEAVE_TMP_DIR, defaulting to /tmp/airweave/processing.

- **Bug Fixes**
  - Create /tmp/airweave/processing/<sync_id>, expose as sync_context.tmp_processing_dir, and export AIRWEAVE_TMP_DIR during the run.
  - Clean the per-sync directory in the orchestrator’s finally block with best-effort rmtree.
  - FileManager resolves the temp dir via AIRWEAVE_TMP_DIR and ensures the dir exists before writes.
  - web_fetcher uses AIRWEAVE_TMP_DIR for temp files with a safe default.

<!-- End of auto-generated description by cubic. -->

