### PR TITLE
fix(alembic): specify correct down revision

### DIFF
--- a/backend/alembic/versions/f9a8b7c6d5e4_add_organization_id_indexes.py
+++ b/backend/alembic/versions/f9a8b7c6d5e4_add_organization_id_indexes.py
@@ -12,7 +12,7 @@ from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = 'f9a8b7c6d5e4'
-down_revision = 'cb4843afd172'
+down_revision = '90780c02944e' 
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Alembic down_revision in f9a8b7c6d5e4 to point to 90780c02944e, restoring the correct migration chain. Prevents upgrade/downgrade errors caused by the wrong parent revision.

<sup>Written for commit 3246557ab4c3ef6b52a14f3df1cce5af583f80ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

