### PR TITLE
remove microsoft from source names

### DIFF
--- a/backend/airweave/platform/sources/excel.py
+++ b/backend/airweave/platform/sources/excel.py
@@ -31,7 +31,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
 
 
 @source(
-    name="Microsoft Excel",
+    name="Excel",
     short_name="excel",
     auth_methods=[
         AuthenticationMethod.OAUTH_BROWSER,

--- a/backend/airweave/platform/sources/onenote.py
+++ b/backend/airweave/platform/sources/onenote.py
@@ -33,7 +33,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
 
 
 @source(
-    name="Microsoft OneNote",
+    name="OneNote",
     short_name="onenote",
     auth_methods=[
         AuthenticationMethod.OAUTH_BROWSER,

--- a/backend/airweave/platform/sources/teams.py
+++ b/backend/airweave/platform/sources/teams.py
@@ -34,7 +34,7 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
 
 
 @source(
-    name="Microsoft Teams",
+    name="Teams",
     short_name="teams",
     auth_methods=[
         AuthenticationMethod.OAUTH_BROWSER,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed source display names by removing the “Microsoft” prefix: now “Excel”, “OneNote”, and “Teams”. UI-only change to standardize product naming; no functional or auth changes.

<!-- End of auto-generated description by cubic. -->

