### PR TITLE
fix: Enable scrolling in edit source connection modal on small screens

### DIFF
--- a/frontend/src/components/collection/EditSourceConnectionDialog.tsx
+++ b/frontend/src/components/collection/EditSourceConnectionDialog.tsx
@@ -84,10 +84,10 @@ export const EditSourceConnectionDialog: React.FC<EditSourceConnectionDialogProp
                     maxHeight: "95vh"
                 }}
             >
-                <div className="flex flex-col h-full">
+                <div className="flex flex-col h-full overflow-hidden">
                     {/* Content area - scrollable */}
-                    <div className="flex-grow overflow-y-auto">
-                        <div className="px-8 py-6 h-full flex flex-col">
+                    <div className="flex-1 overflow-y-auto min-h-0">
+                        <div className="px-8 py-6">
                             {/* Heading with Icon */}
                             <div className="flex items-center gap-4 mb-2">
                                 {/* Source Icon - smaller */}


### PR DESCRIPTION
The "Edit Details" modal for source connections was not scrollable on small screens or when content exceeded viewport height. Users could not access the Update/Cancel buttons at the bottom.

Partially fixes: https://linear.app/airweave-main/issue/ENG-198/cant-edit-source-connection

Full fix combined with: https://github.com/airweave-ai/airweave/pull/986