### PR TITLE
Fix: Enforce auth provider BLOCKED_SOURCES filtering in UI

### DIFF
--- a/frontend/src/components/creation-views/SourceConfigView.tsx
+++ b/frontend/src/components/creation-views/SourceConfigView.tsx
@@ -569,6 +569,7 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
                       selectedProvider={selectedAuthProvider}
                       onProviderSelect={setSelectedAuthProvider}
                       onConfigChange={setAuthProviderConfig}
+                      supportedAuthProviders={sourceDetails?.supported_auth_providers}
                     />
                   )}
 

--- a/frontend/src/components/shared/views/panel/SourceConfigView.tsx
+++ b/frontend/src/components/shared/views/panel/SourceConfigView.tsx
@@ -236,10 +236,16 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ context }) =
                         </div>
                         {useExternalAuthProvider && (
                             <div className="pt-4 border-t">
-                                {isLoadingConnections ? <Loader2 className="animate-spin" /> :
-                                    authProviderConnections.length > 0 ? (
+                                {isLoadingConnections ? <Loader2 className="animate-spin" /> : (() => {
+                                    // Filter connections to only show providers supported by this source
+                                    const supportedAuthProviders = sourceDetails?.supported_auth_providers || [];
+                                    const filteredConnections = authProviderConnections.filter(
+                                        conn => supportedAuthProviders.includes(conn.short_name)
+                                    );
+                                    
+                                    return filteredConnections.length > 0 ? (
                                         <div className="space-y-2">
-                                            {authProviderConnections.map(conn => (
+                                            {filteredConnections.map(conn => (
                                                 <div
                                                     key={conn.id}
                                                     onClick={() => setSelectedAuthProviderConnection(conn)}
@@ -253,9 +259,13 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ context }) =
                                             ))}
                                         </div>
                                     ) : (
-                                        <p className="text-sm text-muted-foreground">No auth providers connected.</p>
-                                    )
-                                }
+                                        <p className="text-sm text-muted-foreground">
+                                            {authProviderConnections.length > 0 
+                                                ? "This source is not supported by your connected auth providers."
+                                                : "No auth providers connected."}
+                                        </p>
+                                    );
+                                })()}
                             </div>
                         )}
                     </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforced auth provider compatibility filtering in source setup so users only see providers that support the selected source. This prevents picking blocked/incompatible providers and clarifies empty states.

- **Bug Fixes**
  - Filter provider connections by sourceDetails.supported_auth_providers in AuthProviderSelector and the panel SourceConfigView.
  - Improve empty states: show “This source is not supported by your connected auth providers.” when none match; otherwise “No auth providers connected.” with a “Connect one →” link.

<sup>Written for commit 6babfc4d5b5393f85264384063a019a2f52b9221. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

