### PR TITLE
fix: add localhost:8001 to CSP connect-src

### DIFF
--- a/frontend/serve.json
+++ b/frontend/serve.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://eu-assets.i.posthog.com; connect-src 'self' https://api.dev-airweave.com https://api.stg-airweave.com https://api.airweave.ai https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://*.auth0.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; frame-src 'self' https://*.auth0.com; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://eu-assets.i.posthog.com; connect-src 'self' http://localhost:8001 https://api.dev-airweave.com https://api.stg-airweave.com https://api.airweave.ai https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://*.auth0.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; frame-src 'self' https://*.auth0.com; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
Includes localhost:8001 to the Content-Security-Policy connect-src directive to allow local development connections. This resolves a regression where the local development server was blocked by CSP.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add http://localhost:8001 to the CSP connect-src to restore local development connections. Fixes the regression that blocked requests to the local dev server.

<sup>Written for commit e8becac5dbc1da5626f1f8fb0b253a7cab5edb04. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

