### PR TITLE
fix: update user schema

### DIFF
--- a/backend/airweave/api/deps.py
+++ b/backend/airweave/api/deps.py
@@ -51,9 +51,8 @@ async def _authenticate_auth0_user(
         return None, AuthMethod.AUTH0, {}
 
     # Update last active timestamp directly (can't use CRUD during auth flow)
-    from airweave.schemas.user import UserUpdate
 
-    user_update = UserUpdate(last_active_at=datetime.utcnow())
+    user_update = schemas.UserUpdate(last_active_at=datetime.utcnow())
     user = await crud.user.update_user_no_auth(db, id=user.id, obj_in=user_update)
 
     user_context = schemas.User.model_validate(user)

--- a/backend/airweave/schemas/user.py
+++ b/backend/airweave/schemas/user.py
@@ -58,6 +58,7 @@ class UserUpdate(UserBase):
 
     auth0_id: Optional[str] = None
     permissions: Optional[list[str]] = None
+    last_active_at: Optional[datetime] = None
 
 
 class UserInDBBase(UserBase):


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add last_active_at to UserUpdate and set it during Auth0 authentication to correctly track user activity. Also refactors deps.py to use schemas.UserUpdate instead of a local import.

<!-- End of auto-generated description by cubic. -->

