### PR TITLE
Fix: Embedder vector size

### DIFF
--- a/backend/airweave/core/collection_service.py
+++ b/backend/airweave/core/collection_service.py
@@ -44,6 +44,8 @@ class CollectionService:
         uow: UnitOfWork,
     ) -> schemas.Collection:
         """Create a new collection."""
+        from airweave.platform.destinations.collection_strategy import get_default_vector_size
+
         # Check if the collection already exists
         try:
             existing_collection = await crud.collection.get_by_readable_id(
@@ -57,20 +59,39 @@ class CollectionService:
                 status_code=400, detail="Collection with this readable_id already exists"
             )
 
-        collection = await crud.collection.create(db, obj_in=collection_in, ctx=ctx, uow=uow)
+        # Determine vector size and embedding model for this collection
+        vector_size = get_default_vector_size()
+
+        # Determine embedding model name based on vector size
+        from airweave.platform.destinations.collection_strategy import (
+            get_openai_embedding_model_for_vector_size,
+        )
+
+        try:
+            embedding_model_name = get_openai_embedding_model_for_vector_size(vector_size)
+        except ValueError:
+            # For non-OpenAI vector sizes (e.g., 384), use a generic name
+            embedding_model_name = "sentence-transformers/all-MiniLM-L6-v2"
+
+        # Add vector_size and embedding_model_name to collection data
+        collection_data = collection_in.model_dump()
+        collection_data["vector_size"] = vector_size
+        collection_data["embedding_model_name"] = embedding_model_name
+
+        collection = await crud.collection.create(db, obj_in=collection_data, ctx=ctx, uow=uow)
         await uow.session.flush()
 
-        # Create Qdrant destination with organization context
-        # Vector size is auto-detected based on embedding model configuration
+        # Create Qdrant destination with explicit vector size
         qdrant_destination = await QdrantDestination.create(
             credentials=None,  # Native Qdrant uses settings
             config=None,
             collection_id=collection.id,
             organization_id=ctx.organization.id,
+            vector_size=vector_size,
             logger=ctx.logger,
         )
 
-        # Setup the physical shared collection (auto-detects vector size)
+        # Setup the physical shared collection
         await qdrant_destination.setup_collection()
 
         return schemas.Collection.model_validate(collection, from_attributes=True)

--- a/backend/airweave/models/collection.py
+++ b/backend/airweave/models/collection.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, List
 
-from sqlalchemy import String
+from sqlalchemy import Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from airweave.models._base import OrganizationBase, UserMixin
@@ -19,6 +19,8 @@ class Collection(OrganizationBase, UserMixin):
 
     name: Mapped[str] = mapped_column(String, nullable=False)
     readable_id: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    vector_size: Mapped[int] = mapped_column(Integer, nullable=False)
+    embedding_model_name: Mapped[str] = mapped_column(String, nullable=False)
     # Status is now ephemeral - removed from database model
 
     # Relationships

--- a/backend/airweave/platform/destinations/collection_strategy.py
+++ b/backend/airweave/platform/destinations/collection_strategy.py
@@ -3,6 +3,7 @@
 All collections now use shared physical collections in Qdrant:
 - 384-dim vectors → airweave_shared_minilm_l6_v2 (local model)
 - 1536-dim vectors → airweave_shared_text_embedding_3_small (OpenAI)
+- 3072-dim vectors → airweave_shared_text_embedding_3_large (OpenAI)
 
 Tenant isolation is achieved via airweave_collection_id payload filtering.
 """
@@ -31,13 +32,38 @@ def get_physical_collection_name(vector_size: int | None = None) -> str:
     Returns:
         Physical collection name in Qdrant:
         - "airweave_shared_text_embedding_3_large" for 3072-dim vectors
+        - "airweave_shared_text_embedding_3_small" for 1536-dim vectors
         - "airweave_shared_minilm_l6_v2" for 384-dim vectors (default for other sizes)
     """
     if vector_size is None:
         vector_size = get_default_vector_size()
 
-    return (
-        "airweave_shared_text_embedding_3_large"
-        if vector_size == 3072
-        else "airweave_shared_minilm_l6_v2"
-    )
+    if vector_size == 3072:
+        return "airweave_shared_text_embedding_3_large"
+    elif vector_size == 1536:
+        return "airweave_shared_text_embedding_3_small"
+    else:
+        return "airweave_shared_minilm_l6_v2"
+
+
+def get_openai_embedding_model_for_vector_size(vector_size: int) -> str:
+    """Get OpenAI embedding model name for given vector dimensions.
+
+    Args:
+        vector_size: Vector dimensions (3072 or 1536)
+
+    Returns:
+        - "text-embedding-3-large" for 3072-dim
+        - "text-embedding-3-small" for 1536-dim
+
+    Raises:
+        ValueError: For vector sizes that don't use OpenAI models (e.g., 384 uses local model)
+    """
+    if vector_size == 3072:
+        return "text-embedding-3-large"
+    elif vector_size == 1536:
+        return "text-embedding-3-small"
+    else:
+        raise ValueError(
+            f"No OpenAI model for vector_size {vector_size}. Only 3072 and 1536 use OpenAI models."
+        )

