### PR TITLE
Fix: Search provider fallback

### DIFF
--- a/backend/airweave/search/providers/_base.py
+++ b/backend/airweave/search/providers/_base.py
@@ -12,6 +12,14 @@ from airweave.api.context import ApiContext
 from .schemas import ProviderModelSpec
 
 
+class ProviderError(RuntimeError):
+    """Base exception for provider issues with retryability metadata."""
+
+    def __init__(self, message: str, *, retryable: bool = True) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+
+
 class BaseProvider(ABC):
     """Base class for LLM providers."""
 
@@ -46,6 +54,9 @@ class BaseProvider(ABC):
         Returns:
             True if error should trigger fallback to next provider
         """
+        if isinstance(error, ProviderError):
+            return error.retryable
+
         error_str = str(error).lower()
 
         # Check for HTTP status codes and error patterns in error message

--- a/backend/airweave/search/providers/cerebras.py
+++ b/backend/airweave/search/providers/cerebras.py
@@ -13,7 +13,7 @@ from tiktoken import Encoding
 
 from airweave.api.context import ApiContext
 
-from ._base import BaseProvider
+from ._base import BaseProvider, ProviderError
 from .schemas import ProviderModelSpec
 
 
@@ -59,7 +59,7 @@ class CerebrasProvider(BaseProvider):
         # Extract content from response
         content = response.choices[0].message.content
         if not content:
-            raise ValueError("Cerebras returned empty completion content")
+            raise ProviderError("Cerebras returned empty completion content")
 
         return content
 
@@ -106,14 +106,14 @@ class CerebrasProvider(BaseProvider):
 
         content = response.choices[0].message.content
         if not content:
-            raise RuntimeError("Cerebras returned empty structured output content")
+            raise ProviderError("Cerebras returned empty structured output content")
 
         try:
             parsed = schema.model_validate(json.loads(content))
         except json.JSONDecodeError as e:
-            raise RuntimeError(f"Cerebras returned invalid JSON: {e}") from e
+            raise ProviderError(f"Cerebras returned invalid JSON: {e}") from e
         except Exception as e:
-            raise RuntimeError(f"Failed to parse Cerebras structured output: {e}") from e
+            raise ProviderError(f"Failed to parse Cerebras structured output: {e}") from e
 
         return parsed
 

--- a/backend/airweave/search/providers/cohere.py
+++ b/backend/airweave/search/providers/cohere.py
@@ -16,7 +16,7 @@ from tiktoken import Encoding
 
 from airweave.api.context import ApiContext
 
-from ._base import BaseProvider
+from ._base import BaseProvider, ProviderError
 from .schemas import ProviderModelSpec
 
 
@@ -109,7 +109,7 @@ class CohereProvider(BaseProvider):
             raise RuntimeError(f"Cohere rerank API call failed: {e}") from e
 
         if not response.results:
-            raise RuntimeError("Cohere returned empty rerank results")
+            raise ProviderError("Cohere returned empty rerank results")
 
         return [
             {"index": result.index, "relevance_score": result.relevance_score}

--- a/backend/airweave/search/providers/groq.py
+++ b/backend/airweave/search/providers/groq.py
@@ -13,7 +13,7 @@ from tiktoken import Encoding
 
 from airweave.api.context import ApiContext
 
-from ._base import BaseProvider
+from ._base import BaseProvider, ProviderError
 from .schemas import ProviderModelSpec
 
 
@@ -65,7 +65,7 @@ class GroqProvider(BaseProvider):
 
         content = response.choices[0].message.content
         if not content:
-            raise ValueError("Groq returned empty completion content")
+            raise ProviderError("Groq returned empty completion content")
 
         return content
 
@@ -100,14 +100,14 @@ class GroqProvider(BaseProvider):
 
         content = response.choices[0].message.content
         if not content:
-            raise RuntimeError("Groq returned empty structured output content")
+            raise ProviderError("Groq returned empty structured output content")
 
         try:
             parsed = schema.model_validate(json.loads(content))
         except json.JSONDecodeError as e:
-            raise RuntimeError(f"Groq returned invalid JSON: {e}") from e
+            raise ProviderError(f"Groq returned invalid JSON: {e}") from e
         except Exception as e:
-            raise RuntimeError(f"Failed to parse Groq structured output: {e}") from e
+            raise ProviderError(f"Failed to parse Groq structured output: {e}") from e
 
         return parsed
 
@@ -149,7 +149,7 @@ class GroqProvider(BaseProvider):
         )
 
         if not rerank_result.rankings:
-            raise RuntimeError("Groq returned empty rankings")
+            raise ProviderError("Groq returned empty rankings")
 
         # Map rankings relative to chosen subset back to original indices
         mapped: List[Dict[str, Any]] = []

--- a/backend/airweave/search/providers/openai.py
+++ b/backend/airweave/search/providers/openai.py
@@ -12,7 +12,7 @@ from tiktoken import Encoding
 
 from airweave.api.context import ApiContext
 
-from ._base import BaseProvider
+from ._base import BaseProvider, ProviderError
 from .schemas import ProviderModelSpec
 
 
@@ -83,7 +83,7 @@ class OpenAIProvider(BaseProvider):
 
         content = response.choices[0].message.content
         if not content:
-            raise ValueError("OpenAI returned empty completion content")
+            raise ProviderError("OpenAI returned empty completion content")
 
         return content
 
@@ -112,7 +112,7 @@ class OpenAIProvider(BaseProvider):
 
         parsed = response.output_parsed
         if not parsed:
-            raise RuntimeError("OpenAI returned empty structured output")
+            raise ProviderError("OpenAI returned empty structured output")
 
         return parsed
 
@@ -157,7 +157,7 @@ class OpenAIProvider(BaseProvider):
             all_embeddings.extend(batch_result)
 
         if len(all_embeddings) != len(texts):
-            raise RuntimeError(
+            raise ProviderError(
                 f"Embedding count mismatch: got {len(all_embeddings)} for {len(texts)} texts"
             )
 
@@ -176,10 +176,10 @@ class OpenAIProvider(BaseProvider):
             ) from e
 
         if not response.data:
-            raise RuntimeError(f"OpenAI returned no embeddings for batch at {batch_start}")
+            raise ProviderError(f"OpenAI returned no embeddings for batch at {batch_start}")
 
         if len(response.data) != len(batch):
-            raise RuntimeError(
+            raise ProviderError(
                 f"OpenAI returned {len(response.data)} embeddings but expected {len(batch)}"
             )
 
@@ -219,7 +219,7 @@ class OpenAIProvider(BaseProvider):
         )
 
         if not rerank_result.rankings:
-            raise RuntimeError("OpenAI returned empty rankings")
+            raise ProviderError("OpenAI returned empty rankings")
 
         # Map rankings relative to chosen subset back to original indices
         mapped: List[Dict[str, Any]] = []


### PR DESCRIPTION
New error type to throw in providers, so that we can indicate the error as retryable for the fallback mechanism in case of a faulty provider.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make provider fallback reliable by introducing a retry-aware ProviderError and using it across providers. This prevents hard failures when a provider returns empty or invalid responses.

- **Bug Fixes**
  - Added ProviderError(retryable: bool) and updated BaseProvider.is_retryable_error to honor it.
  - Switched Cerebras, Groq, Cohere, and OpenAI to raise ProviderError for empty content, invalid JSON, empty rankings, and embedding count mismatches.

<sup>Written for commit 8c33b784406555430228f9520f2cee1d9330b9e5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

