### PR TITLE
feat(helm): Simplify self-hosted integrations and enforce BYOC

### DIFF
--- a/backend/airweave/api/v1/endpoints/sources.py
+++ b/backend/airweave/api/v1/endpoints/sources.py
@@ -11,6 +11,7 @@ from airweave.api.context import ApiContext
 from airweave.api.examples import create_single_source_response, create_source_list_response
 from airweave.api.router import TrailingSlashRouter
 from airweave.core.auth_provider_service import auth_provider_service
+from airweave.core.config import settings
 from airweave.core.exceptions import NotFoundException
 from airweave.platform.configs._base import Fields
 from airweave.platform.locator import resource_locator
@@ -91,6 +92,11 @@ async def list(
                 "config_fields": config_fields,
                 "supported_auth_providers": supported_auth_providers,
             }
+
+            # In self-hosted mode, force requires_byoc for OAuth sources
+            if settings.ENVIRONMENT == "self-hosted" and source.auth_methods:
+                if "oauth_browser" in source.auth_methods or "oauth_token" in source.auth_methods:
+                    source_dict["requires_byoc"] = True
 
             source_model = schemas.Source.model_validate(source_dict)
             result_sources.append(source_model)
@@ -173,6 +179,11 @@ async def get(
             "config_fields": config_fields,
             "supported_auth_providers": supported_auth_providers,
         }
+
+        # In self-hosted mode, force requires_byoc for OAuth sources
+        if settings.ENVIRONMENT == "self-hosted" and source.auth_methods:
+            if "oauth_browser" in source.auth_methods or "oauth_token" in source.auth_methods:
+                source_dict["requires_byoc"] = True
 
         # Validate in one step with all fields present
         source_model = schemas.Source.model_validate(source_dict)