--- a/backend/airweave/platform/sync/entity_pipeline.py
+++ b/backend/airweave/platform/sync/entity_pipeline.py
@@ -1167,9 +1167,10 @@ class EntityPipeline:
             sparse_texts.append(json.dumps(entity_dict, sort_keys=True))
 
         # Compute dense embeddings (always required)
+        # Create embedder with collection's vector_size (creates fresh instance)
         from airweave.platform.embedders import DenseEmbedder
 
-        dense_embedder = DenseEmbedder()
+        dense_embedder = DenseEmbedder(vector_size=sync_context.collection.vector_size)
         dense_embeddings = await dense_embedder.embed_many(dense_texts, sync_context)
 
         # Compute sparse embeddings (only if destination supports keyword index)

--- a/backend/airweave/platform/sync/factory.py
+++ b/backend/airweave/platform/sync/factory.py
@@ -951,7 +951,7 @@ class SyncFactory:
         return credential
 
     @classmethod
-    async def _create_destination_instances(
+    async def _create_destination_instances(  # noqa: C901
         cls,
         db: AsyncSession,
         sync: schemas.Sync,
@@ -997,12 +997,17 @@ class SyncFactory:
                     destination_schema = schemas.Destination.model_validate(destination_model)
                     destination_class = resource_locator.get_destination(destination_schema)
 
+                    # Fail-fast: vector_size must be set
+                    if collection.vector_size is None:
+                        raise ValueError(f"Collection {collection.id} has no vector_size set.")
+
                     # Native Qdrant: no credentials (uses settings)
                     destination = await destination_class.create(
                         credentials=None,
                         config=None,
                         collection_id=collection.id,
                         organization_id=collection.organization_id,
+                        vector_size=collection.vector_size,
                         logger=logger,
                     )
 

--- a/backend/airweave/schemas/collection.py
+++ b/backend/airweave/schemas/collection.py
@@ -166,6 +166,22 @@ class CollectionInDBBase(CollectionBase):
             "once the collection is created."
         ),
     )
