### PR TITLE
fix(confluence): Add retry logic for transient errors

### DIFF
--- a/backend/airweave/platform/sources/confluence.py
+++ b/backend/airweave/platform/sources/confluence.py
@@ -113,7 +113,6 @@ class ConfluenceSource(BaseSource):
     @tenacity.retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10),
-        retry=tenacity.retry_if_exception_type(httpx.HTTPStatusError),
         reraise=True,
     )
     async def _get_with_auth(self, client: httpx.AsyncClient, url: str) -> Any:


### PR DESCRIPTION
Fixes Confluence syncs failing on transient network and API errors.

**Problem:** 
Confluence syncs failed immediately on transient errors (connection drops, timeouts, temporary server issues), even after processing thousands of entities.

Note: Preserves existing 401 token refresh logic





