### PR TITLE
chore(cursor rules): microsoft onenote

### DIFF
--- a/.cursor/rules/auth-providers.mdc
+++ b/.cursor/rules/auth-providers.mdc
@@ -42,7 +42,11 @@ Map between Airweave and external service naming:
 FIELD_NAME_MAPPING = {"api_key": "generic_api_key", "personal_access_token": "access_token"}
 
 # Map Airweave source names to provider source names (only needed when names differ)
-SLUG_NAME_MAPPING = {"google_drive": "googledrive", "outlook_mail": "outlook"}
+SLUG_NAME_MAPPING = {
+    "google_drive": "googledrive", 
+    "outlook_mail": "outlook",
+    "onenote": "one_drive"  # OneNote uses OneDrive integration (same Graph API)
+}
 ```
 
 
@@ -129,3 +133,40 @@ The system automatically detects which mode to use:
 - Proxy URL: `https://api.pipedream.com/v1/connect/{project_id}/proxy/{encoded_url}`
 - Auth headers stripped and injected by Pipedream
 - Non-auth headers forwarded with `x-pd-proxy-` prefix
+
+**Blocked Sources:**
+The following sources are blocked from using Pipedream due to technical limitations:
+- `github` - Pipedream enforces proxy mode creating heavy bottlenecks
+- `jira` - Atlassian constructs URLs using cloud ID which Pipedream doesn't provide
+- `confluence` - Atlassian constructs URLs using cloud ID which Pipedream doesn't provide
+- `bitbucket` - Workspace configuration conflicts with Composio
+- `onenote` - Microsoft Graph API integration not supported via Pipedream proxy
+
+## OneNote Authentication Configuration
+
+### Auth Config Class
+OneNote uses `OneNoteAuthConfig` which extends `OAuth2WithRotatingRefreshAuthConfig`:
+
+```python
+# backend/airweave/platform/configs/auth.py
+class OneNoteAuthConfig(OAuth2WithRotatingRefreshAuthConfig):
+    """OneNote authentication credentials schema."""
+    
+    # Inherits access_token, refresh_token from OAuth2WithRotatingRefreshAuthConfig
+    # Uses Microsoft Graph API OAuth2 with rotating refresh tokens
+```
+
+### Required OAuth Scopes
+OneNote requires specific Microsoft Graph API scopes:
+- `offline_access` - Enables refresh tokens for long-term access
+- `https://graph.microsoft.com/User.Read` - Read user profile information
+- `https://graph.microsoft.com/Notes.Read` - Read OneNote notebooks, sections, and pages
+- `https://graph.microsoft.com/Notes.Create` - Create new OneNote content (for testing)
+- `https://graph.microsoft.com/Notes.ReadWrite` - Update and delete OneNote content (for testing)
+
+### Composio Integration
+OneNote uses Composio auth provider with OneDrive integration:
+- **Slug Mapping**: `"onenote": "one_drive"` (uses OneDrive integration for Graph API)
+- **Account ID**: Composio account identifier
+- **Auth Config ID**: Composio auth configuration identifier
+- **Scopes**: Must include Notes.Read, Notes.Create, Notes.ReadWrite for full functionality

--- a/.cursor/rules/connector-development-end-to-end.mdc
+++ b/.cursor/rules/connector-development-end-to-end.mdc
@@ -806,7 +806,33 @@ Make sure to:
 - Process file entities if the API supports them
 
 Reference the Asana source as an example: @asana.py
-```
+
+### OneNote Connector Example
+For Microsoft Graph API connectors like OneNote:
+
+**Key Considerations:**
+- Uses Microsoft Graph API with OAuth2 rotating refresh tokens
+- Hierarchical structure: notebooks → sections → pages
+- HTML content processing via FileEntity pipeline
+- Performance optimizations with $select and $expand
+- Composio auth provider integration
+
+**Entity Structure:**
+- `OneNoteNotebookEntity` - Top-level containers
+- `OneNoteSectionEntity` - Organizational units within notebooks  
+- `OneNotePageFileEntity` - Individual pages processed as HTML files
+
+**Authentication:**
+- Requires Microsoft Graph API scopes: Notes.Read, User.Read, offline_access
+- Uses Composio with OneDrive integration (same Graph API)
+- Slug mapping: "onenote" → "one_drive"
+
+**Performance Features:**
+- API optimizations with $select and $expand parameters
+- Concurrent processing for sections
+- FileEntity processing for HTML-to-Markdown conversion
+
+Reference: `backend/airweave/platform/sources/onenote.py`
 
 ```
 Now implement the Monke tests.
