### PR TITLE
gitignore: local scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ Thumbs.db
 htmlcov/
 .env.local
 local_storage/
+local_scripts/
 
 .DS_Store
 __pycache__


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added local_scripts/ to .gitignore to prevent committing local dev scripts and keep the repo clean.

<sup>Written for commit 0bce4e6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

