### PR TITLE
Fix: Create token manager based on oauth type not auth config class

### DIFF
--- a/backend/airweave/platform/sync/factory.py
+++ b/backend/airweave/platform/sync/factory.py
@@ -491,7 +491,7 @@ class SyncFactory:
             else:
                 logger.debug(
                     f"⏭️ Skipping token manager for {short_name} - "
-                    f"oauth_type={source_model.oauth_type.value} does not support token refresh"
+                    f"oauth_type={source_model.oauth_type} does not support token refresh"
                 )
 
         if should_create_token_manager:

--- a/backend/airweave/search/factory.py
+++ b/backend/airweave/search/factory.py
@@ -911,7 +911,7 @@ class SearchFactory:
                 else:
                     ctx.logger.debug(
                         f"⏭️ Skipping token manager for {source_connection.short_name} - "
-                        f"oauth_type={source_model.oauth_type.value} does not support token refresh"
+                        f"oauth_type={source_model.oauth_type} does not support token refresh"
                     )
 
             ctx.logger.info(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Create the token manager based on a source’s oauth_type instead of the auth config class. Only set up a token manager for OAuth sources that support token refresh.

- **Bug Fixes**
  - Sync factory: switch to oauth_type checks (WITH_REFRESH, WITH_ROTATING_REFRESH); remove auth_config_class logic; add clear debug logs for skips.
  - Search factory: gate token manager setup behind the same oauth_type refresh check; log when skipped.

<sup>Written for commit 47be81d006e7d317ca0219fb779706c6885a8d28. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

