### PR TITLE
refactor(api): let rate limits only apply on api key + use enums for auth method

### DIFF
--- a/backend/airweave/api/context.py
+++ b/backend/airweave/api/context.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from airweave import schemas
 from airweave.core.logging import ContextualLogger
+from airweave.core.shared_models import AuthMethod
 from airweave.core.shared_models import FeatureFlag as FeatureFlagEnum
 
 
@@ -28,7 +29,7 @@ class ApiContext(BaseModel):
     # Authentication context
     organization: schemas.Organization
     user: Optional[schemas.User] = None
-    auth_method: str  # "auth0", "api_key", "system"
+    auth_method: AuthMethod
     auth_metadata: Optional[Dict[str, Any]] = None
 
     # Contextual logger with all dimensions pre-configured
@@ -62,12 +63,12 @@ class ApiContext(BaseModel):
     @property
     def is_api_key_auth(self) -> bool:
         """Whether this is API key authentication."""
-        return self.auth_method == "api_key"
+        return self.auth_method == AuthMethod.API_KEY
 
     @property
     def is_user_auth(self) -> bool:
         """Whether this is user authentication (Auth0)."""
-        return self.auth_method == "auth0"
+        return self.auth_method == AuthMethod.AUTH0
 
     def has_feature(self, flag: FeatureFlagEnum) -> bool:
         """Check if organization has a feature enabled.
@@ -90,13 +91,13 @@ class ApiContext(BaseModel):
         if self.user:
             return (
                 f"ApiContext(request_id={self.request_id[:8]}..., "
-                f"method={self.auth_method}, user={self.user.email}, "
+                f"method={self.auth_method.value}, user={self.user.email}, "
                 f"org={self.organization.id})"
             )
         else:
             return (
                 f"ApiContext(request_id={self.request_id[:8]}..., "
-                f"method={self.auth_method}, org={self.organization.id})"
+                f"method={self.auth_method.value}, org={self.organization.id})"
             )
 
     def to_serializable_dict(self) -> Dict[str, Any]:
@@ -110,6 +111,6 @@ class ApiContext(BaseModel):
             "organization_id": str(self.organization.id),
             "organization": self.organization.model_dump(mode="json"),
             "user": self.user.model_dump(mode="json") if self.user else None,
-            "auth_method": self.auth_method,
+            "auth_method": self.auth_method.value,
             "auth_metadata": self.auth_metadata,
         }

--- a/backend/airweave/api/v1/endpoints/users.py
+++ b/backend/airweave/api/v1/endpoints/users.py
@@ -20,6 +20,7 @@ from airweave.api.router import TrailingSlashRouter
 from airweave.core.email_service import send_welcome_email
 from airweave.core.exceptions import NotFoundException
 from airweave.core.logging import logger
+from airweave.core.shared_models import AuthMethod
 from airweave.db.unit_of_work import UnitOfWork
 from airweave.schemas import OrganizationWithRole, User
 
@@ -189,7 +190,7 @@ async def create_or_update_user(
                     request=uuid4(),
                     user=user,
                     organization=organization,
-                    auth_method="auth0",
+                    auth_method=AuthMethod.AUTH0,
                 ),
                 uow=uow,
             )

--- a/backend/airweave/billing/service.py
+++ b/backend/airweave/billing/service.py
@@ -26,6 +26,7 @@ from airweave.billing.plan_logic import (
 from airweave.billing.transactions import billing_transactions
 from airweave.core.exceptions import InvalidStateError, NotFoundException
 from airweave.core.logging import ContextualLogger, logger
+from airweave.core.shared_models import AuthMethod
 from airweave.db.unit_of_work import UnitOfWork
 from airweave.integrations.stripe_client import stripe_client
 from airweave.models import Organization
@@ -49,7 +50,7 @@ class BillingService:
         request_id = str(uuid4())
         return ApiContext(
             request_id=request_id,
-            auth_method="internal_system",
+            auth_method=AuthMethod.INTERNAL_SYSTEM,
             auth_subject_id=str(uuid4()),
             auth_subject_name=f"billing_{source}",
             organization=organization,
@@ -57,7 +58,7 @@ class BillingService:
             logger=logger.with_context(
                 request_id=request_id,
                 organization_id=str(organization.id),
-                auth_method="internal_system",
+                auth_method=AuthMethod.INTERNAL_SYSTEM.value,
                 source=source,
             ),
         )
@@ -450,7 +451,7 @@ class BillingService:
         target_plan = BillingPlan(new_plan)
 
         # Block public Enterprise upgrades/changes (allow only internal/system)
-        if target_plan == BillingPlan.ENTERPRISE and ctx.auth_method != "internal_system":
+        if target_plan == BillingPlan.ENTERPRISE and ctx.auth_method != AuthMethod.INTERNAL_SYSTEM:
             raise InvalidStateError(
                 "Enterprise plan is only available via sales. Please contact support."
             )

--- a/backend/airweave/billing/webhook_handler.py
+++ b/backend/airweave/billing/webhook_handler.py
@@ -22,6 +22,7 @@ from airweave.billing.plan_logic import (
 from airweave.billing.service import billing_service
 from airweave.billing.transactions import billing_transactions
 from airweave.core.logging import ContextualLogger, logger
+from airweave.core.shared_models import AuthMethod
 from airweave.integrations.stripe_client import stripe_client
 from airweave.schemas.billing_period import BillingPeriodStatus, BillingTransition
 from airweave.schemas.organization_billing import (
@@ -90,13 +91,13 @@ class BillingWebhookProcessor:
         if organization_id:
             return logger.with_context(
                 organization_id=str(organization_id),
-                auth_method="stripe_webhook",
+                auth_method=AuthMethod.STRIPE_WEBHOOK.value,
                 event_type=event.type,
                 stripe_event_id=event.id,
             )
 
         return logger.with_context(
-            auth_method="stripe_webhook",
+            auth_method=AuthMethod.STRIPE_WEBHOOK.value,
             event_type=event.type,
             stripe_event_id=event.id,
         )

--- a/backend/airweave/core/organization_service.py
+++ b/backend/airweave/core/organization_service.py
@@ -13,6 +13,7 @@ from airweave.api.context import ApiContext
 # Import billing dependencies only if Stripe is enabled
 from airweave.core.config import settings
 from airweave.core.logging import logger
+from airweave.core.shared_models import AuthMethod
 from airweave.db.unit_of_work import UnitOfWork
 from airweave.integrations.auth0_management import auth0_management_client
 from airweave.models import Organization, User, UserOrganization
@@ -147,11 +148,11 @@ class OrganizationService:
                         request_id=str(uuid4()),
                         organization=local_org_schema,
                         user=None,
-                        auth_method="system",
+                        auth_method=AuthMethod.SYSTEM,
                         auth_metadata={"source": "organization_creation"},
                         logger=logger.with_context(
                             organization_id=str(local_org_schema.id),
-                            auth_method="system",
+                            auth_method=AuthMethod.SYSTEM.value,
                             source="organization_creation",
                         ),
                     )
@@ -212,7 +213,7 @@ class OrganizationService:
                 contextual_logger = logger.with_context(
                     request_id=request_id,
                     organization_id=str(org_id),
-                    auth_method="system",
+                    auth_method=AuthMethod.SYSTEM.value,
                     context_base="organization_service",
                     user_id=str(owner_user.id),
                     user_email=owner_user.email,
@@ -222,7 +223,7 @@ class OrganizationService:
                     request_id=request_id,
                     organization=organization,  # Use the full organization object
                     user=owner_user,  # Set the owner as the creator
-                    auth_method="system",
+                    auth_method=AuthMethod.SYSTEM,
                     auth_metadata={"source": "organization_creation"},
                     logger=contextual_logger,
                 )

--- a/backend/airweave/core/rate_limiter_service.py
+++ b/backend/airweave/core/rate_limiter_service.py
@@ -135,8 +135,8 @@ class RateLimiter:
             return RateLimitResult(
                 allowed=True,
                 retry_after=0.0,
-                limit=0,
-                remaining=0,
+                limit=9999,
+                remaining=9999,
             )
 
         current_time = time.time()

--- a/backend/airweave/core/shared_models.py
+++ b/backend/airweave/core/shared_models.py
@@ -76,3 +76,17 @@ class FeatureFlag(str, Enum):
 
     S3_DESTINATION = "s3_destination"
     PRIORITY_SUPPORT = "priority_support"
+
+
+class AuthMethod(str, Enum):
+    """Authentication methods used in API requests.
+
+    Defines the valid authentication methods for API context.
+    """
+
+    AUTH0 = "auth0"  # User authentication via Auth0 JWT tokens
+    API_KEY = "api_key"  # Programmatic access via API keys
+    SYSTEM = "system"  # Internal system operations (local dev, migrations)
+    INTERNAL_SYSTEM = "internal_system"  # Internal service-to-service calls
+    STRIPE_WEBHOOK = "stripe_webhook"  # Stripe webhook handlers
+    OAUTH_CALLBACK = "oauth_callback"  # OAuth callback handlers

--- a/backend/airweave/core/source_connection_service_helpers.py
+++ b/backend/airweave/core/source_connection_service_helpers.py
@@ -21,6 +21,7 @@ from airweave.core.constants.reserved_ids import (
     NATIVE_TEXT2VEC_UUID,
 )
 from airweave.core.shared_models import (
+    AuthMethod,
     ConnectionStatus,
     FeatureFlag,
     SourceConnectionStatus,
@@ -148,7 +149,7 @@ class SourceConnectionHelpers:
             request_id=request_id,
             organization_id=str(organization_schema.id),
             organization_name=organization_schema.name,
-            auth_method="oauth_callback",  # Special auth method for OAuth callbacks
+            auth_method=AuthMethod.OAUTH_CALLBACK.value,  # Special auth method for OAuth callbacks
             context_base="oauth",
         )
 
@@ -156,7 +157,7 @@ class SourceConnectionHelpers:
             request_id=request_id,
             organization=organization_schema,
             user=None,  # No user context for OAuth callbacks
-            auth_method="oauth_callback",
+            auth_method=AuthMethod.OAUTH_CALLBACK,
             auth_metadata={"session_id": str(init_session.id)},
             logger=base_logger,
         )

--- a/backend/airweave/db/init_db.py
+++ b/backend/airweave/db/init_db.py
@@ -10,6 +10,7 @@ from airweave.api.context import ApiContext
 from airweave.core.config import settings
 from airweave.core.exceptions import NotFoundException
 from airweave.core.logging import logger
+from airweave.core.shared_models import AuthMethod
 from airweave.db.init_db_native import (
     init_db_with_entity_definitions,
     init_db_with_native_connections,
@@ -50,7 +51,7 @@ async def init_db(db: AsyncSession) -> None:
                 request_id=str(uuid.uuid4()),
                 user=user,
                 organization=organization,
-                auth_method="system",
+                auth_method=AuthMethod.SYSTEM,
                 logger=logger,
             ),
         )

--- a/backend/airweave/schemas/rate_limit.py
+++ b/backend/airweave/schemas/rate_limit.py
@@ -8,5 +8,14 @@ class RateLimitResult(BaseModel):
 
     allowed: bool = Field(..., description="Whether the request should be allowed")
     retry_after: float = Field(..., description="Seconds until rate limit resets (0.0 if allowed)")
-    limit: int = Field(..., description="Maximum requests per window (0 indicates unlimited)")
-    remaining: int = Field(..., description="Requests remaining in current window")
+    limit: int = Field(
+        ...,
+        description=(
+            "Maximum requests per window "
+            "(9999 indicates unlimited/not applicable, e.g., for Auth0 or system auth)"
+        ),
+    )
+    remaining: int = Field(
+        ...,
+        description="Requests remaining in current window (9999 for unlimited/not applicable)",
+    )

--- a/backend/tests/unit/core/test_rate_limiter_service.py
+++ b/backend/tests/unit/core/test_rate_limiter_service.py
@@ -123,8 +123,8 @@ async def test_rate_limiter_unlimited_for_enterprise(
 
     assert result.allowed is True
     assert result.retry_after == 0.0
-    assert result.limit == 0  # 0 indicates unlimited
-    assert result.remaining == 0
+    assert result.limit == 9999  # 9999 indicates unlimited
+    assert result.remaining == 9999
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Limit rate limiting to API key requests and switch auth method handling to the AuthMethod enum across the backend. This fixes access-token calls being rate-limited and standardizes auth metadata and logging.

- **Bug Fixes**
  - Rate limiting now applies only to API key auth; Auth0 and system auth are excluded.
  - RateLimitResult uses 9999 for unlimited/not applicable (replaces 0).

- **Migration**
  - If you consume rate limit values, update checks to treat 9999 as unlimited instead of 0.

<!-- End of auto-generated description by cubic. -->

