### PR TITLE
fix(admin): fix enterprise organization creation workflow

### DIFF
--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -700,18 +700,21 @@ export function AdminDashboard() {
                             <Flag className="h-3 w-3" />
                             Features
                           </Button>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => {
-                              setSelectedOrg(org);
-                              setActionType('upgrade');
-                            }}
-                            className="h-7 gap-1.5 text-xs"
-                          >
-                            <ArrowUpCircle className="h-3 w-3" />
-                            Upgrade
-                          </Button>
+                          {/* Only show Upgrade for non-enterprise plans */}
+                          {org.billing_plan !== 'enterprise' && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => {
+                                setSelectedOrg(org);
+                                setActionType('upgrade');
+                              }}
+                              className="h-7 gap-1.5 text-xs"
+                            >
+                              <ArrowUpCircle className="h-3 w-3" />
+                              Upgrade
+                            </Button>
+                          )}
                         </div>
                       </TableCell>
                     </TableRow>


### PR DESCRIPTION
Fix issues in the admin dashboard's Create Enterprise Organization flow that prevented successful organization creation with proper billing setup.

Backend fixes (admin.py):
- Fix request schema to accept flat JSON body instead of query parameters
- Add CreateEnterpriseOrganizationRequest schema matching frontend payload
- Remove invalid Organization model fields (created_by_email, modified_by_email)
- Fix SQLAlchemy detached instance errors by:
  * Extracting all user attributes before entering UnitOfWork context
  * Capturing org_id before UnitOfWork commit
  * Reloading organization with CRUD layer after creation
- Return dict instead of Pydantic model to avoid FastAPI re-serialization issues
- Require Stripe to be enabled (production-only endpoint)

Frontend fixes (AdminDashboard.tsx):
- Conditionally hide "Upgrade" button for organizations already on enterprise plan based on billing_plan !== 'enterprise'
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the admin “Create Enterprise Organization” flow so orgs are created on the enterprise plan with proper billing, and the dashboard UI reflects enterprise status. Backend now accepts a flat JSON body and avoids SQLAlchemy state issues during creation.

- **Bug Fixes**
  - Switched to CreateEnterpriseOrganizationRequest (flat JSON) and removed invalid org fields; response returns a dict to avoid FastAPI/SQLAlchemy re-serialization problems.
  - Prevented detached-instance errors by reading user data before UnitOfWork, capturing org_id before commit, and reloading via CRUD with enrich.
  - Required Stripe to be enabled; creates customer and enterprise billing, with failures logged but not blocking org creation.
  - AdminDashboard: shows “Upgrade” only when billing_plan is not 'enterprise'.

<!-- End of auto-generated description by cubic. -->

