### PR TITLE
feat: add POSTGRES_PORT support for PgBouncer connections and disable ssl mode

### DIFF
--- a/backend/airweave/core/config.py
+++ b/backend/airweave/core/config.py
@@ -100,9 +100,11 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
 
     POSTGRES_HOST: str
+    POSTGRES_PORT: int = 5432
     POSTGRES_DB: str = "airweave"
     POSTGRES_USER: str
     POSTGRES_PASSWORD: str
+    POSTGRES_SSLMODE: str = "prefer"  # disable for PgBouncer, require for Azure PostgreSQL
     SQLALCHEMY_ASYNC_DATABASE_URI: Optional[PostgresDsn] = None
 
     LOCAL_NGROK_SERVER: Optional[str] = None
@@ -328,12 +330,14 @@ class Settings(BaseSettings):
         # Connect to local PostgreSQL server during local development
         # This allows developers to debug without Docker
         host = info.data.get("POSTGRES_HOST", "localhost")
+        port = info.data.get("POSTGRES_PORT", 5432)
 
         return PostgresDsn.build(
             scheme="postgresql+asyncpg",
             username=info.data.get("POSTGRES_USER"),
             password=info.data.get("POSTGRES_PASSWORD"),
             host=host,
+            port=port,
             path=f"{info.data.get('POSTGRES_DB') or ''}",
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added POSTGRES_PORT and POSTGRES_SSLMODE to support PgBouncer connections with custom ports and to optionally disable SSL for internal traffic. This improves connection flexibility while keeping compatibility with providers that require SSL (e.g., Azure PostgreSQL).

- **New Features**
  - Support POSTGRES_PORT in the async SQLAlchemy URI (default 5432).
  - Add POSTGRES_SSLMODE (default "prefer"); when set to "disable", pass ssl=False to asyncpg.
  - Usage: set POSTGRES_PORT to your PgBouncer port and POSTGRES_SSLMODE=disable for cluster-internal PgBouncer.

<sup>Written for commit e13099508c1c7cde66ea53fc3fa7e7bae42a96da. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

