### PR TITLE
Fix: Prevent cleanup job from cancelling healthy incremental syncs with no changes

### DIFF
--- a/.cursor/rules/sync-architecture.mdc
+++ b/.cursor/rules/sync-architecture.mdc
@@ -161,13 +161,21 @@ if all_edges_go_to_destinations:
 - **Atomic Counters**: Thread-safe increment operations with async locks
 - **Threshold Publishing**: Publishes updates every N operations (default: 3)
 - **Entity Tracking**: Maintains count of unique entities by type
-- **Redis Integration**: Publishes to `sync_job:{job_id}` channels
+- **Redis Integration**: Publishes to `sync_job:{job_id}` channels and stores snapshots for cleanup job
 
 **Statistics Tracked**:
 - `inserted`, `updated`, `deleted`: Destination operations
 - `kept`: Unchanged entities (hash match)
 - `skipped`: Failed or filtered entities
 - `entities_encountered`: Count by entity type
+- `status`: Final job status (None if still in progress)
+- `last_update_timestamp`: ISO timestamp of last update (for cleanup job stuck detection)
+
+**Redis Snapshot Storage**:
+- Each progress update stores a snapshot in Redis with key `sync_progress_snapshot:{job_id}`
+- Snapshot includes `last_update_timestamp` for cleanup job to detect stuck syncs
+- 30-minute TTL to automatically clean up completed syncs
+- Used by `cleanup_stuck_sync_jobs_activity` to identify RUNNING jobs with no recent activity
 
 **Critical Fix**:
 ```python
@@ -247,7 +255,10 @@ EntityProcessor.process()
 Every operation increments counter
 ├── Async lock ensures thread safety
 ├── Threshold check (every 3 ops)
-├── Publish to Redis if threshold met
+├── Publish to Redis pubsub if threshold met
+│   ├── Real-time updates to subscribers
+│   └── Snapshot stored in Redis (sync_progress_snapshot:{job_id})
+│       └── Includes last_update_timestamp for cleanup job detection
 └── Subscribers receive real-time updates
 ```
 

--- a/backend/airweave/schemas/sync_pubsub.py
+++ b/backend/airweave/schemas/sync_pubsub.py
@@ -29,6 +29,10 @@ class SyncProgressUpdate(BaseModel):
     )
     # Status field to track the final state - None means still in progress
     status: Optional[SyncJobStatus] = None
+    # Timestamp for stuck job detection
+    last_update_timestamp: Optional[str] = Field(
+        None, description="ISO timestamp of last update (for cleanup job stuck detection)"
+    )
 
 
 class EntityStateUpdate(BaseModel):


### PR DESCRIPTION
The cleanup job (`CleanupStuckSyncJobsWorkflow`) was incorrectly cancelling healthy running syncs, particularly incremental syncs where all entities were unchanged (e.g., Confluence syncs with no new/modified content).

**Example from production:**
- Confluence sync was actively processing ~5 ops/sec
- All 3,656 entities were "kept" (unchanged, no DB writes needed)
- After ~5 minutes, cleanup job marked it as "stuck" and cancelled it
- Sync was healthy but cleanup logic only checked for NEW database entity timestamps

### Root Cause
The cleanup job determined if a sync was stuck by checking:
```python
latest_entity_time = await crud.entity.get_latest_entity_time_for_job(db, sync_job_id)
```
This query returns `MAX(created_at)` from the entity table, which only reflects when entities were **created/updated in the database**. For incremental syncs where all entities are unchanged ("kept"), no new entities are written to the database, so the timestamp appears stale even though the sync is actively processing.

### Solution
Modified the stuck detection logic to check **real-time sync activity** via Redis instead of database timestamps:

1. **Added timestamp to sync progress**: `SyncProgressUpdate` now includes `last_update_timestamp`
2. **Store Redis snapshot**: Each progress publish now stores a retrievable snapshot at `sync_progress_snapshot:{job_id}` with 30-min TTL
3. **Check Redis in cleanup**: Cleanup job now reads the snapshot and checks the timestamp + total operations (including "kept" entities)
4. **Reduced threshold**: Changed stuck detection from 10 minutes to 5 minutes for faster cleanup

## Testing
Simulated a long running sync with only kept entities, verified redis snapshot existence and timestamp updates, and new cleanup job behavior.







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the cleanup job from cancelling healthy incremental syncs by using real-time Redis progress snapshots instead of DB entity timestamps. Tightens stuck detection to 5 minutes.

- **Bug Fixes**
  - Publish progress with last_update_timestamp and store a Redis snapshot (sync_progress_snapshot:{job_id}, 30‑min TTL).
  - Cleanup reads the snapshot to check recent activity and total ops (inserted/updated/deleted/kept/skipped), with DB fallback on errors.
  - Reduced RUNNING job cutoff from 10 to 5 minutes.

<sup>Written for commit d69d21444c4a2428e685d5925aae49964773ed70. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







