### PR TITLE
security(CASA-22): remove shared/default accounts from production

### DIFF
--- a/backend/alembic/versions/9a977647c5a4_add_is_admin_and_fix_connection_cascade.py
+++ b/backend/alembic/versions/9a977647c5a4_add_is_admin_and_fix_connection_cascade.py
@@ -102,7 +102,12 @@ def upgrade():
     op.execute("UPDATE \"user\" SET is_admin = false")
 
     # Then, set users with @airweave.ai email to is_admin = true
-    op.execute("UPDATE \"user\" SET is_admin = true WHERE email LIKE '%@airweave.ai' OR email = 'admin@example.com'")
+    # For non-production environments, also grant admin to test account
+    from airweave.core.config import settings
+    if settings.ENVIRONMENT != 'prd':
+        op.execute("UPDATE \"user\" SET is_admin = true WHERE email LIKE '%@airweave.ai' OR email = 'admin@example.com'")
+    else:
+        op.execute("UPDATE \"user\" SET is_admin = true WHERE email LIKE '%@airweave.ai'")
 
     # Now make the column NOT NULL
     op.alter_column('user', 'is_admin', nullable=False)

--- a/backend/alembic/versions/ab5c202f5d68_resolve_migration_conflicts_and_apply_.py
+++ b/backend/alembic/versions/ab5c202f5d68_resolve_migration_conflicts_and_apply_.py
@@ -204,7 +204,12 @@ def upgrade():
         op.execute("UPDATE \"user\" SET is_admin = false")
 
         # Then, set users with @airweave.ai email to is_admin = true
-        op.execute("UPDATE \"user\" SET is_admin = true WHERE email LIKE '%@airweave.ai' OR email = 'admin@example.com'")
+        # For non-production environments, also grant admin to test account
+        from airweave.core.config import settings
+        if settings.ENVIRONMENT != 'prd':
+            op.execute("UPDATE \"user\" SET is_admin = true WHERE email LIKE '%@airweave.ai' OR email = 'admin@example.com'")
+        else:
+            op.execute("UPDATE \"user\" SET is_admin = true WHERE email LIKE '%@airweave.ai'")
 
         # Now make the column NOT NULL
         op.alter_column('user', 'is_admin', nullable=False)

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -81,6 +81,8 @@ services:
       - POSTGRES_USER=airweave
       - POSTGRES_PASSWORD=airweave1234!
       - POSTGRES_DB=airweave
+      # DEV/TEST ONLY: Default superuser credentials for local development and testing
+      # NEVER use these credentials in production - use Azure Key Vault secrets instead
       - FIRST_SUPERUSER=admin@example.com
       - FIRST_SUPERUSER_PASSWORD=admin
       - ENCRYPTION_KEY="SpgLrrEEgJ/7QdhSMSvagL1juEY5eoyCG0tZN7OSQV0="


### PR DESCRIPTION
## Summary
Eliminates hardcoded shared accounts in production to comply with CASA-22 requirements while maintaining development usability.

## Changes
- **Environment-aware migrations**: Modified database migrations to only grant admin privileges to `admin@example.com` in non-production environments
- **Documentation**: Added clear dev/test-only comments to docker-compose.test.yml

## Implementation Details
Migrations now check `settings.ENVIRONMENT != 'prd'` before granting admin rights to the test account. Production databases only grant admin privileges to `@airweave.ai` email addresses.

## Testing
- Existing tests continue to work with `admin@example.com` in dev/test environments
- Production deployments will not auto-provision the test account with admin privileges

## Related
- Linear: ENG-169
- Companion PR in infra-core for production Helm config changes

Resolves #ENG-169

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes shared/default admin accounts from production to meet CASA-22. In prod, admin is granted only to @airweave.ai emails; the test admin@example.com stays in dev/test (per Linear ENG-169).

- **Migration**
  - Make is_admin updates environment-aware: only add admin@example.com when ENVIRONMENT != 'prd'.
  - In production, set is_admin=true only for @airweave.ai accounts.
  - Add dev/test-only notes in docker-compose.test.yml for local superuser creds; never use in prod.

<!-- End of auto-generated description by cubic. -->

