### PR TITLE
fix(temporal): Remove duplicate _start_control_server call causing wo…

### DIFF
--- a/backend/airweave/platform/temporal/worker.py
+++ b/backend/airweave/platform/temporal/worker.py
@@ -40,9 +40,6 @@ class TemporalWorker:
             # Start control server for /drain endpoint
             await self._start_control_server()
 
-            # Start control server for /drain endpoint
-            await self._start_control_server()
-
             client = await temporal_client.get_client()
             task_queue = settings.TEMPORAL_TASK_QUEUE
             logger.info(f"Starting Temporal worker on task queue: {task_queue}")


### PR DESCRIPTION
…rker crashes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate _start_control_server call in the Temporal worker start method to prevent double-binding the control server and crashes on startup. The worker now starts reliably and exposes the /drain endpoint as intended.

<!-- End of auto-generated description by cubic. -->

