### PR TITLE
security(CASA-41): Fix XSS vulnerability in innerHTML usage

### DIFF
--- a/frontend/src/components/auth-providers/AuthProviderDetailView.tsx
+++ b/frontend/src/components/auth-providers/AuthProviderDetailView.tsx
@@ -561,13 +561,18 @@ export const AuthProviderDetailView: React.FC<AuthProviderDetailViewProps> = ({
                                                 className="w-full h-full object-contain"
                                                 onError={(e) => {
                                                     e.currentTarget.style.display = 'none';
-                                                    e.currentTarget.parentElement!.innerHTML = `
-                                                        <div class="w-full h-full rounded flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}">
-                                                            <span class="text-xl font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}">
-                                                                AW
-                                                            </span>
-                                                        </div>
-                                                    `;
+                                                    const parent = e.currentTarget.parentElement!;
+
+                                                    // Create elements safely without innerHTML to prevent XSS
+                                                    const wrapper = document.createElement('div');
+                                                    wrapper.className = `w-full h-full rounded flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}`;
+
+                                                    const span = document.createElement('span');
+                                                    span.className = `text-xl font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}`;
+                                                    span.textContent = 'AW';
+
+                                                    wrapper.appendChild(span);
+                                                    parent.appendChild(wrapper);
                                                 }}
                                             />
                                         </div>
@@ -655,13 +660,18 @@ export const AuthProviderDetailView: React.FC<AuthProviderDetailViewProps> = ({
                                                 className="w-full h-full object-contain"
                                                 onError={(e) => {
                                                     e.currentTarget.style.display = 'none';
-                                                    e.currentTarget.parentElement!.innerHTML = `
-                                                        <div class="w-full h-full rounded-lg flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}">
-                                                            <span class="text-xl font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}">
-                                                                ${authProviderShortName.substring(0, 2).toUpperCase()}
-                                                            </span>
-                                                        </div>
-                                                    `;
+                                                    const parent = e.currentTarget.parentElement!;
+
+                                                    // Create elements safely without innerHTML to prevent XSS
+                                                    const wrapper = document.createElement('div');
+                                                    wrapper.className = `w-full h-full rounded-lg flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}`;
+
+                                                    const span = document.createElement('span');
+                                                    span.className = `text-xl font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}`;
+                                                    span.textContent = authProviderShortName.substring(0, 2).toUpperCase();
+
+                                                    wrapper.appendChild(span);
+                                                    parent.appendChild(wrapper);
                                                 }}
                                             />
                                         </div>

--- a/frontend/src/components/collection/EditSourceConnectionDialog.tsx
+++ b/frontend/src/components/collection/EditSourceConnectionDialog.tsx
@@ -101,13 +101,18 @@ export const EditSourceConnectionDialog: React.FC<EditSourceConnectionDialogProp
                                         className="w-full h-full object-contain"
                                         onError={(e) => {
                                             e.currentTarget.style.display = 'none';
-                                            e.currentTarget.parentElement!.innerHTML = `
-                                                <div class="w-full h-full rounded-lg flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}">
-                                                    <span class="text-xs font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}">
-                                                        ${sourceConnection.short_name.substring(0, 2).toUpperCase()}
-                                                    </span>
-                                                </div>
-                                            `;
+                                            const parent = e.currentTarget.parentElement!;
+
+                                            // Create elements safely without innerHTML to prevent XSS
+                                            const wrapper = document.createElement('div');
+                                            wrapper.className = `w-full h-full rounded-lg flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}`;
+
+                                            const span = document.createElement('span');
+                                            span.className = `text-xs font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}`;
+                                            span.textContent = sourceConnection.short_name.substring(0, 2).toUpperCase();
+
+                                            wrapper.appendChild(span);
+                                            parent.appendChild(wrapper);
                                         }}
                                     />
                                 </div>

--- a/frontend/src/components/dashboard/AuthProviderButton.tsx
+++ b/frontend/src/components/dashboard/AuthProviderButton.tsx
@@ -68,8 +68,14 @@ export const AuthProviderButton = ({
                 onError={(e) => {
                     // Fallback to initials if icon fails to load
                     e.currentTarget.style.display = 'none';
-                    e.currentTarget.parentElement!.classList.add(getColorClass(shortName));
-                    e.currentTarget.parentElement!.innerHTML = `<span class="text-white font-semibold text-xs sm:text-sm">${shortName.substring(0, 2).toUpperCase()}</span>`;
+                    const parent = e.currentTarget.parentElement!;
+                    parent.classList.add(getColorClass(shortName));
+
+                    // Create span element safely without innerHTML to prevent XSS
+                    const span = document.createElement('span');
+                    span.className = 'text-white font-semibold text-xs sm:text-sm';
+                    span.textContent = shortName.substring(0, 2).toUpperCase();
+                    parent.appendChild(span);
                 }}
             />
         </div>

--- a/frontend/src/components/dashboard/SmallSourceButton.tsx
+++ b/frontend/src/components/dashboard/SmallSourceButton.tsx
@@ -44,8 +44,14 @@ export const SmallSourceButton = ({ id, name, shortName, connected = false, onCl
                 onError={(e) => {
                     // Fallback to initials if icon fails to load
                     e.currentTarget.style.display = 'none';
-                    e.currentTarget.parentElement!.classList.add(getColorClass(shortName));
-                    e.currentTarget.parentElement!.innerHTML = `<span class="text-white font-semibold text-sm">${shortName.substring(0, 2).toUpperCase()}</span>`;
+                    const parent = e.currentTarget.parentElement!;
+                    parent.classList.add(getColorClass(shortName));
+
+                    // Create span element safely without innerHTML to prevent XSS
+                    const span = document.createElement('span');
+                    span.className = 'text-white font-semibold text-sm';
+                    span.textContent = shortName.substring(0, 2).toUpperCase();
+                    parent.appendChild(span);
                 }}
             />
         </div>

--- a/frontend/src/components/dashboard/SourceButton.tsx
+++ b/frontend/src/components/dashboard/SourceButton.tsx
@@ -55,8 +55,14 @@ export const SourceButton = ({ id, name, shortName, onClick, disabled, usageChec
         onError={(e) => {
           // Fallback to initials if icon fails to load
           e.currentTarget.style.display = 'none';
-          e.currentTarget.parentElement!.classList.add(getColorClass(shortName));
-          e.currentTarget.parentElement!.innerHTML = `<span class="text-white font-semibold text-xs sm:text-sm">${shortName.substring(0, 2).toUpperCase()}</span>`;
+          const parent = e.currentTarget.parentElement!;
+          parent.classList.add(getColorClass(shortName));
+
+          // Create span element safely without innerHTML to prevent XSS
+          const span = document.createElement('span');
+          span.className = 'text-white font-semibold text-xs sm:text-sm';
+          span.textContent = shortName.substring(0, 2).toUpperCase();
+          parent.appendChild(span);
         }}
       />
     </div>

--- a/frontend/src/components/shared/views/ConnectionErrorView.tsx
+++ b/frontend/src/components/shared/views/ConnectionErrorView.tsx
@@ -143,13 +143,18 @@ export const ConnectionErrorView: React.FC<ConnectionErrorViewProps> = ({
                                 className="w-full h-full object-contain"
                                 onError={(e) => {
                                     e.currentTarget.style.display = 'none';
-                                    e.currentTarget.parentElement!.innerHTML = `
-                                    <div class="w-full h-full rounded-lg flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}">
-                                      <span class="text-5xl font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}">
-                                        ${sourceShortName.substring(0, 2).toUpperCase()}
-                                      </span>
-                                    </div>
-                                  `;
+                                    const parent = e.currentTarget.parentElement!;
+
+                                    // Create elements safely without innerHTML to prevent XSS
+                                    const wrapper = document.createElement('div');
+                                    wrapper.className = `w-full h-full rounded-lg flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}`;
+
+                                    const span = document.createElement('span');
+                                    span.className = `text-5xl font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}`;
+                                    span.textContent = sourceShortName.substring(0, 2).toUpperCase();
+
+                                    wrapper.appendChild(span);
+                                    parent.appendChild(wrapper);
                                 }}
                             />
                         </div>

--- a/frontend/src/components/shared/views/CreateCollectionView.tsx
+++ b/frontend/src/components/shared/views/CreateCollectionView.tsx
@@ -340,16 +340,21 @@ export const CreateCollectionView: React.FC<CreateCollectionViewProps> = ({
                                     src={getAppIconUrl(sourceShortName, resolvedTheme)}
                                     alt={`${sourceName} icon`}
                                     className="w-full h-full object-contain"
-                                    onError={(e) => {
-                                        e.currentTarget.style.display = 'none';
-                                        e.currentTarget.parentElement!.innerHTML = `
-                        <div class="w-full h-full rounded-lg flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}">
-                          <span class="text-5xl font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}">
-                            ${sourceShortName.substring(0, 2).toUpperCase()}
-                          </span>
-                        </div>
-                      `;
-                                    }}
+                                onError={(e) => {
+                                    e.currentTarget.style.display = 'none';
+                                    const parent = e.currentTarget.parentElement!;
+
+                                    // Create elements safely without innerHTML to prevent XSS
+                                    const wrapper = document.createElement('div');
+                                    wrapper.className = `w-full h-full rounded-lg flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}`;
+
+                                    const span = document.createElement('span');
+                                    span.className = `text-5xl font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}`;
+                                    span.textContent = sourceShortName.substring(0, 2).toUpperCase();
+
+                                    wrapper.appendChild(span);
+                                    parent.appendChild(wrapper);
+                                }}
                                 />
                             </div>
                         </div>

--- a/frontend/src/components/shared/views/EditAuthProviderView.tsx
+++ b/frontend/src/components/shared/views/EditAuthProviderView.tsx
@@ -253,16 +253,21 @@ export const EditAuthProviderView: React.FC<EditAuthProviderViewProps> = ({
                                     src={getAuthProviderIconUrl(authProviderShortName, resolvedTheme)}
                                     alt={`${authProviderName} icon`}
                                     className="w-full h-full object-contain"
-                                    onError={(e) => {
-                                        e.currentTarget.style.display = 'none';
-                                        e.currentTarget.parentElement!.innerHTML = `
-                                            <div class="w-full h-full rounded-lg flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}">
-                                                <span class="text-5xl font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}">
-                                                    ${authProviderShortName.substring(0, 2).toUpperCase()}
-                                                </span>
-                                            </div>
-                                        `;
-                                    }}
+                                onError={(e) => {
+                                    e.currentTarget.style.display = 'none';
+                                    const parent = e.currentTarget.parentElement!;
+
+                                    // Create elements safely without innerHTML to prevent XSS
+                                    const wrapper = document.createElement('div');
+                                    wrapper.className = `w-full h-full rounded-lg flex items-center justify-center ${isDark ? 'bg-blue-900' : 'bg-blue-100'}`;
+
+                                    const span = document.createElement('span');
+                                    span.className = `text-5xl font-bold ${isDark ? 'text-blue-400' : 'text-blue-600'}`;
+                                    span.textContent = authProviderShortName.substring(0, 2).toUpperCase();
+
+                                    wrapper.appendChild(span);
+                                    parent.appendChild(wrapper);
+                                }}
                                 />
                             </div>
                         </div>

--- a/frontend/src/components/sync/nodes/TransformerNode.tsx
+++ b/frontend/src/components/sync/nodes/TransformerNode.tsx
@@ -33,8 +33,14 @@ export const TransformerNode = memo(({ data, selected, ...props }: NodeProps) =>
             onError={(e) => {
               // Fallback to initials if icon fails to load
               e.currentTarget.style.display = 'none';
+              const parent = e.currentTarget.parentElement!;
               const initials = data.name?.substring(0, 2).toUpperCase() || 'TR';
-              e.currentTarget.parentElement!.innerHTML = `<span class="text-foreground font-medium text-xs">${initials}</span>`;
+
+              // Create span element safely without innerHTML to prevent XSS
+              const span = document.createElement('span');
+              span.className = 'text-foreground font-medium text-xs';
+              span.textContent = initials;
+              parent.appendChild(span);
             }}
           />
         </div>

--- a/frontend/src/pages/SemanticMcp.tsx
+++ b/frontend/src/pages/SemanticMcp.tsx
@@ -873,8 +873,14 @@ const SemanticMcp = () => {
                                                 onError={(e) => {
                                                     // Fallback to initials if icon fails to load
                                                     e.currentTarget.style.display = 'none';
-                                                    e.currentTarget.parentElement!.classList.add('bg-blue-500');
-                                                    e.currentTarget.parentElement!.innerHTML = `<span class="text-white font-semibold text-sm">${connection.short_name.substring(0, 2).toUpperCase()}</span>`;
+                                                    const parent = e.currentTarget.parentElement!;
+                                                    parent.classList.add('bg-blue-500');
+
+                                                    // Create span element safely without innerHTML to prevent XSS
+                                                    const span = document.createElement('span');
+                                                    span.className = 'text-white font-semibold text-sm';
+                                                    span.textContent = connection.short_name.substring(0, 2).toUpperCase();
+                                                    parent.appendChild(span);
                                                 }}
                                             />
                                         </div>
@@ -945,7 +951,12 @@ const SemanticMcp = () => {
                                             e.currentTarget.style.display = 'none';
                                             const parent = e.currentTarget.parentElement!;
                                             parent.classList.add('bg-blue-500');
-                                            parent.innerHTML = `<span class="text-white font-semibold text-xs">${selectedSource.short_name.substring(0, 2).toUpperCase()}</span>`;
+
+                                            // Create span element safely without innerHTML to prevent XSS
+                                            const span = document.createElement('span');
+                                            span.className = 'text-white font-semibold text-xs';
+                                            span.textContent = selectedSource.short_name.substring(0, 2).toUpperCase();
+                                            parent.appendChild(span);
                                         }}
                                     />
                                 </div>


### PR DESCRIPTION
## Overview
Fixes [ENG-181](https://linear.app/airweave-main/issue/ENG-181/casa-41-fix-xss-vulnerability-in-frontend-innerhtml-usage) - Replaced all 12 instances of unsafe `.innerHTML` assignments with secure DOM manipulation to prevent XSS attacks.

## Security Impact
✅ **Eliminates XSS vulnerability**: Even if an attacker injects malicious HTML into `short_name` fields, it will be rendered as plain text rather than executed as code
✅ **Defense-in-depth**: Provides additional security layer beyond existing CSP headers
✅ **Zero innerHTML usage**: Confirmed via grep - no unsafe innerHTML assignments remain

## Changes Summary

### Before (Vulnerable)
```typescript
e.currentTarget.parentElement!.innerHTML = \`<span>\${shortName.substring(0, 2).toUpperCase()}</span>\`;
```

### After (Safe)
```typescript
const span = document.createElement('span');
span.className = '...';
span.textContent = shortName.substring(0, 2).toUpperCase(); // Safe - no HTML interpretation
parent.appendChild(span);
```

## Files Modified (12 instances)

**Button Components:**
- `frontend/src/components/dashboard/SourceButton.tsx`
- `frontend/src/components/dashboard/AuthProviderButton.tsx`
- `frontend/src/components/dashboard/SmallSourceButton.tsx`

**View Components:**
- `frontend/src/components/shared/views/EditAuthProviderView.tsx`
- `frontend/src/components/shared/views/CreateCollectionView.tsx`
- `frontend/src/components/shared/views/ConnectionErrorView.tsx`
- `frontend/src/components/auth-providers/AuthProviderDetailView.tsx` (2 instances)

**Other Components:**
- `frontend/src/pages/SemanticMcp.tsx` (2 instances)
- `frontend/src/components/collection/EditSourceConnectionDialog.tsx`
- `frontend/src/components/sync/nodes/TransformerNode.tsx`

## Testing Checklist
- [ ] Force icon failures (block icon CDNs in DevTools)
- [ ] Verify fallback initials display correctly
- [ ] Check no console errors appear
- [ ] Test edge cases (empty/single char/special char shortNames)

## Compliance
Addresses CASA TAC Security requirement 41: proper output encoding for all contexts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes XSS risk by replacing all unsafe innerHTML fallbacks with safe DOM manipulation for icon initials. Addresses ENG-181 and meets CASA TAC Security requirement 41.

- **Bug Fixes**
  - Replaced innerHTML with createElement + textContent in 12 places across buttons, views, dialogs, and nodes.
  - Fallback initials now render as plain text; theme classes applied via classList.
  - Verified no remaining innerHTML usage.

<!-- End of auto-generated description by cubic. -->

