### PR TITLE
fix: decrement usage for source connections

### DIFF
--- a/backend/airweave/core/guard_rail_service.py
+++ b/backend/airweave/core/guard_rail_service.py
@@ -274,8 +274,9 @@ class GuardRailService:
             )
 
             # Check if this specific action type should flush
+            # Use absolute value to handle both positive and negative accumulated changes
             threshold = self.FLUSH_THRESHOLDS.get(action_type, 1)
-            if self.pending_increments[action_type] >= threshold:
+            if abs(self.pending_increments[action_type]) >= threshold:
                 await self._flush_usage_internal(action_type)
 
     async def decrement(self, action_type: ActionType, amount: int = 1) -> None:
@@ -297,8 +298,9 @@ class GuardRailService:
             )
 
             # Check if this specific action type should flush
+            # Use absolute value to handle both increments and decrements
             threshold = self.FLUSH_THRESHOLDS.get(action_type, 1)
-            if self.pending_increments[action_type] >= threshold:
+            if abs(self.pending_increments[action_type]) >= threshold:
                 await self._flush_usage_internal(action_type)
 
     async def _flush_usage_internal(self, action_type: Optional[ActionType] = None) -> None:
@@ -330,11 +332,11 @@ class GuardRailService:
                 return
             increments_to_flush = {action_type: self.pending_increments[action_type]}
         else:
-            # Flush all non-zero increments
+            # Flush all non-zero increments (both positive and negative)
             increments_to_flush = {
                 action_type: count
                 for action_type, count in self.pending_increments.items()
-                if count > 0
+                if count != 0
             }
 
         # Perform database operations outside the lock

--- a/backend/airweave/crud/crud_usage.py
+++ b/backend/airweave/crud/crud_usage.py
@@ -164,7 +164,7 @@ class CRUDUsage(CRUDBaseOrganization[Usage, UsageCreate, UsageUpdate]):
         params = {"usage_id": usage_id}
 
         for action_type, increment in increments.items():
-            if increment > 0:
+            if increment != 0:  # Handle both positive and negative increments
                 field = action_type.value
                 update_parts.append(f"{field} = {field} + :{field}_inc")
                 params[f"{field}_inc"] = increment


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix usage decrement handling for source connections. Pending negative deltas now trigger flushes, and the DB update applies both increments and decrements.

- **Bug Fixes**
  - Use absolute values when checking flush thresholds so decrements flush correctly.
  - Flush all non-zero pending changes (positive or negative).
  - Apply non-zero increments/decrements in the DB update query.

<!-- End of auto-generated description by cubic. -->

