### PR TITLE
qdrant: move original vectors to disk, keep quantized vectors in mem

### DIFF
--- a/backend/airweave/platform/destinations/qdrant.py
+++ b/backend/airweave/platform/destinations/qdrant.py
@@ -299,7 +299,7 @@ class QdrantDestination(VectorDBDestination):
                     DEFAULT_VECTOR_NAME: rest.VectorParams(
                         size=self.vector_size,
                         distance=rest.Distance.COSINE,
-                        on_disk=False,  # Keep original vectors in RAM for rescoring
+                        on_disk=True,  # Store vectors on disk, load for rescoring on-demand
                     ),
                 },
                 sparse_vectors_config={


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Store original vectors on disk and load them on demand for rescoring; quantized vectors remain in memory for fast search. Increased indexing_threshold to 50k and max_segment_size to 1M to improve indexing performance on large datasets.

<sup>Written for commit 03a1e6d514b185e3e71b44ef8399b9a0b5b00b73. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



