### PR TITLE
Add fallback to parent_entity_id for backward-compatible deletes

### DIFF
--- a/backend/airweave/platform/destinations/qdrant.py
+++ b/backend/airweave/platform/destinations/qdrant.py
@@ -779,11 +779,19 @@ class QdrantDestination(VectorDBDestination):
                                 key="airweave_system_metadata.sync_id",
                                 match=rest.MatchValue(value=str(sync_id)),
                             ),
+                        ],
+                        should=[
+                            # Check new field (indexed)
                             rest.FieldCondition(
                                 key="airweave_system_metadata.original_entity_id",
                                 match=rest.MatchAny(any=[str(pid) for pid in parent_ids]),
                             ),
-                        ]
+                            # Fallback to old field for backward compatibility
+                            rest.FieldCondition(
+                                key="parent_entity_id",
+                                match=rest.MatchAny(any=[str(pid) for pid in parent_ids]),
+                            ),
+                        ],
                     )
                 ),
                 wait=True,


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make Qdrant bulk deletes backward-compatible by matching parent IDs on both original_entity_id (new) and parent_entity_id (old). Uses a should filter so either field triggers deletion, preventing missed records during sync.

<sup>Written for commit 38582d3a78ead08c4752907bc6820b596716ec83. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



