### PR TITLE
Add comprehensive diagnostic logging for sync bottleneck detection

### DIFF
--- a/backend/airweave/platform/sources/hubspot.py
+++ b/backend/airweave/platform/sources/hubspot.py
@@ -1,5 +1,6 @@
 """HubSpot source implementation."""
 
+import time
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 import httpx
@@ -306,6 +307,9 @@ class HubspotSource(BaseSource):
         all_properties = await self._get_all_properties(client, "contacts")
 
         # Fetch all contact IDs first (without properties to avoid URI length issues)
+        fetch_start = time.time()
+        self.logger.info("🔍 [HUBSPOT] Fetching all contact IDs (paginated)...")
+
         url = f"https://api.hubapi.com/crm/v3/objects/contacts?limit={self.HUBSPOT_API_LIMIT}"
         contact_ids = []
         while url:
@@ -317,7 +321,15 @@ class HubspotSource(BaseSource):
             next_link = paging.get("next", {}).get("link")
             url = next_link if next_link else None
 
+        fetch_duration = time.time() - fetch_start
+        self.logger.info(
+            f"✅ [HUBSPOT] Fetched {len(contact_ids)} contact IDs in {fetch_duration:.2f}s"
+        )
+
         # Batch read contacts with all properties
+        self.logger.info(
+            f"🔍 [HUBSPOT] Batch reading {len(contact_ids)} contacts with properties..."
+        )
         batch_url = "https://api.hubapi.com/crm/v3/objects/contacts/batch/read"
         for i in range(0, len(contact_ids), self.HUBSPOT_BATCH_SIZE):
             chunk = contact_ids[i : i + self.HUBSPOT_BATCH_SIZE]
@@ -379,6 +391,9 @@ class HubspotSource(BaseSource):
         all_properties = await self._get_all_properties(client, "companies")
 
         # Fetch all company IDs first (without properties to avoid URI length issues)
+        fetch_start = time.time()
+        self.logger.info("🔍 [HUBSPOT] Fetching all company IDs (paginated)...")
+
         url = f"https://api.hubapi.com/crm/v3/objects/companies?limit={self.HUBSPOT_API_LIMIT}"
         company_ids = []
         while url:
@@ -390,7 +405,15 @@ class HubspotSource(BaseSource):
             next_link = paging.get("next", {}).get("link")
             url = next_link if next_link else None
 
+        fetch_duration = time.time() - fetch_start
+        self.logger.info(
+            f"✅ [HUBSPOT] Fetched {len(company_ids)} company IDs in {fetch_duration:.2f}s"
+        )
+
         # Batch read companies with all properties
+        self.logger.info(
+            f"🔍 [HUBSPOT] Batch reading {len(company_ids)} companies with properties..."
+        )
         batch_url = "https://api.hubapi.com/crm/v3/objects/companies/batch/read"
         for i in range(0, len(company_ids), self.HUBSPOT_BATCH_SIZE):
             chunk = company_ids[i : i + self.HUBSPOT_BATCH_SIZE]
@@ -437,6 +460,9 @@ class HubspotSource(BaseSource):
         all_properties = await self._get_all_properties(client, "deals")
 
         # Fetch all deal IDs first (without properties to avoid URI length issues)
+        fetch_start = time.time()
+        self.logger.info("🔍 [HUBSPOT] Fetching all deal IDs (paginated)...")
+
         url = f"https://api.hubapi.com/crm/v3/objects/deals?limit={self.HUBSPOT_API_LIMIT}"
         deal_ids = []
         while url:
@@ -448,7 +474,11 @@ class HubspotSource(BaseSource):
             next_link = paging.get("next", {}).get("link")
             url = next_link if next_link else None
 
+        fetch_duration = time.time() - fetch_start
+        self.logger.info(f"✅ [HUBSPOT] Fetched {len(deal_ids)} deal IDs in {fetch_duration:.2f}s")
+
         # Batch read deals with all properties
+        self.logger.info(f"🔍 [HUBSPOT] Batch reading {len(deal_ids)} deals with properties...")
         batch_url = "https://api.hubapi.com/crm/v3/objects/deals/batch/read"
         for i in range(0, len(deal_ids), self.HUBSPOT_BATCH_SIZE):
             chunk = deal_ids[i : i + self.HUBSPOT_BATCH_SIZE]
@@ -496,6 +526,9 @@ class HubspotSource(BaseSource):
         all_properties = await self._get_all_properties(client, "tickets")
 
         # Fetch all ticket IDs first (without properties to avoid URI length issues)
+        fetch_start = time.time()
+        self.logger.info("🔍 [HUBSPOT] Fetching all ticket IDs (paginated)...")
+
         url = f"https://api.hubapi.com/crm/v3/objects/tickets?limit={self.HUBSPOT_API_LIMIT}"
         ticket_ids = []
         while url:
@@ -507,7 +540,13 @@ class HubspotSource(BaseSource):
             next_link = paging.get("next", {}).get("link")
             url = next_link if next_link else None
 
+        fetch_duration = time.time() - fetch_start
+        self.logger.info(
+            f"✅ [HUBSPOT] Fetched {len(ticket_ids)} ticket IDs in {fetch_duration:.2f}s"
+        )
+
         # Batch read tickets with all properties
+        self.logger.info(f"🔍 [HUBSPOT] Batch reading {len(ticket_ids)} tickets with properties...")
         batch_url = "https://api.hubapi.com/crm/v3/objects/tickets/batch/read"
         for i in range(0, len(ticket_ids), self.HUBSPOT_BATCH_SIZE):
             chunk = ticket_ids[i : i + self.HUBSPOT_BATCH_SIZE]


### PR DESCRIPTION
## Problem
Large HubSpot syncs (178K+ entities) were being cancelled by the cleanup job after ~5 minutes of apparent inactivity. Without detailed timing logs, it was impossible to identify which phase was causing the delay.

## Solution
Added strategic logging at all potential bottleneck points to enable precise identification of performance issues in production:

### 1. Sync Phase Boundaries (`orchestrator.py`)
- Log start/completion of each major phase with timing:
  - PHASE 1: Sync initialization
  - PHASE 2: Entity processing from source
  - PHASE 3: Orphaned entity cleanup
  - PHASE 4: Sync finalization
- Enables quick identification of which phase is blocking

### 2. Orphaned Entity Cleanup (`entity_pipeline.py`)
- Log database query to fetch all stored entities (suspected bottleneck for large datasets)
- Log comparison phase timing and statistics
- Shows entity counts: total stored, encountered, orphaned

### 3. Bulk Entity Lookup (`entity_pipeline.py`)
- Log bulk lookup operation with chunk count
- Log completion time and hit rate (found/requested)
- Critical for understanding incremental sync performance

### 4. HubSpot ID Fetching (`hubspot.py`)
- Log ID collection phase for all entity types (contacts, companies, deals, tickets)
- Log timing and total count before batch reading
- Separates pagination time from property fetching time








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add detailed timing logs across the sync pipeline to find bottlenecks in large HubSpot syncs. This makes it clear which phase is slow, with durations and counts for key operations.

- **New Features**
  - Orchestrator: logs start/end and duration for four phases (init, processing, orphan cleanup, finalization).
  - Entity pipeline:
    - Orphan cleanup: logs DB fetch time and comparison stats (total, encountered, orphaned).
    - Bulk lookup: logs chunk count, total time, and hit rate (found/requested).
  - HubSpot source: logs ID pagination and batch read for contacts, companies, deals, tickets, including counts and timing.

<sup>Written for commit ad87b5611c4d0eaf7a6466fe5a4477cf0dc044e1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





