### PR TITLE
fix(oauth): do not reference string oauth_type value

### DIFF
--- a/backend/airweave/platform/sync/factory.py
+++ b/backend/airweave/platform/sync/factory.py
@@ -485,7 +485,7 @@ class SyncFactory:
             if source_model.oauth_type in (OAuthType.WITH_REFRESH, OAuthType.WITH_ROTATING_REFRESH):
                 should_create_token_manager = True
                 logger.debug(
-                    f"✅ OAuth source {short_name} with oauth_type={source_model.oauth_type.value} "
+                    f"✅ OAuth source {short_name} with oauth_type={source_model.oauth_type} "
                     f"will use token manager for refresh"
                 )
             else:


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix debug logging in OAuth token manager setup by referencing oauth_type directly instead of oauth_type.value to avoid enum/string mismatches.

<sup>Written for commit a0792c9c330c9ba0e2524a5332313b98a8076ef3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



