### PR TITLE
security(SOC-2): add warning messages on dev.integrations.yaml

### DIFF
--- a/backend/airweave/platform/auth/yaml/dev.integrations.yaml
+++ b/backend/airweave/platform/auth/yaml/dev.integrations.yaml
@@ -1,3 +1,7 @@
+# Warning: this file is not used in production. It is only used for development.
+# The secrets that we openly share with you are for development purposes only and cannot 
+# be used in production.
+
 integrations:
   airtable:
     oauth_type: "with_refresh"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added warnings to dev.integrations.yaml to clarify the file is for development only and that shared secrets cannot be used in production. Helps SOC-2 compliance and prevents accidental use of dev credentials in prod.

<sup>Written for commit c888d65. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

