### PR TITLE
Feat: Don't throw errors on unsupported file type

### DIFF
--- a/backend/airweave/platform/downloader/__init__.py
+++ b/backend/airweave/platform/downloader/__init__.py
@@ -1,5 +1,5 @@
 """File download module for handling file entity downloads."""
 
-from .service import FileDownloadService
+from .service import FileDownloadService, FileSkippedException
 
-__all__ = ["FileDownloadService"]
+__all__ = ["FileDownloadService", "FileSkippedException"]

--- a/backend/airweave/platform/sources/airtable.py
+++ b/backend/airweave/platform/sources/airtable.py
@@ -8,6 +8,7 @@ from tenacity import retry, stop_after_attempt
 from airweave.core.exceptions import TokenRefreshError
 from airweave.core.shared_models import RateLimitLevel
 from airweave.platform.decorators import source
+from airweave.platform.downloader import FileSkippedException
 from airweave.platform.entities._base import BaseEntity, Breadcrumb
 from airweave.platform.entities.airtable import (
     AirtableAttachmentEntity,
@@ -494,6 +495,11 @@ class AirtableSource(BaseSource):
 
                     self.logger.debug(f"Successfully downloaded attachment: {file_entity.name}")
                     yield file_entity
+
+                except FileSkippedException as e:
+                    # File intentionally skipped (unsupported type, too large, etc.) - not an error
+                    self.logger.debug(f"Skipping file: {e.reason}")
+                    continue
 
                 except Exception as e:
                     self.logger.error(f"Error downloading attachment {file_entity.name}: {e}")

--- a/backend/airweave/platform/sources/asana.py
+++ b/backend/airweave/platform/sources/asana.py
@@ -8,6 +8,7 @@ from tenacity import retry, stop_after_attempt
 from airweave.core.exceptions import TokenRefreshError
 from airweave.core.shared_models import RateLimitLevel
 from airweave.platform.decorators import source
+from airweave.platform.downloader import FileSkippedException
 from airweave.platform.entities._base import BaseEntity, Breadcrumb
 from airweave.platform.entities.asana import (
     AsanaCommentEntity,
@@ -116,7 +117,7 @@ class AsanaSource(BaseSource):
                         headers = {"Authorization": f"Bearer {new_token}"}
 
                         # Retry the request with the new token
-                        self.logger.info(f"Retrying request with refreshed token: {url}")
+                        self.logger.debug(f"Retrying request with refreshed token: {url}")
                         response = await client.get(url, headers=headers, params=params)
 
                     except TokenRefreshError as e:
@@ -210,7 +211,7 @@ class AsanaSource(BaseSource):
 
             # Skip projects matching exclude_path
             if self.exclude_path and self.exclude_path in project_name:
-                self.logger.info(f"Skipping excluded project: {project_name}")
+                self.logger.debug(f"Skipping excluded project: {project_name}")
                 continue
 
             yield AsanaProjectEntity(
@@ -527,6 +528,11 @@ class AsanaSource(BaseSource):
                     raise ValueError(f"Download failed - no local path set for {file_entity.name}")
 
                 yield file_entity
+
+            except FileSkippedException as e:
+                # File intentionally skipped (unsupported type, too large, etc.) - not an error
+                self.logger.debug(f"Skipping attachment {attachment_detail['gid']}: {e.reason}")
+                continue
 
             except Exception as e:
                 self.logger.error(

--- a/backend/airweave/platform/sources/confluence.py
+++ b/backend/airweave/platform/sources/confluence.py
@@ -25,6 +25,7 @@ from tenacity import retry, stop_after_attempt
 from airweave.core.exceptions import TokenRefreshError
 from airweave.core.shared_models import RateLimitLevel
 from airweave.platform.decorators import source
+from airweave.platform.downloader import FileSkippedException
 from airweave.platform.entities._base import BaseEntity, Breadcrumb
 from airweave.platform.entities.confluence import (
     ConfluenceBlogPostEntity,
@@ -73,7 +74,7 @@ class ConfluenceSource(BaseSource):
 
         Uses token manager to ensure fresh access token.
         """
-        self.logger.info("Retrieving accessible Atlassian resources")
+        self.logger.debug("Retrieving accessible Atlassian resources")
 
         # Get fresh access token (will refresh if needed)
         access_token = await self.get_access_token()
@@ -93,7 +94,7 @@ class ConfluenceSource(BaseSource):
                 )
                 response.raise_for_status()
                 resources = response.json()
-                self.logger.info(f"Found {len(resources)} accessible Atlassian resources")
+                self.logger.debug(f"Found {len(resources)} accessible Atlassian resources")
                 self.logger.debug(f"Resources: {resources}")
                 return resources
             except httpx.HTTPStatusError as e:
@@ -148,7 +149,7 @@ class ConfluenceSource(BaseSource):
 
                     if refreshed:
                         # Retry with new token (the retry decorator will handle this)
-                        self.logger.info("✅ Token refreshed successfully, retrying request")
+                        self.logger.debug("✅ Token refreshed successfully, retrying request")
                         raise  # Let tenacity retry with the refreshed token
                 except TokenRefreshError as refresh_error:
                     # Token refresh failed - provide clear error message
@@ -289,6 +290,11 @@ class ConfluenceSource(BaseSource):
 
                     self.logger.debug(f"Successfully saved page HTML: {file_entity.name}")
                     yield file_entity
+
+                except FileSkippedException as e:
+                    # File intentionally skipped (unsupported type, too large, etc.) - not an error
+                    self.logger.debug(f"Skipping file: {e.reason}")
+                    continue
 
                 except Exception as e:
                     self.logger.warning(f"Failed to save page {page_title}: {e}")
@@ -460,7 +466,7 @@ class ConfluenceSource(BaseSource):
                 self.logger.error("Confluence validation failed: no accessible resources found")
                 return False
 
-            self.logger.info("✅ Confluence validation successful")
+            self.logger.debug("✅ Confluence validation successful")
             return True
 
         except Exception as e:
@@ -469,7 +475,7 @@ class ConfluenceSource(BaseSource):
 
     async def generate_entities(self) -> AsyncGenerator[BaseEntity, None]:  # noqa: C901
         """Generate all Confluence content."""
-        self.logger.info("Starting Confluence entity generation process")
+        self.logger.debug("Starting Confluence entity generation process")
 
         resources = await self._get_accessible_resources()
         if not resources:

--- a/backend/airweave/platform/sources/google_drive.py
+++ b/backend/airweave/platform/sources/google_drive.py
@@ -23,6 +23,7 @@ from airweave.core.exceptions import TokenRefreshError
 from airweave.core.shared_models import RateLimitLevel
 from airweave.platform.cursors import GoogleDriveCursor
 from airweave.platform.decorators import source
+from airweave.platform.downloader import FileSkippedException
 from airweave.platform.entities._base import BaseEntity
 from airweave.platform.entities.google_drive import (
     GoogleDriveDriveEntity,
@@ -779,6 +780,11 @@ class GoogleDriveSource(BaseSource):
                 self.logger.debug(f"Successfully downloaded file: {file_entity.name}")
                 return file_entity
 
+            except FileSkippedException as e:
+                # File intentionally skipped (unsupported type, too large, etc.) - not an error
+                self.logger.debug(f"Skipping file {file_entity.name}: {e.reason}")
+                return None
+
             except Exception as e:
                 self.logger.error(f"Failed to download file {file_entity.name}: {e}")
                 return None
@@ -839,6 +845,11 @@ class GoogleDriveSource(BaseSource):
                                 )
 
                             yield file_entity
+
+                        except FileSkippedException as e:
+                            # File intentionally skipped (unsupported type, too large, etc.) - not an error
+                            self.logger.debug(f"Skipping file {file_entity.name}: {e.reason}")
+                            continue
 
                         except Exception as e:
                             self.logger.error(f"Failed to download file {file_entity.name}: {e}")
@@ -983,6 +994,13 @@ class GoogleDriveSource(BaseSource):
 
                                             yield file_entity
 
+                                        except FileSkippedException as e:
+                                            # File intentionally skipped (unsupported type, too large, etc.) - not an error
+                                            self.logger.debug(
+                                                f"Skipping file {file_entity.name}: {e.reason}"
+                                            )
+                                            continue
+
                                         except Exception as e:
                                             self.logger.error(
                                                 f"Failed to download file {file_entity.name}: {e}"
@@ -1049,6 +1067,13 @@ class GoogleDriveSource(BaseSource):
                                                 )
 
                                             yield file_entity
+
+                                        except FileSkippedException as e:
+                                            # File intentionally skipped (unsupported type, too large, etc.) - not an error
+                                            self.logger.debug(
+                                                f"Skipping file {file_entity.name}: {e.reason}"
+                                            )
+                                            continue
 
                                         except Exception as e:
                                             self.logger.error(
@@ -1128,6 +1153,13 @@ class GoogleDriveSource(BaseSource):
 
                                         yield file_entity
 
+                                    except FileSkippedException as e:
+                                        # File intentionally skipped (unsupported type, too large, etc.) - not an error
+                                        self.logger.debug(
+                                            f"Skipping file {file_entity.name}: {e.reason}"
+                                        )
+                                        continue
+
                                     except Exception as e:
                                         self.logger.error(
                                             f"Failed to download file {file_entity.name}: {e}"
@@ -1193,6 +1225,13 @@ class GoogleDriveSource(BaseSource):
                                             )
 
                                         yield file_entity
+
+                                    except FileSkippedException as e:
+                                        # File intentionally skipped (unsupported type, too large, etc.) - not an error
+                                        self.logger.debug(
+                                            f"Skipping file {file_entity.name}: {e.reason}"
+                                        )
+                                        continue
 
                                     except Exception as e:
                                         self.logger.error(

--- a/backend/airweave/platform/sources/google_slides.py
+++ b/backend/airweave/platform/sources/google_slides.py
@@ -23,6 +23,7 @@ from tenacity import retry, stop_after_attempt
 from airweave.core.shared_models import RateLimitLevel
 from airweave.platform.cursors import GoogleSlidesCursor
 from airweave.platform.decorators import source
+from airweave.platform.downloader import FileSkippedException
 from airweave.platform.entities._base import BaseEntity
 from airweave.platform.entities.google_slides import (
     GoogleSlidesPresentationEntity,
@@ -152,6 +153,11 @@ class GoogleSlidesSource(BaseSource):
 
                 self.logger.debug(f"Successfully downloaded presentation: {presentation.name}")
                 yield presentation
+
+            except FileSkippedException as e:
+                # Presentation intentionally skipped (unsupported type, too large, etc.)
+                self.logger.debug(f"Skipping presentation {presentation.title}: {e.reason}")
+                continue
 
             except Exception as e:
                 self.logger.error(f"Failed to download presentation {presentation.title}: {e}")

--- a/backend/airweave/platform/sources/outlook_calendar.py
+++ b/backend/airweave/platform/sources/outlook_calendar.py
@@ -18,6 +18,7 @@ from tenacity import retry, stop_after_attempt
 from airweave.core.logging import logger
 from airweave.core.shared_models import RateLimitLevel
 from airweave.platform.decorators import source
+from airweave.platform.downloader import FileSkippedException
 from airweave.platform.entities._base import BaseEntity, Breadcrumb
 from airweave.platform.entities.outlook_calendar import (
     OutlookCalendarAttachmentEntity,
@@ -498,6 +499,11 @@ class OutlookCalendarSource(BaseSource):
 
                 self.logger.debug(f"Successfully processed attachment: {attachment_name}")
                 return file_entity
+
+            except FileSkippedException as e:
+                # File intentionally skipped (unsupported type, too large, etc.) - not an error
+                self.logger.debug(f"Skipping attachment {attachment_name}: {e.reason}")
+                return None
 
             except Exception as e:
                 self.logger.error(f"Failed to save attachment {attachment_name}: {e}")

--- a/backend/airweave/platform/sources/sharepoint.py
+++ b/backend/airweave/platform/sources/sharepoint.py
@@ -21,6 +21,7 @@ from tenacity import retry, stop_after_attempt
 
 from airweave.core.shared_models import RateLimitLevel
 from airweave.platform.decorators import source
+from airweave.platform.downloader import FileSkippedException
 from airweave.platform.entities._base import BaseEntity, Breadcrumb
 from airweave.platform.entities.sharepoint import (
     SharePointDriveEntity,
@@ -613,6 +614,11 @@ class SharePointSource(BaseSource):
                     file_count += 1
                     self.logger.debug(f"Processed file {file_count}: {file_entity.name}")
                     yield file_entity
+
+                except FileSkippedException as e:
+                    # File intentionally skipped (unsupported type, too large, etc.) - not an error
+                    self.logger.debug(f"Skipping file {file_entity.name}: {e.reason}")
+                    continue
 
                 except Exception as e:
                     self.logger.error(f"Failed to download file {file_entity.name}: {e}")


### PR DESCRIPTION
Throw a new FileSkippedException in the download service. This is to differentiate between intentional skips and actual errors. The donke will therefore not alert on unsupported file types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce FileSkippedException to flag intentional file skips (unsupported type, too large, missing URL) instead of treating them as errors. All sources now catch and log these at debug, reducing false alerts and noise.

- **Bug Fixes**
  - Downloader raises FileSkippedException for expected skips and exports it via the module.
  - Source handlers catch FileSkippedException, log debug, and continue; several routine "info" logs downgraded to debug.

<sup>Written for commit 32299d90b184b9408d52c1a2d63fc737357dce6e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

