### PR TITLE
Fix: Edit source connection for direct auth sources

### DIFF
--- a/backend/airweave/core/source_connection_service.py
+++ b/backend/airweave/core/source_connection_service.py
@@ -456,6 +456,15 @@ class SourceConnectionService:
             # Update fields
             update_data = obj_in.model_dump(exclude_unset=True)
 
+            # Normalize nested authentication payloads (Direct auth updates)
+            if "authentication" in update_data:
+                auth_payload = update_data.get("authentication") or {}
+                credentials = auth_payload.get("credentials")
+                if credentials:
+                    update_data["credentials"] = credentials
+                # Remove authentication object so we don't try to persist it on the model
+                del update_data["authentication"]
+
             # Handle config update
             if "config" in update_data:
                 validated_config = await self._validate_config_fields(

--- a/backend/airweave/core/source_connection_service_helpers.py
+++ b/backend/airweave/core/source_connection_service_helpers.py
@@ -915,6 +915,12 @@ class SourceConnectionHelpers:
         validated_auth = await self.validate_auth_fields(
             db, source_conn.short_name, auth_fields, ctx
         )
+        if hasattr(validated_auth, "model_dump"):
+            serializable_auth = validated_auth.model_dump()
+        elif hasattr(validated_auth, "dict"):
+            serializable_auth = validated_auth.dict()
+        else:
+            serializable_auth = validated_auth
 
         connection = await crud.connection.get(db, id=source_conn.connection_id, ctx=ctx)
         if connection and connection.integration_credential_id:
@@ -923,7 +929,7 @@ class SourceConnectionHelpers:
             )
             if credential:
                 credential_update = schemas.IntegrationCredentialUpdate(
-                    encrypted_credentials=credentials.encrypt(validated_auth)
+                    encrypted_credentials=credentials.encrypt(serializable_auth)
                 )
                 await crud.integration_credential.update(
                     db, db_obj=credential, obj_in=credential_update, ctx=ctx, uow=uow

--- a/frontend/src/components/collection/SourceConnectionSettings.tsx
+++ b/frontend/src/components/collection/SourceConnectionSettings.tsx
@@ -339,7 +339,9 @@ export const SourceConnectionSettings: React.FC<SourceConnectionSettingsProps> =
         .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
 
       if (Object.keys(filledAuthFields).length > 0) {
-        updateData.auth_fields = filledAuthFields;
+        updateData.authentication = {
+          credentials: filledAuthFields
+        };
       }
 
       if (editFormData.auth_provider !== sourceConnection?.auth_provider) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes editing for direct-auth source connections. The UI now sends credentials under authentication, and the backend normalizes and encrypts them so updates save correctly.

- **Bug Fixes**
  - Frontend: send updateData.authentication.credentials instead of auth_fields.
  - Backend service: pull authentication.credentials into credentials and drop authentication from payload.
  - Backend helpers: serialize validated_auth before encrypting to prevent type issues.

<sup>Written for commit d6742d0da09ed2bb8f2e4bd762d22201cd4fbfd8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

