### PR TITLE
security(CASA-11): remove API key from donke URL query parameters 

### DIFF
--- a/backend/airweave/api/v1/endpoints/organizations.py
+++ b/backend/airweave/api/v1/endpoints/organizations.py
@@ -694,9 +694,10 @@ async def _notify_donke_signup(
         # Simple HTTP call to Donke (uses Azure app key)
         async with httpx.AsyncClient() as client:
             await client.post(
-                f"{settings.DONKE_URL}/api/notify-signup?code={settings.DONKE_API_KEY}",
+                f"{settings.DONKE_URL}/api/notify-signup",
                 headers={
                     "Content-Type": "application/json",
+                    "x-functions-key": settings.DONKE_API_KEY,
                 },
                 json={
                     "organization_name": organization.name,

--- a/backend/airweave/billing/webhook_handler.py
+++ b/backend/airweave/billing/webhook_handler.py
@@ -941,9 +941,10 @@ async def _notify_donke_subscription(
     try:
         async with httpx.AsyncClient() as client:
             await client.post(
-                f"{settings.DONKE_URL}/api/notify-subscription?code={settings.DONKE_API_KEY}",
+                f"{settings.DONKE_URL}/api/notify-subscription",
                 headers={
                     "Content-Type": "application/json",
+                    "x-functions-key": settings.DONKE_API_KEY,
                 },
                 json={
                     "organization_name": org.name,
@@ -1012,9 +1013,10 @@ async def _send_team_welcome_email(
         # Call Donke to send the welcome email
         async with httpx.AsyncClient() as client:
             await client.post(
-                f"{settings.DONKE_URL}/api/send-team-welcome-email?code={settings.DONKE_API_KEY}",
+                f"{settings.DONKE_URL}/api/send-team-welcome-email",
                 headers={
                     "Content-Type": "application/json",
+                    "x-functions-key": settings.DONKE_API_KEY,
                 },
                 json={
                     "organization_name": org.name,


### PR DESCRIPTION
## Summary

This PR addresses **CASA-11** security requirement by removing API keys from URL query parameters in all Donke API calls.

## Changes

Updated 3 Donke API calls to use Azure Functions' native `x-functions-key` header authentication instead of exposing the API key in URL query parameters (`?code=`).

### Files Modified:
- `backend/airweave/billing/webhook_handler.py` (2 locations)
  - `_notify_donke_subscription` function
  - `_send_team_welcome_email` function
- `backend/airweave/api/v1/endpoints/organizations.py` (1 location)
  - `_notify_donke_signup` function

## Security Impact

✅ **No more API keys in URLs** - Prevents exposure in:
- Server access logs
- Browser history
- Network monitoring tools
- HTTP referrer headers
- Debugging/error logs

✅ **Azure Functions native support** - Both methods (`?code=` and `x-functions-key` header) are officially supported by `AuthLevel.FUNCTION`, no Donke changes required.

## Testing

Please test:
1. Organization signup flow → verify Slack notification arrives
2. Paid subscription creation → verify Slack notification arrives
3. Team plan subscription → verify welcome email is scheduled
4. Review server logs to confirm API keys are no longer visible in URLs

## References

- Linear Issue: ENG-165
- CASA Requirement: #11 - "Verify API URLs do not expose sensitive information"
- [Azure Functions Key Authentication Docs](https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed API keys from Donke API URLs by switching to x-functions-key header auth to satisfy CASA-11. Prevents key exposure in logs, referrers, and history; addresses Linear ENG-165.

- **Changes**
  - Replaced ?code= with x-functions-key in three Donke calls: notify-signup, notify-subscription, send-team-welcome-email.
  - Uses Azure Functions AuthLevel.FUNCTION; no Donke-side changes needed.

<!-- End of auto-generated description by cubic. -->