@@ -821,6 +847,23 @@ Start with:
 
 Reference the Asana tests but NOTE that they have a bug: they create comments
 but don't verify them. You must verify ALL entity types.
+
+### OneNote Monke Testing
+For OneNote connector testing:
+
+**Test Structure:**
+- Creates test notebooks, sections, and pages
+- Uses Microsoft Graph API for CRUD operations
+- Embeds tracking tokens in page content
+- Verifies all entity types in vector database
+
+**Key Features:**
+- HTML content generation for realistic pages
+- Proper entity ID tracking for deletions
+- Microsoft Graph API rate limiting
+- Composio credential resolution
+
+Reference: `monke/bongos/onenote.py` and `monke/configs/onenote.yaml`
 ```
 
 ---

--- a/.cursor/rules/integrations-yaml.mdc
+++ b/.cursor/rules/integrations-yaml.mdc
@@ -85,6 +85,30 @@ teams:
   scope: "offline_access User.Read Team.ReadBasic.All Channel.ReadBasic.All ChannelMessage.Read.All Chat.Read ChatMessage.Read Files.Read.All"
 ```
 
+**Microsoft OneNote (Microsoft Graph API):**
+```yaml
+onenote:
+  oauth_type: "with_rotating_refresh"
+  url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+  backend_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+  grant_type: "authorization_code"
+  client_id: "your-client-id"
+  client_secret: "your-client-secret"
+  content_type: "application/x-www-form-urlencoded"
+  client_credential_location: "body"
+  scope: "offline_access https://graph.microsoft.com/User.Read https://graph.microsoft.com/Notes.Read"
+  additional_frontend_params:
+    response_type: "code"
+    response_mode: "query"
+```
+
+**OneNote Scopes:**
+- `offline_access` - Enables refresh tokens for long-term access
+- `https://graph.microsoft.com/User.Read` - Read user profile information
+- `https://graph.microsoft.com/Notes.Read` - Read OneNote notebooks, sections, and pages
+- `https://graph.microsoft.com/Notes.Create` - Create new OneNote content (for testing)
+- `https://graph.microsoft.com/Notes.ReadWrite` - Update and delete OneNote content (for testing)
+
 ## Folder Structure
 The files appear to be part of a structured monorepo with:
 

--- a/.cursor/rules/monke-testing-guide.mdc
+++ b/.cursor/rules/monke-testing-guide.mdc
@@ -1111,6 +1111,52 @@ See the Asana tests for a complete example:
 
 ---
 
+## OneNote Connector Testing
+
+### Special Considerations for OneNote
+
+OneNote connector testing requires specific handling due to Microsoft Graph API integration:
+
+**Entity Types to Test:**
+- `OneNoteNotebookEntity` - Top-level containers
+- `OneNoteSectionEntity` - Organizational units within notebooks
+- `OneNotePageFileEntity` - Individual pages processed as HTML files
+
+**Authentication Setup:**
+- Uses Composio auth provider with OneDrive integration
+- Requires Microsoft Graph API scopes: Notes.Read, Notes.Create, Notes.ReadWrite
+- Slug mapping: "onenote" → "one_drive"
+
+**Test Configuration:**
+```yaml
+# monke/configs/onenote.yaml
+connector:
+  name: "onenote_test"
+  type: "onenote"
+  auth_mode: composio
+  composio_config:
+    account_id: ${ONENOTE_AUTH_PROVIDER_ACCOUNT_ID}
+    auth_config_id: ${ONENOTE_AUTH_PROVIDER_AUTH_CONFIG_ID}
+```
+
+**Bongo Implementation:**
+- Creates test notebooks, sections, and pages via Microsoft Graph API
+- Embeds tracking tokens in HTML content
+- Handles Microsoft Graph API rate limiting
+- Properly tracks entity IDs for deletion verification
+
+**Key Features:**
+- HTML content generation for realistic OneNote pages
+- Microsoft Graph API CRUD operations
+- Composio credential resolution
+- Proper entity ID tracking for deletions
+
+**Reference Files:**
+- Bongo: `monke/bongos/onenote.py`
+- Schema: `monke/generation/schemas/onenote.py`
+- Generator: `monke/generation/onenote.py`
+- Config: `monke/configs/onenote.yaml`
+
 ## Next Steps
 
 1. Implement the bongo, schemas, generation, and config

