### PR TITLE
fix: Update HTTP methods for collection and source-connection endpoints (PUT → PATCH)

### DIFF
--- a/frontend/src/components/collection/SourceConnectionSettings.tsx
+++ b/frontend/src/components/collection/SourceConnectionSettings.tsx
@@ -49,13 +49,13 @@ interface SourceConnection {
   name: string;
   description?: string;
   short_name: string;
+  readable_collection_id: string;
   config_fields?: Record<string, any>;
   sync_id?: string;
   organization_id: string;
   created_at: string;
   modified_at: string;
   connection_id?: string;
-  collection: string;
   created_by_email: string;
   modified_by_email: string;
   auth_fields?: Record<string, any> | string;
@@ -285,7 +285,7 @@ export const SourceConnectionSettings: React.FC<SourceConnectionSettingsProps> =
         return;
       }
 
-      const response = await apiClient.put(`/source-connections/${sourceConnection?.id}`, null, updateData);
+      const response = await apiClient.patch(`/source-connections/${sourceConnection?.id}`, updateData);
 
       if (!response.ok) {
         throw new Error("Failed to update source connection");

--- a/frontend/src/pages/CollectionDetailView.tsx
+++ b/frontend/src/pages/CollectionDetailView.tsx
@@ -462,7 +462,7 @@ const Collections = () => {
         }
 
         try {
-            const response = await apiClient.put(`/collections/${readable_id}`, null, { name: newName });
+            const response = await apiClient.patch(`/collections/${readable_id}`, { name: newName });
             if (!response.ok) throw new Error("Failed to update collection name");
 
             // Update local state after successful API call


### PR DESCRIPTION
Resolves:

- https://linear.app/airweave-main/issue/ENG-199/cannot-change-collection-name
- https://linear.app/airweave-main/issue/ENG-198/cant-edit-source-connection
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switch update calls from PUT to PATCH for collections and source connections to match the backend and fix failed updates. Also corrected how the request body is sent and aligned types.

- **Bug Fixes**
  - Use PATCH for /collections/:id and /source-connections/:id updates.
  - Send the update payload as the request body (removed the null param).

- **Refactors**
  - Updated SourceConnection type: added readable_collection_id, removed collection.

<!-- End of auto-generated description by cubic. -->

