### PR TITLE
fix: cannot use direct crud user update method

### DIFF
--- a/backend/airweave/api/deps.py
+++ b/backend/airweave/api/deps.py
@@ -52,9 +52,7 @@ async def _authenticate_auth0_user(
 
     # Update last active timestamp directly (can't use CRUD during auth flow)
     user.last_active_at = datetime.utcnow()
-    db.add(user)
-    await db.commit()
-    await db.refresh(user)
+    user = await crud.user.update_user_no_auth(db, id=user.id, obj_in=user)
 
     user_context = schemas.User.model_validate(user)
     return user_context, AuthMethod.AUTH0, {"auth0_id": auth0_user.id}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes user activity timestamp updates during Auth0 login by adding a safe no-auth CRUD path and using it in the auth flow. Prevents errors when updating user data before a session exists.

- **Bug Fixes**
  - Added crud_user.update_user_no_auth to update a user without a current_user.
  - In _authenticate_auth0_user, stop using the regular CRUD update; set last_active_at and persist via the new method.
  - Ensures login succeeds and last_active_at is updated reliably.

<!-- End of auto-generated description by cubic. -->

