### PR TITLE
fix(google-drive/diskpressure): Exclude all video files from download to prevent tmp storage issues

### DIFF
--- a/backend/airweave/platform/sources/google_drive.py
+++ b/backend/airweave/platform/sources/google_drive.py
@@ -580,8 +580,15 @@ class GoogleDriveSource(BaseSource):
     def _build_file_entity(self, file_obj: Dict) -> Optional[GoogleDriveFileEntity]:
         """Helper to build a GoogleDriveFileEntity from a file API response object.
 
-        Returns None for files that should be skipped (e.g., trashed files).
+        Returns None for files that should be skipped (e.g., trashed files, videos).
         """
+        # Skip all video files to prevent tmp storage issues
+        mime_type = file_obj.get("mimeType", "")
+        if mime_type.startswith("video/"):
+            file_name = file_obj.get("name", "unknown")
+            self.logger.debug(f"Skipping video file ({mime_type}): {file_name}")
+            return None
+
         # Create download URL based on file type
         download_url = None
 


### PR DESCRIPTION
Video files from Google Drive syncs are filling up temporary storage in Kubernetes pods, causing storage pressure and potential pod failures.

Added a simple MIME type check in `_build_file_entity()` to skip all video files (any MIME type starting with `video/`) before they are downloaded. Files are excluded early in the processing pipeline, preventing any storage impact.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Skip downloading video files from Google Drive to prevent tmp storage pressure and potential pod failures in Kubernetes pods. Added a MIME type check in _build_file_entity() to exclude any file with mimeType starting with video/.

<!-- End of auto-generated description by cubic. -->

