### PR TITLE
fix(qdrant): Filter prefetch for multi-tenant performance

### DIFF
--- a/backend/airweave/platform/destinations/qdrant.py
+++ b/backend/airweave/platform/destinations/qdrant.py
@@ -865,6 +865,7 @@ class QdrantDestination(VectorDBDestination):
         sparse_vector: SparseEmbedding | dict | None,
         search_method: Literal["hybrid", "neural", "keyword"],
         decay_config: Optional[DecayConfig] = None,
+        filter: Optional[rest.Filter] = None,
     ) -> rest.QueryRequest:
         """Create a single QueryRequest consistent with the old method."""
         query_request_params: dict = {}
@@ -912,11 +913,17 @@ class QdrantDestination(VectorDBDestination):
                     pass
 
             prefetch_params = [
-                {"query": query_vector, "using": DEFAULT_VECTOR_NAME, "limit": prefetch_limit},
+                {
+                    "query": query_vector,
+                    "using": DEFAULT_VECTOR_NAME,
+                    "limit": prefetch_limit,
+                    **({"filter": filter} if filter else {}),
+                },
                 {
                     "query": rest.SparseVector(**obj),
                     "using": KEYWORD_VECTOR_NAME,
                     "limit": prefetch_limit,
+                    **({"filter": filter} if filter else {}),
                 },
             ]
             prefetches = [rest.Prefetch(**p) for p in prefetch_params]
@@ -972,17 +979,8 @@ class QdrantDestination(VectorDBDestination):
         """Create per-query request objects with automatic tenant filtering."""
         requests: list[rest.QueryRequest] = []
         for i, qv in enumerate(query_vectors):
-            sv = sparse_vectors[i] if sparse_vectors else None
-            req = await self._prepare_query_request(
-                query_vector=qv,
-                limit=limit,
-                sparse_vector=sv,
-                search_method=search_method,
-                decay_config=decay_config,
-            )
-
-            # CRITICAL: Auto-inject tenant filter for multi-tenant isolation
-            # This ensures searches only return results from the correct collection
+            # CRITICAL: Build tenant filter BEFORE preparing query request
+            # This ensures prefetch operations are also filtered by tenant
             tenant_filter = rest.Filter(
                 must=[
                     rest.FieldCondition(
@@ -997,13 +995,26 @@ class QdrantDestination(VectorDBDestination):
                 user_filter = rest.Filter.model_validate(filter_conditions[i])
                 # Combine must conditions (tenant filter + user filters)
                 combined_must = tenant_filter.must + (user_filter.must or [])
-                req.filter = rest.Filter(
+                combined_filter = rest.Filter(
                     must=combined_must,
                     should=user_filter.should,
                     must_not=user_filter.must_not,
                 )
             else:
-                req.filter = tenant_filter
+                combined_filter = tenant_filter
+
+            sv = sparse_vectors[i] if sparse_vectors else None
+            req = await self._prepare_query_request(
+                query_vector=qv,
+                limit=limit,
+                sparse_vector=sv,
+                search_method=search_method,
+                decay_config=decay_config,
+                filter=combined_filter,  # Pass filter to prefetch operations!
+            )
+
+            # Filter is already set via _prepare_query_request
+            req.filter = combined_filter
 
             if offset and offset > 0:
                 req.offset = offset


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Apply tenant filters to Qdrant prefetch searches to enforce isolation and improve multi-tenant query performance. Filters are built before request creation and passed through to ensure consistent behavior across dense and sparse prefetch.

- **Bug Fixes**
  - Added a filter parameter to _prepare_query_request and applied it to both dense and sparse prefetches.
  - Built the tenant filter first and merged with any user filters, then passed the combined filter into request creation.
  - Ensured the final QueryRequest retains the combined filter and existing pagination behavior.

<sup>Written for commit b4213436a159a76331c6f3fdcbbb5f82ad1f2513. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

