### PR TITLE
feat: improve collections loading, enable pagination, UI improvements

### DIFF
--- a/backend/airweave/api/v1/endpoints/collections.py
+++ b/backend/airweave/api/v1/endpoints/collections.py
@@ -38,17 +38,32 @@ async def list(
     limit: int = Query(
         100, description="Maximum number of collections to return (1-1000)", le=1000, ge=1
     ),
+    search: str = Query(None, description="Search term to filter by name or readable_id"),
     db: AsyncSession = Depends(deps.get_db),
     ctx: ApiContext = Depends(deps.get_context),
 ) -> List[schemas.Collection]:
-    """List all collections that belong to your organization."""
+    """List all collections that belong to your organization with optional search filtering.
+
+    Collections are always sorted by creation date (newest first).
+    """
     collections = await crud.collection.get_multi(
         db,
         ctx=ctx,
         skip=skip,
         limit=limit,
+        search_query=search,
     )
     return collections
+
+
+@router.get("/count", response_model=int)
+async def count(
+    search: str = Query(None, description="Search term to filter by name or readable_id"),
+    db: AsyncSession = Depends(deps.get_db),
+    ctx: ApiContext = Depends(deps.get_context),
+) -> int:
+    """Get total count of collections for the organization with optional search filtering."""
+    return await crud.collection.count(db, ctx=ctx, search_query=search)
 
 
 @router.post("/", response_model=schemas.Collection)

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -54,15 +54,16 @@ import { UsageChecker } from "@/components/UsageChecker"; // App-level usage che
 const CollectionsSection = memo(() => {
   const location = useLocation();
   const [isOpen, setIsOpen] = useState(true);
-  const { collections, isLoading: isLoadingCollections, error: collectionError, fetchCollections } = useCollectionsStore();
+  const { collections, totalCount, isLoading: isLoadingCollections, error: collectionError, fetchCollections, fetchCollectionsCount } = useCollectionsStore();
   const { currentOrganization } = useOrganizationStore();
 
   // Initialize collections and event listeners
   useEffect(() => {
     fetchCollections();
+    fetchCollectionsCount();
     const unsubscribe = useCollectionsStore.getState().subscribeToEvents();
     return unsubscribe;
-  }, [fetchCollections]);
+  }, [fetchCollections, fetchCollectionsCount]);
 
   // Active status for nav items
   const isActive = useCallback((path: string) => {
@@ -136,7 +137,7 @@ const CollectionsSection = memo(() => {
                 className="flex items-center px-3 py-2.5 text-sm rounded-lg text-primary hover:text-primary/80 hover:bg-primary/10 mt-3 mb-2 transition-all duration-200"
               >
                 <ExternalLink className="mr-2 h-3.5 w-3.5 opacity-70" />
-                <span>See all{collections.length > 0 ? ` (${collections.length})` : ''}</span>
+                <span>See all{totalCount !== null ? ` (${totalCount})` : collections.length > 0 ? ` (${collections.length})` : ''}</span>
               </Link>
 
             </>

--- a/frontend/src/pages/CollectionsView.tsx
+++ b/frontend/src/pages/CollectionsView.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { CollectionCard } from "@/components/dashboard";
-import { useCollectionsStore, useSourcesStore } from "@/lib/stores";
+import { useCollectionsStore } from "@/lib/stores";
 import { useCollectionCreationStore } from "@/stores/collectionCreationStore";
 import { apiClient } from "@/lib/api";
 import { useUsageStore } from "@/lib/stores/usage";
@@ -16,18 +16,23 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { SingleActionCheckResponse } from "@/types";
+import type { Collection } from "@/lib/stores/collections";
 
 const CollectionsView = () => {
   const navigate = useNavigate();
   const {
-    collections,
-    isLoading: isLoadingCollections,
-    fetchCollections
+    totalCount,
+    fetchCollectionsPaginated,
+    fetchCollectionsCount,
   } = useCollectionsStore();
 
-  const { fetchSources } = useSourcesStore();
-  const [filteredCollections, setFilteredCollections] = useState([]);
+  const [collections, setCollections] = useState<Collection[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [filteredCount, setFilteredCount] = useState<number | null>(null);
+  const itemsPerPage = 24; // 4 cols × 6 rows
 
   // Modal state
   const { openModal } = useCollectionCreationStore();
@@ -45,64 +50,110 @@ const CollectionsView = () => {
     entities: actionChecks.entities
   };
 
-  // Usage checking is now handled by UsageChecker component at app level
+  // Calculate pagination (use filtered count when searching, otherwise total)
+  const displayCount = filteredCount !== null ? filteredCount : (totalCount || 0);
+  const totalPages = Math.ceil(displayCount / itemsPerPage);
+  const startIndex = (currentPage - 1) * itemsPerPage;
 
-  // Initialize collections and event listeners
-  useEffect(() => {
-    console.log("🔄 [CollectionsView] Initializing");
-
-    // Subscribe to collection events
-    const unsubscribe = useCollectionsStore.getState().subscribeToEvents();
-
-    // Load collections (will use cache if available)
-    fetchCollections().then(collections => {
-      console.log(`🔄 [CollectionsView] Collections loaded: ${collections.length} collections available`);
-    });
-
-    return unsubscribe;
-  }, [fetchCollections]);
-
-  // Usage limits are now checked by UsageChecker component
-
-  // Filter collections based on search query
-  useEffect(() => {
-    if (searchQuery.trim() === "") {
-      setFilteredCollections(collections);
-    } else {
-      const query = searchQuery.toLowerCase();
-      const filtered = collections.filter(
-        (collection) =>
-          collection.name.toLowerCase().includes(query) ||
-          collection.readable_id.toLowerCase().includes(query)
-      );
-      setFilteredCollections(filtered);
+  // Helper: Fetch filtered count
+  const updateFilteredCount = useCallback(async (query: string) => {
+    const params = new URLSearchParams({ search: query });
+    const response = await apiClient.get(`/collections/count?${params}`);
+    if (response.ok) {
+      const count = await response.json();
+      setFilteredCount(count);
     }
-  }, [searchQuery, collections]);
+  }, []);
+
+  // Debounce search query (300ms)
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery);
+      setCurrentPage(1); // Reset to first page on search
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  // Fetch collections (with search support)
+  useEffect(() => {
+    const loadCollections = async () => {
+      setIsLoading(true);
+      const data = await fetchCollectionsPaginated(
+        startIndex,
+        itemsPerPage,
+        debouncedSearchQuery || undefined
+      );
+      setCollections(data);
+      setIsLoading(false);
+    };
+
+    loadCollections();
+  }, [currentPage, debouncedSearchQuery, fetchCollectionsPaginated, startIndex, itemsPerPage]);
+
+  // Fetch total count on mount (never filtered)
+  useEffect(() => {
+    fetchCollectionsCount();
+  }, [fetchCollectionsCount]);
+
+  // Fetch filtered count when searching
+  useEffect(() => {
+    if (debouncedSearchQuery) {
+      updateFilteredCount(debouncedSearchQuery);
+    } else {
+      setFilteredCount(null);
+    }
+  }, [debouncedSearchQuery, updateFilteredCount]);
+
+  // Handle collection events
+  useEffect(() => {
+    const handleRefresh = async () => {
+      // Refresh total count
+      await fetchCollectionsCount();
+
+      // Refresh filtered count if searching
+      if (debouncedSearchQuery) {
+        await updateFilteredCount(debouncedSearchQuery);
+      }
+
+      // Refresh collections
+      const data = await fetchCollectionsPaginated(
+        startIndex,
+        itemsPerPage,
+        debouncedSearchQuery || undefined
+      );
+      setCollections(data);
+    };
+
+    window.addEventListener('collection-created', handleRefresh);
+    window.addEventListener('collection-updated', handleRefresh);
+    window.addEventListener('collection-deleted', handleRefresh);
+
+    return () => {
+      window.removeEventListener('collection-created', handleRefresh);
+      window.removeEventListener('collection-updated', handleRefresh);
+      window.removeEventListener('collection-deleted', handleRefresh);
+    };
+  }, [fetchCollectionsCount, fetchCollectionsPaginated, startIndex, itemsPerPage, debouncedSearchQuery, updateFilteredCount]);
 
   // Open create collection modal
   const handleCreateCollection = () => {
     openModal();
   };
 
-  // Refresh collections when modal closes
-  useEffect(() => {
-    const handleCollectionCreated = () => {
-      fetchCollections(true);
-      // Usage will be checked automatically by UsageChecker
-    };
-
-    window.addEventListener('collection-created', handleCollectionCreated);
-    return () => {
-      window.removeEventListener('collection-created', handleCollectionCreated);
-    };
-  }, [fetchCollections]);
-
   return (
     <div className="mx-auto w-full max-w-[1800px] px-6 py-6 pb-8">
       {/* Header */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between mb-6 gap-4">
         <div>
-          <h1 className="text-3xl font-bold mb-1">Collections</h1>
+          <div className="flex items-center gap-3 mb-1">
+            <h1 className="text-3xl font-bold">Collections</h1>
+            {totalCount !== null && (
+              <span className="px-2.5 py-1 text-xs font-medium bg-muted text-muted-foreground rounded-full">
+                {totalCount}
+              </span>
+            )}
+          </div>
           <p className="text-sm text-muted-foreground">
             View and manage all your collections
           </p>
@@ -175,34 +226,119 @@ const CollectionsView = () => {
             onChange={(e) => setSearchQuery(e.target.value)}
           />
         </div>
+        {searchQuery && filteredCount !== null && (
+          <div className="mt-2 text-sm text-muted-foreground">
+            Found {filteredCount} collection{filteredCount !== 1 ? 's' : ''}
+          </div>
+        )}
       </div>
 
       {/* Collections Grid */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 gap-6 sm:gap-8 auto-rows-fr">
-        {isLoadingCollections ? (
-          Array.from({ length: 8 }).map((_, index) => (
-            <div
-              key={index}
-              className="h-[220px] rounded-xl animate-pulse bg-slate-100 dark:bg-slate-800/50"
-            />
-          ))
-        ) : filteredCollections.length === 0 ? (
-          <div className="col-span-full text-center py-20 text-muted-foreground">
-            {searchQuery ? "No collections found matching your search" : "No collections found"}
+      <div className="relative">
+        {/* Loading overlay */}
+        {isLoading && collections.length > 0 && (
+          <div className="absolute inset-0 bg-background/60 backdrop-blur-sm z-10 flex items-center justify-center rounded-xl">
+            <div className="flex flex-col items-center gap-2">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              <p className="text-sm text-muted-foreground">
+                {searchQuery ? 'Searching collections...' : 'Loading collections...'}
+              </p>
+            </div>
           </div>
-        ) : (
-          filteredCollections.map((collection) => (
-            <CollectionCard
-              key={collection.id}
-              id={collection.id}
-              name={collection.name}
-              readableId={collection.readable_id}
-              status={collection.status}
-              onClick={() => navigate(`/collections/${collection.readable_id}`)}
-            />
-          ))
         )}
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 gap-6 sm:gap-8 auto-rows-fr">
+          {isLoading && collections.length === 0 ? (
+            Array.from({ length: 8 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-[220px] rounded-xl animate-pulse bg-slate-100 dark:bg-slate-800/50"
+              />
+            ))
+          ) : collections.length === 0 ? (
+            <div className="col-span-full text-center py-20 text-muted-foreground">
+              {searchQuery ? `No collections found matching "${searchQuery}"` : "No collections found"}
+            </div>
+          ) : (
+            collections.map((collection) => (
+              <CollectionCard
+                key={collection.id}
+                id={collection.id}
+                name={collection.name}
+                readableId={collection.readable_id}
+                status={collection.status}
+                onClick={() => navigate(`/collections/${collection.readable_id}`)}
+              />
+            ))
+          )}
+        </div>
       </div>
+
+      {/* Pagination Controls */}
+      {totalPages > 1 && (
+        <div className="mt-8 flex items-center justify-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+            disabled={currentPage === 1 || isLoading}
+            className={cn(
+              "gap-1 hover:bg-accent",
+              currentPage === 1 && "opacity-40 cursor-not-allowed"
+            )}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Previous
+          </Button>
+
+          <div className="flex items-center gap-1.5">
+            {[...Array(totalPages)].map((_, i) => {
+              const page = i + 1;
+              // Show first, last, current, and adjacent pages
+              if (
+                page === 1 ||
+                page === totalPages ||
+                (page >= currentPage - 1 && page <= currentPage + 1)
+              ) {
+                return (
+                  <Button
+                    key={page}
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setCurrentPage(page)}
+                    disabled={isLoading}
+                    className={cn(
+                      "min-w-[40px] hover:bg-accent transition-colors",
+                      currentPage === page
+                        ? "bg-muted font-medium text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground"
+                    )}
+                  >
+                    {page}
+                  </Button>
+                );
+              } else if (page === currentPage - 2 || page === currentPage + 2) {
+                return <span key={page} className="px-2 text-muted-foreground">...</span>;
+              }
+              return null;
+            })}
+          </div>
+
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+            disabled={currentPage === totalPages || isLoading}
+            className={cn(
+              "gap-1 hover:bg-accent",
+              currentPage === totalPages && "opacity-40 cursor-not-allowed"
+            )}
+          >
+            Next
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -62,8 +62,10 @@ const Dashboard = () => {
   // Use collections store
   const {
     collections,
+    totalCount,
     isLoading: isLoadingCollections,
     fetchCollections,
+    fetchCollectionsCount,
     sourceConnections,
     fetchSourceConnections
   } = useCollectionsStore();
@@ -117,6 +119,9 @@ const Dashboard = () => {
       console.log(`🔄 [Dashboard] Collections loaded: ${collections.length} collections available`);
     });
 
+    // Load collections count
+    fetchCollectionsCount();
+
     // Load sources - will use cached data if available
     fetchSources().then(sources => {
       console.log(`🔄 [Dashboard] Sources loaded: ${sources.length} sources available`);
@@ -125,7 +130,7 @@ const Dashboard = () => {
     return () => {
       unsubscribeCollections();
     };
-  }, [fetchCollections, fetchSources]);
+  }, [fetchCollections, fetchCollectionsCount, fetchSources]);
 
   // Usage limits are now checked by UsageChecker component
 
@@ -169,7 +174,7 @@ const Dashboard = () => {
                   className="flex items-center text-sm text-primary hover:text-primary/80 hover:bg-accent/30 px-2 py-1.5 rounded-md"
                 >
                   <ExternalLink className="mr-2 h-3.5 w-3.5 opacity-70" />
-                  <span>See all {collections.length > 0 ? `(${collections.length})` : ''}</span>
+                  <span>See all {totalCount !== null ? `(${totalCount})` : collections.length > 0 ? `(${collections.length})` : ''}</span>
                 </Link>
               </div>
 


### PR DESCRIPTION
Collections list endpoint (`GET /collections`) was taking 2+ seconds for orgs with 100-200 collections due to a classic N+1 query problem.

Each collection triggered 5 separate queries to compute its status:
- 200 collections × 5 queries = ~1,000 queries total

The `organization_id` index we added helped individual queries but didn't address the fundamental N+1 issue.

## Solution
Refactored `_attach_ephemeral_status()` to use bulk queries:

1. **Single query path** → **Bulk query path**: Fetch ALL source connections for ALL collections in one query using `WHERE readable_collection_id IN (...)`
2. **Reuse existing optimized methods**: Leverage the 4 `_fetch_*` methods from `crud_source_connection` that already handle bulk fetching
3. **Pure status computation**: Extract status logic into `_compute_status_from_connections()` - no DB access, works on pre-fetched data



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the N+1 query in the collection list endpoint by batching source connection lookups and computing collection status in memory. Added backend sorting and server-side search (including a /collections/count endpoint), and enabled paginated listings with total and filtered counts in the UI.

- **Performance**
  - Fetch all SourceConnection records for the requested collections in one query.
  - Load auth, last jobs, counts, and federated flags with existing bulk helpers.
  - Compute collection status via a pure function using pre-fetched data; no DB calls in the loop.

<sup>Written for commit 5a59554ea78a904d7dff06317f6ebd821f9a5f10. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<img width="350" height="134" alt="Screenshot 2025-11-13 at 10 52 22" src="https://github.com/user-attachments/assets/fc481c8c-5c32-413f-bc3b-f72269b2af3c" />
<img width="448" height="110" alt="Screenshot 2025-11-13 at 10 52 26" src="https://github.com/user-attachments/assets/fb57a880-ba21-41b3-adfc-ddbd91f9b1b5" />
<img width="430" height="122" alt="Screenshot 2025-11-13 at 10 52 31" src="https://github.com/user-attachments/assets/fc0fcb86-5fd9-41c3-a4f3-0903f24970e1" />
<img width="447" height="215" alt="Screenshot 2025-11-13 at 10 52 34" src="https://github.com/user-attachments/assets/30356682-fee1-4f49-aef0-4b2ade687428" />
