### PR TITLE
hotfix: stabilize sync jobs with reduced concurrency and enhanced deadlock handling

### DIFF
--- a/backend/airweave/core/config.py
+++ b/backend/airweave/core/config.py
@@ -170,8 +170,8 @@ class Settings(BaseSettings):
     ANALYTICS_ENABLED: bool = True
 
     # Sync configuration
-    SYNC_MAX_WORKERS: int = 100
-    SYNC_THREAD_POOL_SIZE: int = 100
+    SYNC_MAX_WORKERS: int = 20  # Reduced from 100 to prevent DB connection exhaustion
+    SYNC_THREAD_POOL_SIZE: int = 20  # Scale with worker count
     WEB_FETCHER_MAX_CONCURRENT: int = 10  # Max concurrent web scraping requests
     OPENAI_MAX_CONCURRENT: int = 20  # Max concurrent OpenAI API requests
     CTTI_MAX_CONCURRENT: int = 3  # Max concurrent CTTI (ClinicalTrials.gov) requests

--- a/backend/airweave/db/session.py
+++ b/backend/airweave/db/session.py
@@ -10,15 +10,15 @@ from airweave.core.config import settings
 # Connection Pool Sizing Strategy:
 # - With proper connection management, workers only hold DB connections for milliseconds
 # - Database operations: entity lookup (~0.1s), insert/update (~0.1s)
-# - Even with 100 concurrent workers, only a few need connections at the same time
+# - Even with 20 concurrent workers, only a few need connections at the same time
 # - Pool size 15 + overflow 15 = 30 total connections available
 # - This efficiently handles bursts while preventing connection exhaustion
 # - Multiple sync jobs can run simultaneously without issues
 
-# Determine pool size based on worker count
-worker_count = getattr(settings, "SYNC_MAX_WORKERS", 100)
-# With on-demand connections: pool_size = workers * 0.15 (only 15% need DB at once)
-POOL_SIZE = min(15, max(10, int(worker_count * 0.15)))
+# Determine pool size based on worker count (default: 20 workers)
+worker_count = getattr(settings, "SYNC_MAX_WORKERS", 20)
+# With on-demand connections: pool_size = workers * 0.75 (75% coverage for peak load)
+POOL_SIZE = min(15, max(10, int(worker_count * 0.75)))
 MAX_OVERFLOW = POOL_SIZE  # Allow doubling during spikes
 
 # Connection Pool Timeout Behavior:

--- a/backend/airweave/platform/sync/worker_pool.py
+++ b/backend/airweave/platform/sync/worker_pool.py
@@ -14,11 +14,11 @@ class AsyncWorkerPool:
     preventing system overload when processing many items in parallel.
     """
 
-    def __init__(self, logger: ContextualLogger, max_workers: int = 100):
+    def __init__(self, logger: ContextualLogger, max_workers: int = 20):
         """Initialize worker pool with concurrency control.
 
         Args:
-            max_workers: Maximum number of tasks allowed to run concurrently
+            max_workers: Maximum number of tasks allowed to run concurrently (default: 20)
             logger: Optional logger instance for contextual logging
         """
         self.semaphore = asyncio.Semaphore(max_workers)


### PR DESCRIPTION
- logs
- less workers: 100 -> 20
- more retries on deadlock
- deduplication async lock

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes sync runs by reducing concurrency and hardening deadlock handling. Adds an async dedup lock, smarter DB retries, and moves noisy logs to debug with timing across the pipeline.

- **Bug Fixes**
  - Prevent duplicate inserts with an async lock in entity dedup to avoid race conditions and deadlocks.
  - Retry PostgreSQL deadlocks with 5 attempts, exponential backoff + jitter, and clearer diagnostics.

- **Performance**
  - Lower max workers and thread pool from 100 to 20; align DB pool sizing to prevent connection exhaustion.
  - Add stage-by-stage debug timing and batch IDs across chunking, Mistral conversion, OpenAI embedding, Qdrant upserts/deletes, and orchestration.
  - Shift high-volume logs to debug; include throughput metrics and semaphore state in Qdrant operations.

<sup>Written for commit d0d3f12980d47692c4003199346db33c39fa6caa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

