### PR TITLE
feat: replace Azure storage with cloud-agnostic filesystem backend

### DIFF
--- a/backend/airweave/core/config.py
+++ b/backend/airweave/core/config.py
@@ -122,6 +122,9 @@ class Settings(BaseSettings):
     QDRANT_PORT: Optional[int] = None
     TEXT2VEC_INFERENCE_URL: str = "http://localhost:9878"
 
+    # Storage configuration (filesystem-based, cloud-agnostic)
+    STORAGE_PATH: str = "./local_storage"  # In K8s: /data/airweave-storage (PVC mount)
+
     OPENAI_API_KEY: Optional[str] = None
     ANTHROPIC_API_KEY: Optional[str] = None
     MISTRAL_API_KEY: Optional[str] = None


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced Azure Blob Storage with a filesystem-based, cloud-agnostic backend configured via STORAGE_PATH. Simplifies setup, removes Azure SDKs, and works the same locally and on Kubernetes (PVC).

- **Refactors**
  - Introduced FilesystemStorageBackend using directories as containers.
  - Added settings.STORAGE_PATH (default: ./local_storage); PVC example: /data/airweave-storage.
  - Auto-creates default containers: sync-data, sync-metadata, processed-files, backup.
  - Simplified StorageClient configuration and logging (logs storage_path).

- **Migration**
  - Set STORAGE_PATH in your env/config.
  - For K8s, mount a PVC to /data/airweave-storage (or your chosen path) and set STORAGE_PATH accordingly.
  - Remove Azure storage env vars and credentials; no cloud SDKs required.
  - Note: StorageClient.is_local_disk was removed. If referenced, remove those checks.

<sup>Written for commit 1b95926811a65d0b6dd18e002744cb76ee126c16. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



