### PR TITLE
Add Cache-Control headers for CASA-49 compliance (ENG-187)

### DIFF
--- a/backend/airweave/api/middleware.py
+++ b/backend/airweave/api/middleware.py
@@ -220,6 +220,33 @@ async def rate_limit_headers_middleware(request: Request, call_next: callable) -
     return response
 
 
+async def cache_control_middleware(request: Request, call_next: callable) -> Response:
+    """Add Cache-Control headers to prevent caching of sensitive data.
+
+    Applies to all API endpoints to meet CASA-49 compliance requirements.
+    Does not override existing Cache-Control headers (e.g., SSE endpoints).
+
+    Args:
+    ----
+        request (Request): The incoming request.
+        call_next (callable): The next middleware in the chain.
+
+    Returns:
+    -------
+        Response: The response with Cache-Control headers added if not present.
+
+    """
+    response = await call_next(request)
+
+    # Don't override existing Cache-Control headers (e.g., SSE endpoints)
+    if "Cache-Control" not in response.headers:
+        # For API endpoints, prevent all caching
+        if request.url.path.startswith("/api/v1/"):
+            response.headers["Cache-Control"] = "no-store, private"
+
+    return response
+
+
 class DynamicCORSMiddleware(BaseHTTPMiddleware):
     """Middleware to dynamically update CORS origins based on configuration.
 

--- a/backend/airweave/main.py
+++ b/backend/airweave/main.py
@@ -19,6 +19,7 @@ from airweave.api.middleware import (
     add_request_id,
     airweave_exception_handler,
     analytics_middleware,
+    cache_control_middleware,
     exception_logging_middleware,
     invalid_state_exception_handler,
     log_requests,
@@ -105,6 +106,7 @@ app.middleware("http")(add_request_id)
 app.middleware("http")(request_body_size_middleware)
 app.middleware("http")(request_timeout_middleware)
 app.middleware("http")(rate_limit_headers_middleware)
+app.middleware("http")(cache_control_middleware)
 app.middleware("http")(log_requests)
 app.middleware("http")(analytics_middleware)
 app.middleware("http")(exception_logging_middleware)


### PR DESCRIPTION
Implements CASA-49 compliance by adding Cache-Control middleware to prevent caching of sensitive data.

Changes:
- Added cache_control_middleware in backend/airweave/api/middleware.py
- Registered middleware in backend/airweave/main.py

Sets Cache-Control: no-store, private on all /api/v1/ endpoints while respecting existing SSE headers.

Closes ENG-187

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cache-Control middleware to prevent caching of /api/v1 responses for CASA-49 compliance (ENG-187). Sets Cache-Control: no-store, private, and preserves existing headers so SSE endpoints are unaffected.

<!-- End of auto-generated description by cubic. -->