+    vector_size: int = Field(
+        ...,
+        description=(
+            "Vector dimensions used by this collection. Determines which embedding model "
+            "is used: 3072 (text-embedding-3-large), 1536 (text-embedding-3-small), "
+            "or 384 (MiniLM-L6-v2)."
+        ),
+    )
+    embedding_model_name: str = Field(
+        ...,
+        description=(
+            "Name of the embedding model used for this collection "
+            "(e.g., 'text-embedding-3-large', 'text-embedding-3-small'). "
+            "This ensures queries use the same model as the indexed data."
+        ),
+    )
     created_at: datetime = Field(
         ...,
         description="Timestamp when the collection was created (ISO 8601 format).",

--- a/backend/airweave/search/defaults.yml
+++ b/backend/airweave/search/defaults.yml
@@ -23,6 +23,16 @@ provider_models:
       name: "gpt-5-nano"
       tokenizer: "cl100k_base"
       context_window: 400000
+    embedding_large:
+      name: "text-embedding-3-large"
+      tokenizer: "cl100k_base"
+      dimensions: 3072
+      max_tokens: 8191
+    embedding_small:
+      name: "text-embedding-3-small"
+      tokenizer: "cl100k_base"
+      dimensions: 1536
+      max_tokens: 8191
     embedding:
       name: "text-embedding-3-large"
       tokenizer: "cl100k_base"

--- a/backend/airweave/search/operations/embed_query.py
+++ b/backend/airweave/search/operations/embed_query.py
@@ -19,10 +19,13 @@ from ._base import SearchOperation
 class EmbedQuery(SearchOperation):
     """Generate vector embeddings for queries."""
 
-    def __init__(self, strategy: RetrievalStrategy, provider: BaseProvider) -> None:
-        """Initialize with retrieval strategy and provider."""
+    def __init__(
+        self, strategy: RetrievalStrategy, provider: BaseProvider, vector_size: int
+    ) -> None:
+        """Initialize with retrieval strategy, provider, and vector dimensions."""
         self.strategy = strategy
         self.provider = provider
+        self.vector_size = vector_size
 
     def depends_on(self) -> List[str]:
         """Depends on query expansion to get all queries to embed."""

--- a/backend/airweave/search/providers/openai.py
+++ b/backend/airweave/search/providers/openai.py
@@ -38,6 +38,13 @@ class OpenAIProvider(BaseProvider):
         except Exception as e:
             raise RuntimeError(f"Failed to initialize OpenAI client: {e}") from e
 
+        # Log which embedding model we're using (if any)
+        if model_spec.embedding_model:
+            self.ctx.logger.info(
+                f"[OpenAIProvider] Using embedding model: {model_spec.embedding_model.name} "
+                f"({model_spec.embedding_model.dimensions}-dim)"
+            )
+
         self.ctx.logger.debug(f"[OpenAIProvider] Initialized with model spec: {model_spec}")
 
         self.llm_tokenizer: Optional[Encoding] = None

--- a/backend/alembic/versions/d702ba6de953_add_vector_size_to_collection.py
+++ b/backend/alembic/versions/d702ba6de953_add_vector_size_to_collection.py
@@ -1,0 +1,172 @@
+"""add vector_size to collection
+
+Revision ID: d702ba6de953
+Revises: 8be89aca78a6
+Create Date: 2025-10-29 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+from datetime import datetime, timezone
+
+
+# revision identifiers, used by Alembic.
+revision = "d702ba6de953"
+down_revision = "8be89aca78a6"
+branch_labels = None
+depends_on = None
+
+
+# CRITICAL: This is when we switched from text-embedding-3-small (1536) to text-embedding-3-large (3072)
+# Collections created BEFORE this timestamp use 1536-dim
+# Collections created AFTER this timestamp use 3072-dim (or get_default_vector_size())
+EMBEDDING_MODEL_SWITCH_DATE = datetime(2025, 10, 29, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def get_default_vector_size():
+    """Get default vector size based on environment."""
+    import os
+
+    # If OpenAI API key is set, default to 3072 (text-embedding-3-large)
+    # Otherwise default to 384 (MiniLM-L6-v2)
+    return 3072 if os.getenv("OPENAI_API_KEY") else 384
+
+
+def upgrade():
+    """Add vector_size and embedding_model_name columns to collection table.
+
+    Strategy:
+    1. Add vector_size column with temporary default (0)
+    2. Add embedding_model_name column with temporary default ('')
+    3. Backfill both based on creation timestamp:
+       - Collections created BEFORE Oct 29, 2025 00:00:00 UTC:
+         → 1536-dim + text-embedding-3-small
+       - Collections created AFTER that date:
+         → 3072-dim + text-embedding-3-large (current default)
+    4. Make both columns NOT NULL (remove defaults)
+
+    This time-based approach is:
+    - Simple and deterministic
+    - No external dependencies (no Qdrant queries needed)
+    - Works reliably in all environments
+    - Accurate based on when the embedding model was switched
+    """
+    print("\n" + "="*80)
+    print("MIGRATION: Adding vector_size and embedding_model_name to collection table")
+    print("="*80)
+    print(f"\nEmbedding model switch date: {EMBEDDING_MODEL_SWITCH_DATE}")
+    print(f"  - Collections created BEFORE this date → 1536-dim (text-embedding-3-small)")
+    print(f"  - Collections created AFTER this date  → 3072-dim (text-embedding-3-large)")
+
+    # Step 1: Add columns with temporary defaults
+    print("\n[Step 1] Adding vector_size and embedding_model_name columns...")
+    op.add_column(
+        "collection",
+        sa.Column("vector_size", sa.Integer(), nullable=False, server_default="0")
+    )
+    op.add_column(
+        "collection",
+        sa.Column("embedding_model_name", sa.String(), nullable=False, server_default="")
+    )
+    print("✅ Columns added")
+
+    # Step 2: Backfill existing collections based on creation timestamp
+    print("\n[Step 2] Backfilling vector_size and embedding_model_name (time-based)...")
+    conn = op.get_bind()
+
+    # Get all existing collections with their creation timestamps
+    result = conn.execute(text("SELECT id, readable_id, name, created_at FROM collection"))
+    collections = list(result)
+
+    if not collections:
+        print("   No existing collections found - skipping backfill")
+    else:
+        print(f"   Found {len(collections)} existing collections to backfill")
+
+        default_vector_size = get_default_vector_size()
+        print(f"   Current default vector size: {default_vector_size}")
+
+        old_count = 0
+        new_count = 0
+
+        for collection_id, readable_id, name, created_at in collections:
+            # Ensure created_at is timezone-aware for comparison
+            # Database stores UTC timestamps but may return them as naive
+            if created_at.tzinfo is None:
+                created_at_aware = created_at.replace(tzinfo=timezone.utc)
+            else:
+                created_at_aware = created_at
+
+            # Determine vector size and model name based on creation date
+            if created_at_aware < EMBEDDING_MODEL_SWITCH_DATE:
+                # Old collection - uses small embedding model
+                vector_size = 1536
+                embedding_model_name = "text-embedding-3-small"
+                old_count += 1
+                age_indicator = "OLD"
+            else:
+                # New collection - uses current default (large embedding model)
+                vector_size = default_vector_size
+                if vector_size == 3072:
+                    embedding_model_name = "text-embedding-3-large"
+                elif vector_size == 1536:
+                    embedding_model_name = "text-embedding-3-small"
+                else:
+                    # 384 or other sizes
+                    embedding_model_name = "sentence-transformers/all-MiniLM-L6-v2"
+                new_count += 1
+                age_indicator = "NEW"
+
+            print(f"   {age_indicator} - {readable_id}: {vector_size}-dim ({embedding_model_name}, created: {created_at})")
+
+            # Update the collection with both fields
+            conn.execute(
+                text("UPDATE collection SET vector_size = :size, embedding_model_name = :model WHERE id = :id"),
+                {"size": vector_size, "model": embedding_model_name, "id": collection_id}
+            )
+
+        print(f"\n   ✅ Backfilled {len(collections)} collections:")
+        print(f"      - {old_count} old collections → 1536-dim (text-embedding-3-small)")
+        print(f"      - {new_count} new collections → {default_vector_size}-dim")
+
+    # Step 3: Remove temporary defaults (make them true NOT NULL columns)
+    print("\n[Step 3] Removing temporary defaults (finalizing schema)...")
+    op.alter_column(
+        "collection",
+        "vector_size",
+        existing_type=sa.Integer(),
+        nullable=False,
+        server_default=None,  # Remove default
+    )
+    op.alter_column(
+        "collection",
+        "embedding_model_name",
+        existing_type=sa.String(),
+        nullable=False,
+        server_default=None,  # Remove default
+    )
+    print("✅ Columns finalized as NOT NULL")
+
+    print("\n" + "="*80)
+    print("✅ MIGRATION COMPLETE")
+    print("="*80)
+    print("\nSummary:")
+    print(f"  - Added vector_size and embedding_model_name columns to collection table")
+    print(f"  - Backfilled {len(collections) if collections else 0} existing collections based on creation date")
+    print(f"  - Old collections (< {EMBEDDING_MODEL_SWITCH_DATE}): 1536-dim + text-embedding-3-small")
+    print(f"  - New collections (>= {EMBEDDING_MODEL_SWITCH_DATE}): {get_default_vector_size()}-dim + appropriate model")
+    print(f"  - Future collections will determine vector_size and model at creation time")
+    print("\n")
+
+
+def downgrade():
+    """Remove vector_size and embedding_model_name columns from collection table."""
+    print("\n⚠️  WARNING: Downgrading - removing vector_size and embedding_model_name columns")
+    print("   This will lose information about which embedding model each collection uses!")
+
+    op.drop_column("collection", "embedding_model_name")
+    op.drop_column("collection", "vector_size")
+
+    print("✅ Columns removed (not recommended for production)")


### PR DESCRIPTION
- old collections use small embeddings, while new collections use large embeddings
- collections have a vector size and embedding_model_name in the db
- function to get qdrant collection name based on vector size
- function to get openai embedding model name  for vector size
- entity pipeline is no longer singleton (created with vector size)
- search determines embedder based on collection vector size
- collections before 29-09-2025 00:00:00 UTC are considered "old" (small embeddings), after are "new"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-collection embedding configuration and updates search/sync to use the correct vector size and model. Migrates existing collections so old data uses 1536-dim and new data defaults to 3072-dim (or 384-dim if OpenAI is unavailable).

- **New Features**
  - Store vector_size and embedding_model_name on collections.
  - Select OpenAI model by vector size (3072 = text-embedding-3-large, 1536 = text-embedding-3-small; 384 = MiniLM).
  - Build embedders per collection (no singleton) and pass vector_size through sync and search.
  - Map Qdrant physical collections by vector size and initialize destinations with explicit dimensions.
  - Update search defaults and provider selection to use the model that matches the collection’s vector size.

- **Migration**
  - Add Alembic migration to backfill vector_size and embedding_model_name.
  - Collections created before 2025-10-29 00:00:00 UTC → 1536-dim (text-embedding-3-small); after → default vector size (3072 if OPENAI_API_KEY, else 384).
  - New collections set these fields at creation.

<!-- End of auto-generated description by cubic. -->

