### PR TITLE
feat: enable redis sentinel for automatic failovers and high availability

### DIFF
--- a/backend/airweave/core/config.py
+++ b/backend/airweave/core/config.py
@@ -117,6 +117,7 @@ class Settings(BaseSettings):
     REDIS_PORT: int = 6379
     REDIS_PASSWORD: Optional[str] = None
     REDIS_DB: int = 0
+    REDIS_SENTINEL_ENABLED: bool = False  # Enables Redis Sentinel for automatic failover
 
     QDRANT_HOST: Optional[str] = None
     QDRANT_PORT: Optional[int] = None


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable Redis high availability via Sentinel with automatic failover. Also adds a Terraform stack for terratest (S3, ECS, CloudWatch logs, security group, IAM).

- **New Features**
  - Redis client auto-detects Sentinel vs direct mode, toggled by REDIS_SENTINEL_ENABLED; Sentinel uses service name "mymaster" on port 26379 with timeouts, keepalive, and retries.
  - Direct mode now connects to "<REDIS_HOST>-master" to match StatefulSet naming.
  - Added terratest/main.tf provisioning S3 bucket, ECS cluster, CloudWatch log group, ECS task security group, and ECS task execution role.

- **Migration**
  - To use Sentinel, set REDIS_SENTINEL_ENABLED=true and ensure the Sentinel service is reachable at host:26379 with master name "mymaster".
  - In non-Sentinel setups, set REDIS_HOST without the "-master" suffix; the client appends it automatically.

<sup>Written for commit b9829a9f9516d50b55f3aa35d5050be4635beb04. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



