### PR TITLE
fix: don't make use transaction commit

### DIFF
--- a/backend/airweave/crud/crud_user.py
+++ b/backend/airweave/crud/crud_user.py
@@ -79,11 +79,10 @@ class CRUDUser(CRUDBaseUser[User, UserCreate, UserUpdate]):
         for field, value in obj_in.model_dump(exclude_unset=True).items():
             setattr(user, field, value)
 
-        await db.commit()
+        await db.flush()
+        await db.refresh(user)
 
-        stmt = self._get_user_query_with_orgs().where(User.id == user.id)
-        result = await db.execute(stmt)
-        return result.unique().scalar_one()
+        return user
 
     async def get(self, db: AsyncSession, id: UUID, current_user: User) -> Optional[User]:
         """Get a single object by ID.


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Stop committing inside update_user_no_auth to avoid breaking shared transactions. Now we flush and refresh the user, then return it directly, removing the extra query.

<!-- End of auto-generated description by cubic. -->

