### PR TITLE
fix(postgresql): Remove faulty cursor field + Calm Donke on pubsub finalize

### DIFF
--- a/backend/airweave/platform/entities/_base.py
+++ b/backend/airweave/platform/entities/_base.py
@@ -1,9 +1,9 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Type
 from uuid import UUID
 
 from fastembed import SparseEmbedding
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, create_model
 
 
 class Breadcrumb(BaseModel):
@@ -98,11 +98,46 @@ class FileEntity(BaseEntity):
 
 
 class PolymorphicEntity(BaseEntity):
-    """Polymorphic entity schema."""
+    """Base class for entities that are generated dynamically from table schemas."""
 
     table_name: str = Field(..., description="Name of the table this entity belongs to.")
-    schema_name: str = Field(..., description="Name of the schema this entity belongs to.")
-    primary_key_columns: List[str] = Field(..., description="List of primary key columns.")
+    schema_name: Optional[str] = Field(
+        None, description="Name of the schema this entity belongs to."
+    )
+    primary_key_columns: List[str] = Field(
+        default_factory=list, description="List of primary key columns."
+    )
+
+    @classmethod
+    def create_table_entity_class(
+        cls,
+        table_name: str,
+        schema_name: Optional[str],
+        columns: Dict[str, Dict[str, Any]],
+        primary_keys: List[str],
+    ) -> Type["PolymorphicEntity"]:
+        """Create a polymorphic entity subclass for the given table definition."""
+
+        def _pk_default_factory() -> List[str]:
+            return list(primary_keys)
+
+        fields: Dict[str, tuple[Any, Field]] = {
+            "table_name": (str, Field(default=table_name)),
+            "schema_name": (Optional[str], Field(default=schema_name)),
+            "primary_key_columns": (List[str], Field(default_factory=_pk_default_factory)),
+        }
+
+        for column_name, column_info in columns.items():
+            field_name = f"{column_name}_" if column_name == "id" else column_name
+            python_type = column_info.get("python_type", Any)
+            fields[field_name] = (Optional[python_type], Field(default=None))
+
+        model_name = f"{table_name.title().replace('_', '')}TableEntity"
+        return create_model(
+            model_name,
+            __base__=cls,
+            **fields,
+        )
 
 
 class CodeFileEntity(FileEntity):

--- a/backend/airweave/platform/sync/entity_pipeline.py
+++ b/backend/airweave/platform/sync/entity_pipeline.py
@@ -19,9 +19,15 @@ from tenacity import (
 )
 
 from airweave import crud, models
+from airweave.core.constants.reserved_ids import RESERVED_TABLE_ENTITY_ID
 from airweave.core.shared_models import ActionType
 from airweave.db.session import get_db_context
-from airweave.platform.entities._base import BaseEntity, CodeFileEntity, FileEntity
+from airweave.platform.entities._base import (
+    BaseEntity,
+    CodeFileEntity,
+    FileEntity,
+    PolymorphicEntity,
+)
 from airweave.platform.sync.context import SyncContext
 from airweave.platform.sync.exceptions import EntityProcessingError, SyncFailureError
 from airweave.platform.sync.file_types import SUPPORTED_FILE_EXTENSIONS
@@ -495,7 +501,7 @@ class EntityPipeline:
         # Step 2: Build entity requests with definition IDs
         entity_requests = []
         for entity in non_deletes:
