### PR TITLE
fix: pydantic-sqlalchemy model mismatch

### DIFF
--- a/backend/airweave/api/deps.py
+++ b/backend/airweave/api/deps.py
@@ -51,8 +51,10 @@ async def _authenticate_auth0_user(
         return None, AuthMethod.AUTH0, {}
 
     # Update last active timestamp directly (can't use CRUD during auth flow)
-    user.last_active_at = datetime.utcnow()
-    user = await crud.user.update_user_no_auth(db, id=user.id, obj_in=user)
+    from airweave.schemas.user import UserUpdate
+
+    user_update = UserUpdate(last_active_at=datetime.utcnow())
+    user = await crud.user.update_user_no_auth(db, id=user.id, obj_in=user_update)
 
     user_context = schemas.User.model_validate(user)
     return user_context, AuthMethod.AUTH0, {"auth0_id": auth0_user.id}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes a Pydantic–SQLAlchemy mismatch in the Auth0 auth flow by using the UserUpdate schema to update last_active_at. Prevents validation errors and safely updates the timestamp during authentication.

<!-- End of auto-generated description by cubic. -->

