### PR TITLE
Fix search provider fallback to handle rate limits and API errors

### DIFF
--- a/backend/airweave/search/operations/_base.py
+++ b/backend/airweave/search/operations/_base.py
@@ -103,9 +103,15 @@ class SearchOperation(ABC):
             except Exception as e:
                 last_error = e
                 if BaseProvider.is_retryable_error(e) and i < len(providers) - 1:
-                    ctx.logger.warning(
+                    ctx.logger.error(
                         f"[{operation_name}] Provider {provider.__class__.__name__} failed "
-                        f"with retryable error: {e}. Trying next provider..."
+                        f"with retryable error: {e}. Trying next provider...",
+                        extra={
+                            "operation": operation_name,
+                            "provider": provider.__class__.__name__,
+                            "error_type": type(e).__name__,
+                            "fallback_available": True,
+                        },
                     )
                     continue
                 else:


### PR DESCRIPTION
Fixes provider fallback mechanism in search operations to properly fall back to alternative providers when encountering rate limits, server errors, or auth failures.

**Problem:**
- Cerebras provider was wrapping all SDK exceptions in RuntimeError, preventing the fallback mechanism from detecting retryable errors
- is_retryable_error() used fragile string parsing instead of structured exception attributes
- Non-retryable error classification was too conservative (e.g., 401 errors would fail entire search instead of trying next provider)

**Solution:**
- Remove exception wrapping in Cerebras provider - let SDK exceptions propagate naturally
- Enhance is_retryable_error() to check status_code attributes directly (no string parsing)
- Treat ALL HTTP errors (4xx, 5xx) as retryable in multi-provider context since each provider has its own auth, capabilities, and availability
- Only fail fast on programming errors (ValueError, TypeError, etc.)

**Result:**
- Search operations now properly fall back from Cerebras → Groq → OpenAI on rate limits, auth errors, or server issues
- More resilient search experience with better provider utilization





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes search provider fallback to reliably switch to the next provider on rate limits, auth, and server errors. Expands retryable detection across HTTP 4xx/5xx and adds structured error logs; still fails fast on programming errors.

- **Bug Fixes**
  - is_retryable_error now treats 400, 401, 403, 404, 422, 429, and 5xx as retryable (via status codes and HTTP code matching); does not fallback on programming errors.
  - Fallback logs emit at error level with structured context (operation, provider, error_type, fallback_available).

<sup>Written for commit b29711f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





