### PR TITLE
fix(search): remove state parameter from federated search

### DIFF
--- a/backend/airweave/search/operations/federated_search.py
+++ b/backend/airweave/search/operations/federated_search.py
@@ -299,7 +299,6 @@ class FederatedSearch(SearchOperation):
                 operation_call=call_provider,
                 operation_name="FederatedSearch",
                 ctx=ctx,
-                state=state,
             )
 
             # Normalize and ensure single-word coverage


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the state parameter from FederatedSearch to match the current operation signature and avoid passing unused state during provider calls.

<!-- End of auto-generated description by cubic. -->

