### PR TITLE
security(CASA-23): Enforce single-use OAuth redirect session codes

### DIFF
--- a/backend/airweave/api/v1/endpoints/source_connections.py
+++ b/backend/airweave/api/v1/endpoints/source_connections.py
@@ -366,6 +366,13 @@ async def authorize_redirect(
     if not redirect_info:
         raise HTTPException(status_code=404, detail="Authorization link expired or invalid")
 
+    # Check if expired (security: enforce TTL)
+    if redirect_session.is_expired(redirect_info):
+        raise HTTPException(status_code=404, detail="Authorization link expired or invalid")
+
+    # Consume the code immediately to prevent reuse
+    await redirect_session.consume(db, code=code)
+
     # Redirect to the OAuth provider
     return Response(
         status_code=303,


### PR DESCRIPTION
## Overview
Implements single-use enforcement for OAuth redirect session codes to satisfy CASA-23 security requirement.

## Changes
- Added expiry validation in `/source-connections/authorize/{code}` endpoint
- Consume redirect session code immediately after validation
- Prevents replay attacks by deleting database record on first use

## Implementation Details
- Leverages existing `redirect_session.is_expired()` and `redirect_session.consume()` methods
- No CRUD layer changes needed
- Zero breaking changes to OAuth flow
- Existing E2E tests cover this endpoint

## Security Impact
✅ Prevents replay attacks on OAuth authorization URLs
✅ Enforces documented one-time-use behavior
✅ Satisfies CASA-23 requirement for single-use lookup secrets

## Auditor Resolution
Implemented single-use enforcement for OAuth redirect session codes by consuming the code immediately after successful validation. The existing `consume()` method deletes the database record, preventing any subsequent reuse. Added expiry validation to respect the configured 24-hour TTL. This change prevents replay attacks where intercepted authorization URLs could be reused.

Closes ENG-171

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces single-use OAuth redirect session codes in /source-connections/authorize/{code} to prevent replay attacks. Checks TTL and consumes the code on first use, satisfying CASA-23 and addressing ENG-171 without changing the OAuth flow.

<!-- End of auto-generated description by cubic. -->