--- a/.cursor/rules/monke.mdc
+++ b/.cursor/rules/monke.mdc
@@ -169,6 +169,31 @@ async def generate_github_content(token: str) -> str:
 
 Pydantic schemas in `generation/schemas/{connector}.py` define entity structures.
 
+### OneNote Generator Schema
+For OneNote connector testing, the generator schema includes:
+
+```python
+# generation/schemas/onenote.py
+from pydantic import BaseModel
+
+class OneNotePageData(BaseModel):
+    """Schema for OneNote page generation."""
+    title: str
+    content: str
+    token: str
+```
+
+The OneNote generator creates realistic test pages with:
+- **Title**: Descriptive page titles for testing
+- **Content**: Rich HTML content with embedded tracking tokens
+- **Token**: Unique identifier for verification during testing
+
+**Key Features:**
+- HTML content generation for realistic OneNote pages
+- Token embedding for test verification
+- Microsoft Graph API compatible structure
+- Support for hierarchical content (notebooks → sections → pages)
+
 ---
 
 ## Verification

--- a/.cursor/rules/source-connector-implementation.mdc
+++ b/.cursor/rules/source-connector-implementation.mdc
@@ -1088,8 +1088,9 @@ async def _generate_projects(self, client, workspace):
 
 ---
 
-## Complete Example
+## Complete Examples
 
+### Asana Connector
 See the Asana connector for a complete, production-ready example:
 - Source: `backend/airweave/platform/sources/asana.py`
 - Entities: `backend/airweave/platform/entities/asana.py`
@@ -1104,6 +1105,21 @@ The Asana connector demonstrates:
 - ✅ Breadcrumb tracking
 - ✅ Rate limiting
 - ✅ Error handling
+
+### OneNote Connector
+See the OneNote connector for Microsoft Graph API integration:
+- Source: `backend/airweave/platform/sources/onenote.py`
+- Entities: `backend/airweave/platform/entities/onenote.py`
+- OAuth: `backend/airweave/platform/auth/yaml/dev.integrations.yaml` (onenote section)
+
+The OneNote connector demonstrates:
+- ✅ Microsoft Graph API integration with OAuth2
+- ✅ Hierarchical entity generation (notebooks → sections → pages)
+- ✅ HTML content processing via FileEntity pipeline
+- ✅ Performance optimizations ($select, $expand, concurrent processing)
+- ✅ Descriptive error messages for OAuth scope issues
+- ✅ Composio auth provider integration
+- ✅ FileEntity processing for HTML-to-Markdown conversion
 
 ---
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds OneNote connector rules, auth config, and documentation to enable Microsoft Graph integration with end-to-end development and testing. Maps OneNote to OneDrive in Composio, defines required scopes, and publishes a user-facing connector guide.

- **New Features**
  - Added Composio slug mapping: "onenote" → "one_drive"; blocked OneNote from Pipedream proxy.
  - Defined OAuth2 with rotating refresh tokens and Graph scopes (Notes.Read, Notes.Create, Notes.ReadWrite, User.Read, offline_access).
  - Documented connector entity model (notebooks → sections → pages), HTML FileEntity processing, and Graph performance tips ($select, $expand).
  - Added Monke testing guide, generator schema, and sample config for notebooks/sections/pages.
  - Created OneNote entry in integrations YAML.
  - Published OneNote docs page detailing setup, scopes, features, and troubleshooting.

<!-- End of auto-generated description by cubic. -->

