### PR TITLE
fix(qdrant): enhance qdrant error logging and diagnostics

### DIFF
--- a/backend/airweave/platform/destinations/qdrant.py
+++ b/backend/airweave/platform/destinations/qdrant.py
@@ -552,10 +552,12 @@ class QdrantDestination(VectorDBDestination):
             # Qdrant returned an HTTP error (503, 429, etc.)
             n = len(points)
 
-            # Extract structured error details from Qdrant
+            # Extract ALL available error details from Qdrant response
             error_detail = None
+            full_error_data = None
             try:
                 error_data = e.structured()
+                full_error_data = error_data  # Keep for detailed logging
                 # Qdrant error format: {"status": {"error": "message"}} or {"status": "message"}
                 if isinstance(error_data.get("status"), dict):
                     error_detail = error_data["status"].get("error")
@@ -563,7 +565,32 @@ class QdrantDestination(VectorDBDestination):
                     error_detail = error_data.get("status") or error_data.get("message")
             except Exception:
                 # Fallback to raw content if JSON parsing fails
-                error_detail = e.content.decode("utf-8")[:200] if e.content else e.reason_phrase
+                error_detail = e.content.decode("utf-8")[:500] if e.content else e.reason_phrase
+
+            # Build comprehensive error context
+            error_context = {
+                "http_status": e.status_code,
+                "reason_phrase": e.reason_phrase,
+                "error_detail": error_detail,
+                "collection_name": self.collection_name,
+                "collection_id": str(self.collection_id),
+                "vector_size": self.vector_size,
+                "num_points": n,
+                "min_batch": min_batch,
+                "url": self.url or "native",
+            }
+
+            # Add full structured error if available
+            if full_error_data:
+                error_context["qdrant_response"] = full_error_data
+
+            # Add request sample (first point payload keys)
+            if points:
+                try:
+                    sample_payload_keys = list(points[0].payload.keys())[:10]
+                    error_context["sample_payload_keys"] = sample_payload_keys
+                except Exception:
+                    pass
 
             error_summary = f"HTTP {e.status_code} {e.reason_phrase}" + (
                 f": {error_detail}" if error_detail else ""
@@ -572,11 +599,13 @@ class QdrantDestination(VectorDBDestination):
             if n <= 1 or n <= min_batch:
                 self.logger.error(
                     f"[Qdrant] 💥 FATAL rejection: Cannot split further "
-                    f"- {n} points ≤ min_batch={min_batch} "
-                    f"(collection={self.collection_name}, vector_size={self.vector_size}). "
+                    f"- {n} points ≤ min_batch={min_batch}. "
                     f"Error: {error_summary}",
+                    extra={"error_context": error_context},
                     exc_info=True,
                 )
+                # Log full error details on separate line for easier parsing
+                self.logger.error(f"[Qdrant] Error context: {error_context}")
                 raise
 
             mid = n // 2
@@ -584,7 +613,8 @@ class QdrantDestination(VectorDBDestination):
             self.logger.warning(
                 f"[Qdrant] ⚠️  Rejection for {n} points; "
                 f"splitting into {len(left)} + {len(right)} and retrying... "
-                f"({error_summary})"
+                f"({error_summary})",
+                extra={"error_context": error_context},
             )
             await self._upsert_points_with_fallback(left, min_batch=min_batch)
             await self._upsert_points_with_fallback(right, min_batch=min_batch)
@@ -593,16 +623,42 @@ class QdrantDestination(VectorDBDestination):
             # Wrapper for underlying network/parsing errors
             n = len(points)
             source_error = e.source
+
+            # Build comprehensive error context
+            error_context = {
+                "wrapper_exception": "ResponseHandlingException",
+                "source_exception_type": type(source_error).__name__,
+                "source_exception_message": str(source_error),
+                "collection_name": self.collection_name,
+                "collection_id": str(self.collection_id),
+                "vector_size": self.vector_size,
+                "num_points": n,
+                "min_batch": min_batch,
+                "url": self.url or "native",
+            }
+
+            # Extract any HTTP-related details from source error
+            if hasattr(source_error, "status_code"):
+                error_context["http_status"] = source_error.status_code
+            if hasattr(source_error, "request"):
+                try:
+                    error_context["request_method"] = source_error.request.method
+                    error_context["request_url"] = str(source_error.request.url)
+                except Exception:
+                    pass
+
             error_summary = f"{type(source_error).__name__}: {source_error}"
 
             if n <= 1 or n <= min_batch:
                 self.logger.error(
                     f"[Qdrant] 💥 FATAL error: Cannot split further "
-                    f"- {n} points ≤ min_batch={min_batch} "
-                    f"(collection={self.collection_name}, vector_size={self.vector_size}). "
+                    f"- {n} points ≤ min_batch={min_batch}. "
                     f"Error: {error_summary}",
+                    extra={"error_context": error_context},
                     exc_info=True,
                 )
+                # Log full error details on separate line for easier parsing
+                self.logger.error(f"[Qdrant] Error context: {error_context}")
                 raise
 
             mid = n // 2
@@ -610,7 +666,8 @@ class QdrantDestination(VectorDBDestination):
             self.logger.warning(
                 f"[Qdrant] ⚠️  Response handling error for {n} points; "
                 f"splitting into {len(left)} + {len(right)} and retrying... "
-                f"({error_summary})"
+                f"({error_summary})",
+                extra={"error_context": error_context},
             )
             await self._upsert_points_with_fallback(left, min_batch=min_batch)
             await self._upsert_points_with_fallback(right, min_batch=min_batch)
@@ -618,16 +675,49 @@ class QdrantDestination(VectorDBDestination):
         except timeout_errors as e:  # type: ignore[misc]
             # Network timeout (httpx/httpcore)
             n = len(points)
+
+            # Build comprehensive timeout error context
+            error_context = {
+                "exception_type": type(e).__name__,
+                "exception_message": str(e),
+                "collection_name": self.collection_name,
+                "collection_id": str(self.collection_id),
+                "vector_size": self.vector_size,
+                "num_points": n,
+                "min_batch": min_batch,
+                "url": self.url or "native",
+                "client_timeout_setting": 120.0,  # From connect_to_qdrant
+            }
+
+            # Try to extract request details if available
+            if hasattr(e, "request"):
+                try:
+                    error_context["request_method"] = e.request.method
+                    error_context["request_url"] = str(e.request.url)
+                except Exception:
+                    pass
+
+            # Estimate payload size
+            try:
+                import sys
+
+                total_size_mb = sys.getsizeof(points) / (1024 * 1024)
+                error_context["estimated_payload_size_mb"] = round(total_size_mb, 2)
+            except Exception:
+                pass
+
             error_summary = f"{type(e).__name__}: {e}"
 
             if n <= 1 or n <= min_batch:
                 self.logger.error(
                     f"[Qdrant] 💥 FATAL timeout: Cannot split further "
-                    f"- {n} points ≤ min_batch={min_batch} "
-                    f"(collection={self.collection_name}, vector_size={self.vector_size}). "
+                    f"- {n} points ≤ min_batch={min_batch}. "
                     f"Error: {error_summary}",
+                    extra={"error_context": error_context},
                     exc_info=True,
                 )
+                # Log full error details on separate line for easier parsing
+                self.logger.error(f"[Qdrant] Error context: {error_context}")
                 raise
 
             mid = n // 2
@@ -635,7 +725,8 @@ class QdrantDestination(VectorDBDestination):
             self.logger.warning(
                 f"[Qdrant] ⚠️  Timeout for {n} points; "
                 f"splitting into {len(left)} + {len(right)} and retrying... "
-                f"({error_summary})"
+                f"({error_summary})",
+                extra={"error_context": error_context},
             )
             await self._upsert_points_with_fallback(left, min_batch=min_batch)
             await self._upsert_points_with_fallback(right, min_batch=min_batch)
@@ -1222,6 +1313,53 @@ class QdrantDestination(VectorDBDestination):
         except Exception as e:
             self.logger.error(f"Error performing batch search with Qdrant: {e}")
             raise
+
+    # ----------------------------------------------------------------------------------
+    # Health & Diagnostics
+    # ----------------------------------------------------------------------------------
+    async def get_collection_health_info(self) -> dict:
+        """Get comprehensive collection health and statistics for diagnostics.
+
+        Returns:
+            Dict with collection size, segment count, indexing status, etc.
+        """
+        await self.ensure_client_readiness()
+        health_info = {
+            "collection_name": self.collection_name,
+            "collection_id": str(self.collection_id),
+            "vector_size": self.vector_size,
+        }
+
+        try:
+            # Get collection info
+            info = await self.client.get_collection(collection_name=self.collection_name)
+
+            # Extract key metrics
+            health_info["points_count"] = info.points_count
+            health_info["indexed_vectors_count"] = info.indexed_vectors_count
+            health_info["vectors_count"] = info.vectors_count
+            health_info["status"] = (
+                info.status.value if hasattr(info.status, "value") else str(info.status)
+            )
+
+            # Segment info
+            if hasattr(info, "segments_count"):
+                health_info["segments_count"] = info.segments_count
+
+            # Optimizer status
+            if info.optimizer_status:
+                health_info["optimizer_ok"] = info.optimizer_status.ok
+                if hasattr(info.optimizer_status, "error"):
+                    health_info["optimizer_error"] = info.optimizer_status.error
+
+            # Payload schema
+            if info.payload_schema:
+                health_info["indexed_fields"] = list(info.payload_schema.keys())
+
+        except Exception as e:
+            health_info["error"] = f"Failed to fetch collection info: {type(e).__name__}: {str(e)}"
+
+        return health_info
 
     # ----------------------------------------------------------------------------------
     # Introspection


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enhanced Qdrant error observability with rich, structured logs and on-demand collection health diagnostics, improving triage of 5xx/timeout issues during upserts and retries. This also refactors retry logic to attach detailed context and early-stop on permanent errors.

- **Diagnostics & Logging**
  - Add structured error context (HTTP status, reason, Qdrant response, collection name/id, vector size, num_points, min_batch, URL, sample payload keys).
  - Include request method/URL and estimated payload size for timeouts; log full context via extra={"error_context"} and a second line for easier parsing.
  - New get_collection_health_info() returns points/vectors counts, status, segments, optimizer state, and indexed fields for quick diagnostics.

- **Retry Logic**
  - Extracted helpers to build error context, detect retryable exceptions, and identify permanent errors (401/403/404/400/unauthorized/forbidden).
  - On first retry, fetch destination health info and attach to logs; per-attempt warnings include next wait time.
  - Final failure logs include attempt count and total time, with comprehensive error context.

<sup>Written for commit 6f6721c18afc0ac17308d9352919ad96460106f1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