--- a/backend/airweave/platform/auth/yaml/self-hosted.integrations.yaml
+++ b/backend/airweave/platform/auth/yaml/self-hosted.integrations.yaml
@@ -1,0 +1,414 @@
+# This file contains the configuration for self-hosted integrations.
+# Users are expected to bring their own OAuth credentials (BYOC).
+# The backend will enforce BYOC mode for OAuth sources when running in self-hosted environment.
+# We keep the structure but remove the actual secrets.
+
+integrations:
+  airtable:
+    oauth_type: "with_refresh"
+    url: "https://airtable.com/oauth2/v1/authorize"
+    backend_url: "https://airtable.com/oauth2/v1/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "header"
+    scope: "schema.bases:read data.records:read data.recordComments:read"
+    requires_pkce: true
+    additional_frontend_params:
+      response_type: "code"
+
+  asana:
+    oauth_type: "with_refresh"
+    url: "https://app.asana.com/-/oauth_authorize"
+    backend_url: "https://app.asana.com/-/oauth_token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+
+  attio:
+
+  bitbucket:
+
+  box:
+    oauth_type: "with_refresh"
+    url: "https://account.box.com/api/oauth2/authorize"
+    backend_url: "https://api.box.com/oauth2/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "root_readwrite"
+
+  confluence:
+    oauth_type: "with_rotating_refresh"
+    url: "https://auth.atlassian.com/authorize"
+    backend_url: "https://auth.atlassian.com/oauth/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "offline_access read:content:confluence read:page:confluence read:space:confluence read:user:confluence read:comment:confluence read:attachment:confluence read:configuration:confluence"
+    additional_frontend_params:
+      audience: "api.atlassian.com"
+      prompt: "consent"
+      response_mode: "query"
+      state: "YOUR_USER_BOUND_VALUE"
+
+  dropbox:
+    oauth_type: "with_refresh"
+    url: "https://www.dropbox.com/oauth2/authorize"
+    backend_url: "https://api.dropbox.com/oauth2/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    additional_frontend_params:
+      token_access_type: "offline"
+
+  excel:
+    oauth_type: "with_rotating_refresh"
+    url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    backend_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "offline_access https://graph.microsoft.com/User.Read https://graph.microsoft.com/Files.Read.All"
+    additional_frontend_params:
+      response_type: "code"
+      response_mode: "query"
+
+  github:
+
+  gitlab:
+    oauth_type: "with_refresh"
+    url: "https://gitlab.com/oauth/authorize"
+    backend_url: "https://gitlab.com/oauth/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "read_api read_user read_repository openid profile email"
+
+  gmail:
+    oauth_type: "with_refresh"
+    url: "https://accounts.google.com/o/oauth2/auth"
+    backend_url: "https://oauth2.googleapis.com/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "https://www.googleapis.com/auth/gmail.readonly"
+    additional_frontend_params:
+      access_type: "offline"
+      prompt: "consent"
+
+  google_calendar:
+    oauth_type: "with_refresh"
+    url: "https://accounts.google.com/o/oauth2/auth"
+    backend_url: "https://oauth2.googleapis.com/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "https://www.googleapis.com/auth/calendar.events.public.readonly https://www.googleapis.com/auth/calendar.freebusy https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.calendars.readonly https://www.googleapis.com/auth/calendar.events.owned.readonly https://www.googleapis.com/auth/calendar.events.readonly"
+    additional_frontend_params:
+      access_type: "offline"
+      prompt: "consent"
+
+  google_docs:
+    oauth_type: "with_refresh"
+    url: "https://accounts.google.com/o/oauth2/auth"
+    backend_url: "https://oauth2.googleapis.com/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "https://www.googleapis.com/auth/documents.readonly https://www.googleapis.com/auth/drive.readonly"
+    additional_frontend_params:
+      access_type: "offline"
+      prompt: "consent"
+
+  google_slides:
+    oauth_type: "with_refresh"
+    url: "https://accounts.google.com/o/oauth2/auth"
+    backend_url: "https://oauth2.googleapis.com/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "https://www.googleapis.com/auth/presentations.readonly https://www.googleapis.com/auth/drive.readonly"
+    additional_frontend_params:
+      access_type: "offline"
+      prompt: "consent"
+
+  google_drive:
+    oauth_type: "with_refresh"
+    url: "https://accounts.google.com/o/oauth2/auth"
+    backend_url: "https://oauth2.googleapis.com/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "https://www.googleapis.com/auth/docs https://www.googleapis.com/auth/drive.photos.readonly https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.metadata https://www.googleapis.com/auth/drive.metadata.readonly https://www.googleapis.com/auth/gmail.readonly"
+    additional_frontend_params:
+      access_type: "offline"
+      prompt: "consent"
+
+  hubspot:
+    oauth_type: "with_refresh"
+    url: "https://app.hubspot.com/oauth/authorize"
+    backend_url: "https://api.hubapi.com/oauth/v1/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "crm.objects.companies.read crm.objects.contacts.read crm.objects.deals.read oauth tickets"
+
+  intercom:
+    oauth_type: "access_only"
+    url: "https://app.intercom.com/oauth"
+    backend_url: "https://api.intercom.io/auth/eagle/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret_keyvault_name: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "read write"
+
+  jira:
+    oauth_type: "with_rotating_refresh"
+    url: "https://auth.atlassian.com/authorize"
+    backend_url: "https://auth.atlassian.com/oauth/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "read offline_access manage:jira-configuration manage:jira-project read:jira-user read:jira-work read:workflow:jira read:application-role:jira read:avatar:jira read:group:jira read:issue-type:jira read:issue-type-hierarchy:jira read:user:jira read:project:jira read:project-category:jira read:project.component:jira read:project.property:jira read:project-version:jira read:workflow:jira read:project.property:jira"
+    additional_frontend_params:
+      audience: "api.atlassian.com"
+      prompt: "consent"
+      response_mode: "query"
+      state: "YOUR_USER_BOUND_VALUE"
+
+  linear:
+    oauth_type: "access_only"
+    url: "https://linear.app/oauth/authorize"
+    backend_url: "https://api.linear.app/oauth/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "read"
+
+  teams:
+    oauth_type: "with_rotating_refresh"
+    url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    backend_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "offline_access https://graph.microsoft.com/User.Read https://graph.microsoft.com/Team.ReadBasic.All https://graph.microsoft.com/Channel.ReadBasic.All https://graph.microsoft.com/ChannelMessage.Read.All https://graph.microsoft.com/Chat.Read https://graph.microsoft.com/ChatMessage.Read https://graph.microsoft.com/Group.Read.All"
+    additional_frontend_params:
+      response_type: "code"
+      response_mode: "query"
+
+  monday:
+    oauth_type: "access_only"
+    url: "https://auth.monday.com/oauth2/authorize"
+    backend_url: "https://auth.monday.com/oauth2/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "me:read boards:read docs:read workspaces:read users:read account:read updates:read assets:read tags:read teams:read"
+
+  notion:
+    oauth_type: "access_only"
+    url: "https://api.notion.com/v1/oauth/authorize"
+    backend_url: "https://api.notion.com/v1/oauth/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "header"
+    additional_frontend_params:
+      owner: "user"
+
+  onedrive:
+    oauth_type: "with_refresh"
+    url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    backend_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "offline_access https://graph.microsoft.com/User.Read https://graph.microsoft.com/Files.Read.All"
+    additional_frontend_params:
+      response_type: "code"
+
+  onenote:
+    oauth_type: "with_rotating_refresh"
+    url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    backend_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "offline_access https://graph.microsoft.com/User.Read https://graph.microsoft.com/Notes.Read"
+    additional_frontend_params:
+      response_type: "code"
+      response_mode: "query"
+
+  outlook_calendar:
+    oauth_type: "with_rotating_refresh"
+    url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    backend_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "offline_access https://graph.microsoft.com/User.Read https://graph.microsoft.com/Calendars.Read https://graph.microsoft.com/Calendars.Read.Shared"
+    additional_frontend_params:
+      response_mode: "query"
+
+  outlook_mail:
+    oauth_type: "with_rotating_refresh"
+    url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    backend_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "offline_access https://graph.microsoft.com/User.Read https://graph.microsoft.com/MailboxFolder.Read https://graph.microsoft.com/Mail.Read"
+    additional_frontend_params:
+      response_mode: "query"
+
+  sharepoint:
+    oauth_type: "with_rotating_refresh"
+    url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    backend_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "offline_access https://graph.microsoft.com/User.Read.All https://graph.microsoft.com/Group.Read.All https://graph.microsoft.com/Sites.Read.All https://graph.microsoft.com/Files.Read.All"
+    additional_frontend_params:
+      response_type: "code"
+      response_mode: "query"
+
+  slack:
+    oauth_type: "access_only"
+    url: "https://slack.com/oauth/v2/authorize"
+    backend_url: "https://slack.com/api/oauth.v2.access"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    user_scope: "search:read"
+
+  stripe:
+
+  todoist:
+    oauth_type: "access_only"
+    url: "https://todoist.com/oauth/authorize"
+    backend_url: "https://todoist.com/oauth/access_token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "data:read"
+
+  trello:
+    oauth_type: "oauth1"
+    request_token_url: "https://trello.com/1/OAuthGetRequestToken"
+    authorization_url: "https://trello.com/1/OAuthAuthorizeToken"
+    access_token_url: "https://trello.com/1/OAuthGetAccessToken"
+    consumer_key: ""
+    consumer_secret: ""
+    scope: "read,write"
+    expiration: "never"
+
+  zendesk:
+    oauth_type: "with_refresh"
+    url: "https://{subdomain}.zendesk.com/oauth/authorizations/new"
+    backend_url: "https://{subdomain}.zendesk.com/oauth/tokens"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "read write"
+    url_template: true
+    backend_url_template: true
+
+  clickup:
+    oauth_type: "access_only"
+    url: "https://app.clickup.com/api"
+    backend_url: "https://api.clickup.com/api/v2/oauth/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "public data:read team:read space:read list:read folder:read task:read comment:read"
+    additional_frontend_params:
+      access_type: "offline"
+      prompt: "consent"
+
+  salesforce:
+    oauth_type: "with_refresh"
+    url: "https://login.salesforce.com/services/oauth2/authorize"
+    backend_url: "https://{instance_url}/services/oauth2/token"
+    url_template: true
+    backend_url_template: true
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "api refresh_token"
+    additional_frontend_params:
+      response_type: "code"
+
+  word:
+    oauth_type: "with_rotating_refresh"
+    url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    backend_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    grant_type: "authorization_code"
+    client_id: ""
+    client_secret: ""
+    content_type: "application/x-www-form-urlencoded"
+    client_credential_location: "body"
+    scope: "offline_access https://graph.microsoft.com/User.Read https://graph.microsoft.com/Files.Read.All"
+    additional_frontend_params:
+      response_type: "code"
+      response_mode: "query"
+
+  qdrant:


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces BYOC for all OAuth-based sources in self-hosted deployments and adds a dev-only integrations YAML to simplify local setup. Cloud behavior is unchanged.

- **New Features**
  - Forces requires_byoc=true for OAuth sources in sources list/get when ENVIRONMENT=self-hosted.
  - Adds backend/airweave/platform/auth/yaml/self-hosted.integrations.yaml with predefined provider configs for development only (not used in production).

- **Migration**
  - Self-hosted instances must provide their own OAuth client IDs and secrets for affected sources.

<sup>Written for commit 7f3e01c15b68d58c86587f21333cdedb4524a625. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



