### PR TITLE
fix: allow updating user details

### DIFF
--- a/backend/airweave/schemas/user.py
+++ b/backend/airweave/schemas/user.py
@@ -53,12 +53,20 @@ class UserCreate(UserBase):
     auth0_id: Optional[str] = None
 
 
-class UserUpdate(UserBase):
+class UserUpdate(BaseModel):
     """Schema for updating a User object."""
 
+    email: Optional[EmailStr] = None
+    full_name: Optional[str] = None
     auth0_id: Optional[str] = None
     permissions: Optional[list[str]] = None
     last_active_at: Optional[datetime] = None
+
+    class Config:
+        """Pydantic config for UserUpdate."""
+
+        from_orm = True
+        from_attributes = True
 
 
 class UserInDBBase(UserBase):


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enable partial user updates. UserUpdate now uses BaseModel with optional fields (email, full_name, auth0_id, permissions, last_active_at) and Pydantic config for ORM support.

<!-- End of auto-generated description by cubic. -->

