### PR TITLE
fix(docker): enable production-ready backend deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ MISTRAL_API_KEY=
 # Development Settings
 LOCAL_DEVELOPMENT=false
 LOCAL_CURSOR_DEVELOPMENT=false
+# Environment type - affects backend behavior
+# local/dev: Enables hot-reload for development
+# prd: Disables hot-reload for production stability
 ENVIRONMENT=local
 FRONTEND_LOCAL_DEVELOPMENT_PORT=8080
 SKIP_AZURE_STORAGE=true
@@ -62,13 +65,3 @@ LOG_LEVEL=INFO
 RUN_ALEMBIC_MIGRATIONS=true
 RUN_DB_SYNC=true
 CODE_SUMMARIZER_ENABLED=false
-
-# Environment type - affects backend behavior
-# local/development: Enables hot-reload for development
-# production/staging: Disables hot-reload for stability
-ENVIRONMENT=local
-
-# Environment type - affects backend behavior
-# local/development: Enables hot-reload for development
-# production/staging: Disables hot-reload for stability
-ENVIRONMENT=local

--- a/backend/airweave/platform/auth/settings.py
+++ b/backend/airweave/platform/auth/settings.py
@@ -211,7 +211,7 @@ parent_directory = current_file_path.parent
 environment = core_settings.ENVIRONMENT
 if environment == "local":
     env_prefix = "dev"
-elif environment == "production":
+elif environment == "prd":
     env_prefix = "prd"
 else:
     env_prefix = environment

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -58,7 +58,7 @@ echo "Starting application..."
 RELOAD_FLAG=""
 ENVIRONMENT=${ENVIRONMENT:-local}
 
-if [ "$ENVIRONMENT" = "local" ] || [ "$ENVIRONMENT" = "development" ]; then
+if [ "$ENVIRONMENT" = "local" ] || [ "$ENVIRONMENT" = "dev" ]; then
     RELOAD_FLAG="--reload"
     echo "Environment: $ENVIRONMENT - Hot reload ENABLED"
 else


### PR DESCRIPTION
## Summary

This PR adds production-ready support to the backend's Docker entrypoint by making the `--reload` flag conditional based on the `ENVIRONMENT` variable. This fixes "too many open files" errors and container restart loops when running Airweave in production deployments.

## Problem

The current `backend/entrypoint.sh` hardcodes the `--reload` flag on line 56:
```bash
poetry run uvicorn airweave.main:app --host 0.0.0.0 --port 8001 --reload
```

This causes issues in production:
1. **File watcher errors**: Uvicorn's file watcher opens many file descriptors, exceeding system limits
2. **Container crashes**: Leads to `WatchfilesRustInternalError: Too many open files (os error 24)`
3. **Restart loops**: Backend container continuously restarts
4. **Resource waste**: File watching is unnecessary and resource-intensive in production

## Solution

Conditionally enable `--reload` based on the `ENVIRONMENT` variable:

```bash
# Determine if we should enable hot-reload
RELOAD_FLAG=""
ENVIRONMENT=${ENVIRONMENT:-local}

if [ "$ENVIRONMENT" = "local" ] || [ "$ENVIRONMENT" = "development" ]; then
    RELOAD_FLAG="--reload"
    echo "Environment: $ENVIRONMENT - Hot reload ENABLED"
else
    echo "Environment: $ENVIRONMENT - Hot reload DISABLED (production mode)"
fi

poetry run uvicorn airweave.main:app --host 0.0.0.0 --port 8001 $RELOAD_FLAG
```

**Default behavior**: If `ENVIRONMENT` is not set, defaults to `local` (preserving current development workflow)

## Benefits

- ✅ **Backwards compatible**: Development workflow unchanged (defaults to `local` with reload)
- ✅ **Production ready**: Set `ENVIRONMENT=production` to disable reload
- ✅ **Flexible**: Supports `local`, `development`, `staging`, `production`, etc.
- ✅ **Aligns with PR #949**: Complements the profile-based approach
- ✅ **Simple**: Minimal code change, clear behavior

## Testing

Tested on production deployment with Nebula network:

### Before (with --reload):
```
Error creating recommended watcher: Too many open files (os error 24)
Container airweave-backend   Restarting (1) 2 seconds ago
```

### After (ENVIRONMENT=production):
```
Environment: production - Hot reload DISABLED (production mode)
Starting application...
INFO:     Uvicorn running on http://0.0.0.0:8001
Container airweave-backend   Up 5 minutes (healthy)
```

### Development mode still works:
```
Environment: local - Hot reload ENABLED
INFO:     Will watch for changes in these directories: ['/app']
INFO:     Uvicorn running on http://0.0.0.0:8001
```

## Documentation Updates

Updated `.env.example`:
```bash
# Environment type - affects backend behavior
# local/development: Enables hot-reload for development
# production/staging: Disables hot-reload for stability
ENVIRONMENT=local
```

## Related Issues

- Addresses production deployment issues mentioned in #731 (Make docker-compose.yml production-ready)
- Complements PR #949's Docker improvements
- Fixes self-hosting deployment blocker

## Checklist

- [x] Tested in development mode (reload enabled)
- [x] Tested in production mode (reload disabled)
- [x] Updated `.env.example` with ENVIRONMENT variable
- [x] Backwards compatible (defaults to current behavior)
- [x] Clear logging to indicate which mode is active

---

**Note**: This change only affects the backend container. Frontend and worker containers may benefit from similar treatment in future PRs.






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes backend Docker deployment production-ready by disabling Uvicorn hot-reload outside local/dev and fixing production config lookup. Prevents “too many open files” errors and container restart loops in self-hosted deployments.

- **Bug Fixes**
  - entrypoint.sh: enable --reload only for local/dev; default ENVIRONMENT to local with clear logs.
  - auth settings: map ENVIRONMENT=prd to the prd config prefix to load prd.integrations.yaml.
  - .env.example: document ENVIRONMENT usage for local/dev vs prd.

<sup>Written for commit e1a76471578ebd30ea9bbb3d5b7c30157d06e30e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