-            entity_definition_id = sync_context.entity_map.get(entity.__class__)
+            entity_definition_id = self._resolve_entity_definition_id(entity, sync_context)
             if entity_definition_id is None:
                 # Entity type not in map → fatal error
                 sync_context.logger.error(
@@ -508,7 +514,7 @@ class EntityPipeline:
 
         # Also add deletes to lookup (need existing_map for _handle_deletes)
         for entity in deletes:
-            entity_definition_id = sync_context.entity_map.get(entity.__class__)
+            entity_definition_id = self._resolve_entity_definition_id(entity, sync_context)
             if entity_definition_id is None:
                 raise SyncFailureError(
                     f"DELETE entity type {entity.__class__.__name__} not in entity_map"
@@ -565,7 +571,11 @@ class EntityPipeline:
             entity_hash = entity.airweave_system_metadata.hash
 
             # Get entity_definition_id (already validated in Step 2)
-            entity_definition_id = sync_context.entity_map[entity.__class__]
+            entity_definition_id = self._resolve_entity_definition_id(entity, sync_context)
+            if entity_definition_id is None:
+                raise SyncFailureError(
+                    f"Entity type {entity.__class__.__name__} not in sync_context.entity_map"
+                )
 
             # Get existing DB record using composite key
             db_key = (entity.entity_id, entity_definition_id)
@@ -589,6 +599,21 @@ class EntityPipeline:
         )
 
         return partitions
+
+    def _resolve_entity_definition_id(
+        self, entity: BaseEntity, sync_context: SyncContext
+    ) -> Optional[UUID]:
+        """Resolve entity definition ID with polymorphic fallback."""
+        entity_class = entity.__class__
+
+        definition_id = sync_context.entity_map.get(entity_class)
+        if definition_id:
+            return definition_id
+
+        if issubclass(entity_class, PolymorphicEntity):
+            return RESERVED_TABLE_ENTITY_ID
+
+        return None
 
     # ------------------------------------------------------------------------------------
     # Delete Handling
@@ -630,7 +655,7 @@ class EntityPipeline:
         db_ids = []
 
         for entity in deletes:
-            entity_def_id = sync_context.entity_map.get(entity.__class__)
+            entity_def_id = self._resolve_entity_definition_id(entity, sync_context)
             if not entity_def_id:
                 raise SyncFailureError(
                     f"PROGRAMMING ERROR: DELETE entity {entity.entity_id} type "
@@ -655,7 +680,7 @@ class EntityPipeline:
             if hasattr(sync_context, "entity_state_tracker") and sync_context.entity_state_tracker:
                 counts_by_def: Dict[UUID, int] = defaultdict(int)
                 for entity in deletes:
-                    entity_def_id = sync_context.entity_map.get(entity.__class__)
+                    entity_def_id = self._resolve_entity_definition_id(entity, sync_context)
                     key = (entity.entity_id, entity_def_id) if entity_def_id else None
                     if key and key in existing_map:
                         counts_by_def[entity_def_id] += 1
@@ -1377,7 +1402,7 @@ class EntityPipeline:
                     # Build create objects (with deterministic ordering to avoid deadlock cycles)
                     ordered_entities: List[Tuple[UUID, BaseEntity]] = []
                     for entity in deduped:
-                        entity_def_id = sync_context.entity_map.get(entity.__class__)
+                        entity_def_id = self._resolve_entity_definition_id(entity, sync_context)
                         if not entity_def_id:
                             raise SyncFailureError(
                                 f"Entity type {entity.__class__.__name__} not in entity_map"
@@ -1426,7 +1451,12 @@ class EntityPipeline:
                 if updates:
                     update_records = []
                     for entity in updates:
-                        entity_def_id = sync_context.entity_map[entity.__class__]
+                        entity_def_id = self._resolve_entity_definition_id(entity, sync_context)
+                        if entity_def_id is None:
+                            raise SyncFailureError(
+                                f"PROGRAMMING ERROR: UPDATE entity {entity.entity_id} "
+                                f"type {entity.__class__.__name__} not in entity_map"
+                            )
                         key = (entity.entity_id, entity_def_id)
 
                         if key not in existing_map:
@@ -1488,7 +1518,7 @@ class EntityPipeline:
                 counts_by_def: Dict[UUID, int] = defaultdict(int)
                 sample_name_by_def: Dict[UUID, str] = {}
                 for entity in inserts:
-                    entity_def_id = sync_context.entity_map.get(entity.__class__)
+                    entity_def_id = self._resolve_entity_definition_id(entity, sync_context)
                     if entity_def_id:
                         counts_by_def[entity_def_id] += 1
                         sample_name_by_def.setdefault(entity_def_id, entity.__class__.__name__)
@@ -1506,7 +1536,7 @@ class EntityPipeline:
             if updates:
                 counts_by_def_updates: Dict[UUID, int] = defaultdict(int)
                 for entity in updates:
-                    entity_def_id = sync_context.entity_map.get(entity.__class__)
+                    entity_def_id = self._resolve_entity_definition_id(entity, sync_context)
                     if entity_def_id:
                         counts_by_def_updates[entity_def_id] += 1
 

--- a/backend/airweave/platform/sync/pubsub.py
+++ b/backend/airweave/platform/sync/pubsub.py
@@ -130,7 +130,7 @@ class SyncProgress:
             )
 
             if log_level == "error":
-                self.logger.error(message)
+                self.logger.warning(message)
             elif log_level == "warning":
                 self.logger.warning(message)
             else:


### PR DESCRIPTION
- no more cursor field
- create table entity class function
- resolve entity definition in entity pipeline for polymorphic entities
- warn on pubsub finalize for calm donke

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the faulty cursor-based incremental sync in the PostgreSQL source and added dynamic table entity generation with safe column name mapping. The entity pipeline now resolves polymorphic entities to a reserved definition, and pubsub finalize logs are downgraded to warnings to reduce noise.

- **Refactors**
  - Removed cursor field, continuous mode, and incremental sync logic from PostgreSQL; now streams all rows via server-side cursors.
  - Added create_table_entity_class and per-table column mapping with normalized names (e.g., id -> id_, reserved fields handled).

- **Bug Fixes**
  - Entity pipeline maps polymorphic table entities to the reserved definition ID to avoid missing entity_map errors.
  - Pubsub finalize uses warning level for “error” events to calm noisy alerts.

<sup>Written for commit aa98410f83f85f000c9040c54b06a9a1e6e8445a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

