### PR TITLE
Fix: Memory spike in entity pipeline

### DIFF
--- a/backend/airweave/core/config.py
+++ b/backend/airweave/core/config.py
@@ -170,7 +170,7 @@ class Settings(BaseSettings):
     ANALYTICS_ENABLED: bool = True
 
     # Sync configuration
-    SYNC_MAX_WORKERS: int = 100
+    SYNC_MAX_WORKERS: int = 20
     SYNC_THREAD_POOL_SIZE: int = 100
     WEB_FETCHER_MAX_CONCURRENT: int = 10  # Max concurrent web scraping requests
     OPENAI_MAX_CONCURRENT: int = 20  # Max concurrent OpenAI API requests


### PR DESCRIPTION
shorten the amount of time we have the original entity's text repr in memory AND the chunked entity text repr + vectors in memory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces memory spikes in the entity sync pipeline by releasing large text and vector payloads earlier and lowering concurrency. This stabilizes memory usage during large syncs.

- **Bug Fixes**
  - Set textual_representation to None on parent entities immediately after chunking.
  - After persisting to destinations, drop chunk textual_representation and vectors, then clear chunk_entities.
  - Reduced SYNC_MAX_WORKERS from 100 to 20 to lower concurrent memory footprint.

<sup>Written for commit 14cd12f1f134892ca3433ee2eb95466fe374952a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

