### PR TITLE
fix(app registration): onenote prod id

### DIFF
--- a/backend/airweave/platform/auth/yaml/prd.integrations.yaml
+++ b/backend/airweave/platform/auth/yaml/prd.integrations.yaml
@@ -227,7 +227,7 @@ integrations:
     url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
     backend_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
     grant_type: "authorization_code"
-    client_id: "cbd62f0d-9c87-4aa2-b420-debf53b46d30"
+    client_id: "75961685-0b58-4b63-95ac-2ffaa646ea38"
     client_secret: "onenote-client-secret-key"
     content_type: "application/x-www-form-urlencoded"
     client_credential_location: "body"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the OneNote production OAuth client ID to point to the correct app registration so authentication uses the right configuration in prod.

<!-- End of auto-generated description by cubic. -->

