### PR TITLE
feat: Add "last active" tracking and sorting to admin dashboard

### DIFF
--- a/backend/airweave/models/user.py
+++ b/backend/airweave/models/user.py
@@ -1,8 +1,9 @@
 """User model."""
 
+from datetime import datetime
 from typing import TYPE_CHECKING, List
 
-from sqlalchemy import UUID, Boolean, String
+from sqlalchemy import UUID, Boolean, DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from airweave.models._base import Base
@@ -23,6 +24,7 @@ class User(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     is_superuser: Mapped[bool] = mapped_column(Boolean, default=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    last_active_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
 
     # Many-to-many relationship with organizations
     user_organizations: Mapped[List["UserOrganization"]] = relationship(

--- a/backend/airweave/schemas/admin.py
+++ b/backend/airweave/schemas/admin.py
@@ -40,6 +40,9 @@ class OrganizationMetrics(BaseModel):
     )
     entity_count: int = Field(0, description="Total number of entities (from Usage.entities)")
     query_count: int = Field(0, description="Total number of queries (from Usage.queries)")
+    last_active_at: Optional[datetime] = Field(
+        None, description="Last active timestamp of any user in this organization"
+    )
 
     # Admin membership info
     is_member: bool = Field(False, description="Whether the current admin user is already a member")

--- a/backend/airweave/schemas/user.py
+++ b/backend/airweave/schemas/user.py
@@ -1,5 +1,6 @@
 """User schema module."""
 
+from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
@@ -67,6 +68,7 @@ class UserInDBBase(UserBase):
     primary_organization_id: Optional[UUID] = None
     user_organizations: list[UserOrganization] = Field(default_factory=list)
     is_admin: bool = False
+    last_active_at: Optional[datetime] = None
 
     @field_validator("user_organizations", mode="before")
     @classmethod

--- a/backend/alembic/versions/e4ebd5ee78b5_add_last_active_at_to_user.py
+++ b/backend/alembic/versions/e4ebd5ee78b5_add_last_active_at_to_user.py
@@ -1,0 +1,26 @@
+"""add_last_active_at_to_user
+
+Revision ID: e4ebd5ee78b5
+Revises: e3a7e8db826c
+Create Date: 2025-10-21 14:51:55.260463
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e4ebd5ee78b5'
+down_revision = 'e3a7e8db826c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add last_active_at column to user table
+    op.add_column('user', sa.Column('last_active_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    # Remove last_active_at column from user table
+    op.drop_column('user', 'last_active_at')

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -53,12 +53,13 @@ interface OrganizationMetrics {
   source_connection_count: number;
   entity_count: number;
   query_count: number;
+  last_active_at?: string;
   is_member: boolean;
   member_role?: string;
   enabled_features?: string[];
 }
 
-type SortField = 'name' | 'created_at' | 'billing_plan' | 'user_count' | 'source_connection_count' | 'entity_count' | 'query_count' | 'is_member';
+type SortField = 'name' | 'created_at' | 'billing_plan' | 'user_count' | 'source_connection_count' | 'entity_count' | 'query_count' | 'last_active_at' | 'is_member';
 type SortOrder = 'asc' | 'desc';
 type MembershipFilter = 'all' | 'member' | 'non-member';
 
@@ -169,7 +170,7 @@ export function AdminDashboard() {
       filtered = filtered.filter(org => !org.is_member);
     }
 
-    // Apply client-side sorting if sorting by membership
+    // Apply client-side sorting if sorting by membership (not handled by backend)
     if (sortField === 'is_member') {
       filtered = [...filtered].sort((a, b) => {
         const aValue = a.is_member ? 1 : 0;
@@ -471,10 +472,10 @@ export function AdminDashboard() {
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between">
             <div>
-          <CardTitle>All Organizations</CardTitle>
-          <CardDescription>
-            View and manage all organizations on the platform
-          </CardDescription>
+              <CardTitle>All Organizations</CardTitle>
+              <CardDescription>
+                View and manage all organizations on the platform
+              </CardDescription>
             </div>
             <div className="flex items-center gap-2">
               <Select value={membershipFilter} onValueChange={(value: MembershipFilter) => setMembershipFilter(value)}>
@@ -505,13 +506,13 @@ export function AdminDashboard() {
           ) : filteredOrganizations.length === 0 ? (
             <div className="text-center py-12 text-muted-foreground">
               {searchTerm ? 'No organizations match your search' :
-               membershipFilter !== 'all' ? `No ${membershipFilter === 'member' ? 'member' : 'non-member'} organizations found` :
-               'No organizations found'}
+                membershipFilter !== 'all' ? `No ${membershipFilter === 'member' ? 'member' : 'non-member'} organizations found` :
+                  'No organizations found'}
             </div>
           ) : (
             <div className="border-t">
-            <Table>
-              <TableHeader>
+              <Table>
+                <TableHeader>
                   <TableRow className="hover:bg-transparent">
                     <TableHead className="w-[220px]">
                       <Button
@@ -595,6 +596,17 @@ export function AdminDashboard() {
                         variant="ghost"
                         size="sm"
                         className="h-8 -ml-3"
+                        onClick={() => handleSort('last_active_at')}
+                      >
+                        Last Active
+                        <ArrowUpDown className="ml-2 h-3 w-3" />
+                      </Button>
+                    </TableHead>
+                    <TableHead className="w-[130px]">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 -ml-3"
                         onClick={() => handleSort('created_at')}
                       >
                         Created
@@ -602,7 +614,7 @@ export function AdminDashboard() {
                       </Button>
                     </TableHead>
                     <TableHead className="text-right w-[200px]">Actions</TableHead>
-                </TableRow>
+                  </TableRow>
                 </TableHeader>
                 <TableBody>
                   {filteredOrganizations.map((org) => (
@@ -645,10 +657,13 @@ export function AdminDashboard() {
                       </TableCell>
                       <TableCell className="text-right py-2 font-mono text-sm">
                         {formatNumber(org.query_count)}
-                    </TableCell>
+                      </TableCell>
                       <TableCell className="py-2 text-xs text-muted-foreground">
-                      {formatDate(org.created_at)}
-                    </TableCell>
+                        {org.last_active_at ? formatDate(org.last_active_at) : '—'}
+                      </TableCell>
+                      <TableCell className="py-2 text-xs text-muted-foreground">
+                        {formatDate(org.created_at)}
+                      </TableCell>
                       <TableCell className="text-right py-2">
                         <div className="flex justify-end gap-1.5">
                           {org.is_member ? (
@@ -699,10 +714,10 @@ export function AdminDashboard() {
                           </Button>
                         </div>
                       </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
             </div>
           )}
         </CardContent>


### PR DESCRIPTION
Adds "Last Seen" tracking for users and displays it in the admin dashboard with sorting capability. Shows the most recent login timestamp across all users in each organization.

#### Backend
- **User Model** (`models/user.py`): Added `last_active_at` timestamp field
- **User Schema** (`schemas/user.py`): Added `last_active_at` to schema
- **Database Migration**: Created migration to add `last_active_at` column to `user` table
- **Authentication** (`api/deps.py`): Updates `last_active_at` on every Auth0 login
- **Admin Endpoint** (`api/v1/endpoints/admin.py`): 
  - Added query to fetch max `last_active_at` per organization
  - Added support for sorting by `last_active_at`
  - Included `last_active_at` in `OrganizationMetrics` response
- **Admin Schema** (`schemas/admin.py`): Added `last_active_at` field to `OrganizationMetrics`

#### Frontend
- **Admin Dashboard** (`pages/AdminDashboard.tsx`):
  - Added "Last Login" sortable column
  - Displays formatted timestamp or "—" for never-logged-in orgs
  - Added `last_active_at` to TypeScript types

### Notes
- Existing users will have `NULL` last_active_at until they log in again. Shows up on dashboard as "-"
- Timestamp is updated only for Auth0 authentication (not API key auth)
- Shows the most recent activity across *all* users in an organization

<img width="1881" height="650" alt="Screenshot 2025-10-21 at 17 01 06" src="https://github.com/user-attachments/assets/78308d68-cec5-4245-a6ae-45cdf27e0fb7" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds last login tracking and a sortable “Last Login” column to the admin dashboard to surface recent activity per organization. Admins can now quickly see and sort by the most recent user login across orgs.

- **New Features**
  - Backend: Added last_active_at to User model/schema; updates on every Auth0 login.
  - Admin API: Returns max last_active_at per organization and supports sorting by it.
  - Frontend: New “Last Active” column with sorting; shows a formatted timestamp or “—” if none.
  - Behavior: Existing users show “—” until their next Auth0 login; API key auth does not update last_active_at.

- **Migration**
  - Run Alembic upgrade to add the last_active_at column to the user table.

<!-- End of auto-generated description by cubic. -->

