### PR TITLE
Fix: Cohere token limit exceeded

### DIFF
--- a/backend/airweave/search/defaults.yml
+++ b/backend/airweave/search/defaults.yml
@@ -27,17 +27,17 @@ provider_models:
       name: "text-embedding-3-large"
       tokenizer: "cl100k_base"
       dimensions: 3072
-      max_tokens: 8191
+      max_tokens: 8192
     embedding_small:
       name: "text-embedding-3-small"
       tokenizer: "cl100k_base"
       dimensions: 1536
-      max_tokens: 8191
+      max_tokens: 8192
     embedding:
       name: "text-embedding-3-large"
       tokenizer: "cl100k_base"
       dimensions: 3072
-      max_tokens: 8191
+      max_tokens: 8192
     rerank:
       name: "gpt-5-nano"
       tokenizer: "cl100k_base"
@@ -72,7 +72,7 @@ provider_models:
     rerank:
       name: "rerank-v3.5"
       tokenizer: "cl100k_base"
-      max_tokens_per_doc: 8191
+      max_tokens_per_doc: 8192
       max_documents: 1000
 
 # Operation preferences - which provider and which models to use


### PR DESCRIPTION
8192 tokens assumed in entity pipeline, but 8191 in the search pipeline. 
Maxed out entities cause a 1 token limit exceeded error.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned search token limits to 8192 to match the entity pipeline, fixing an off-by-one “token limit exceeded” error when inputs hit the max.

- **Bug Fixes**
  - Set OpenAI embedding max_tokens and Cohere rerank max_tokens_per_doc to 8192 in backend/airweave/search/defaults.yml.

<sup>Written for commit d406c02. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

