### PR TITLE
Add Neo4j Graph Database Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ That's it! Access the dashboard at http://localhost:8080
 <img src="frontend/src/components/icons/apps/jira.svg" alt="Jira" width="50" height="50" style="margin: 8px;" />
 <img src="frontend/src/components/icons/apps/linear.svg" alt="Linear" width="50" height="50" style="margin: 8px;" />
 <img src="frontend/src/components/icons/apps/monday.svg" alt="Monday" width="50" height="50" style="margin: 8px;" />
+<img src="frontend/src/components/icons/apps/neo4j.svg" alt="Neo4j" width="50" height="50" style="margin: 8px;" />
 <img src="frontend/src/components/icons/apps/notion.svg" alt="Notion" width="50" height="50" style="margin: 8px;" />
 <img src="frontend/src/components/icons/apps/onedrive.svg" alt="Onedrive" width="50" height="50" style="margin: 8px;" />
 <img src="frontend/src/components/icons/apps/onenote.svg" alt="OneNote" width="50" height="50" style="margin: 8px;" />

--- a/backend/airweave/platform/configs/auth.py
+++ b/backend/airweave/platform/configs/auth.py
@@ -226,9 +226,15 @@ class QdrantAuthConfig(AuthConfig):
 class Neo4jAuthConfig(AuthConfig):
     """Neo4j authentication credentials schema."""
 
-    uri: str = Field(title="URI", description="The URI of the Neo4j database")
-    username: str = Field(title="Username", description="The username for the Neo4j database")
-    password: str = Field(title="Password", description="The password for the Neo4j database")
+    uri: str = Field(
+        title="URI", description="The URI of the Neo4j database", min_length=1
+    )
+    username: str = Field(
+        title="Username", description="The username for the Neo4j database", min_length=1
+    )
+    password: str = Field(
+        title="Password", description="The password for the Neo4j database", min_length=1
+    )
 
 
 # AUTH CONFIGS FOR ALL SOURCES

--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -322,6 +322,12 @@ class MySQLConfig(SourceConfig):
     pass
 
 
+class Neo4jConfig(SourceConfig):
+    """Neo4j configuration schema."""
+
+    pass
+
+
 class NotionConfig(SourceConfig):
     """Notion configuration schema."""
 

--- a/backend/airweave/platform/sources/neo4j.py
+++ b/backend/airweave/platform/sources/neo4j.py
@@ -1,0 +1,492 @@
+"""Neo4j graph database source implementation.
+
+This source connects to a Neo4j graph database and generates entities for each node label
+based on the graph schema. It dynamically creates entity classes at runtime
+using the PolymorphicEntity system.
+"""
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, AsyncGenerator, Dict, List, Optional, Type, Union
+
+from neo4j import AsyncGraphDatabase, AsyncDriver, AsyncSession
+from neo4j.exceptions import AuthError, DriverError, ServiceUnavailable
+
+from airweave.core.shared_models import RateLimitLevel
+from airweave.platform.decorators import source
+from airweave.platform.entities._base import BaseEntity, PolymorphicEntity
+from airweave.platform.sources._base import BaseSource
+from airweave.schemas.source_connection import AuthenticationMethod
+
+# Mapping of Neo4j types to Python types
+NEO4J_TYPE_MAP = {
+    "String": str,
+    "Integer": int,
+    "Long": int,
+    "Float": float,
+    "Double": float,
+    "Boolean": bool,
+    "DateTime": datetime,
+    "LocalDateTime": datetime,
+    "Date": datetime,
+    "Time": datetime,
+    "LocalTime": datetime,
+    "Duration": str,
+    "Point": dict,
+    "List": list,
+    "Map": dict,
+}
+
+
+@source(
+    name="Neo4j",
+    short_name="neo4j",
+    auth_methods=[AuthenticationMethod.DIRECT, AuthenticationMethod.AUTH_PROVIDER],
+    oauth_type=None,
+    auth_config_class="Neo4jAuthConfig",
+    config_class="Neo4jConfig",
+    labels=["Graph Database"],
+    rate_limit_level=RateLimitLevel.ORG,
+)
+class Neo4jSource(BaseSource):
+    """Neo4j graph database connector integrates with Neo4j databases to extract graph data.
+
+    Synchronizes data from graph nodes.
+
+    It uses dynamic schema introspection to create appropriate entity classes
+    and provides comprehensive access to graph data with proper type mapping.
+    """
+
+    _RESERVED_ENTITY_FIELDS = {
+        "entity_id",
+        "breadcrumbs",
+        "name",
+        "created_at",
+        "updated_at",
+        "textual_representation",
+        "airweave_system_metadata",
+        "label",
+        "node_id",
+        "table_name",
+        "schema_name",
+        "primary_key_columns",
+    }
+
+    def __init__(self):
+        """Initialize the Neo4j source."""
+        super().__init__()
+        self.driver: Optional[AsyncDriver] = None
+        self.entity_classes: Dict[str, Type[PolymorphicEntity]] = {}
+        self.property_field_mappings: Dict[str, Dict[str, str]] = {}
+
+    @classmethod
+    async def create(
+        cls, credentials: Dict[str, Any], config: Optional[Dict[str, Any]] = None
+    ) -> "Neo4jSource":
+        """Create a new Neo4j source instance.
+
+        Args:
+            credentials: Dictionary containing connection details:
+                - uri: Neo4j URI (e.g., neo4j://localhost:7687)
+                - username: Database username
+                - password: Database password
+            config: Optional configuration parameters for the Neo4j source.
+        """
+        instance = cls()
+        instance.config = (
+            credentials.model_dump() if hasattr(credentials, "model_dump") else dict(credentials)
+        )
+        return instance
+
+    def _get_label_key(self, label: str) -> str:
+        """Generate consistent label key for identification."""
+        return f"neo4j:{label}"
+
+    def _normalize_model_field_name(self, property_name: str) -> str:
+        """Normalize property names to avoid collisions with entity base fields."""
+        if property_name == "id":
+            return "id_"
+        if property_name in self._RESERVED_ENTITY_FIELDS:
+            return f"{property_name}_field"
+        return property_name
+
+    async def _connect(self) -> None:
+        """Establish Neo4j driver connection with timeout and error handling."""
+        if not self.driver:
+            try:
+                uri = self.config["uri"]
+                username = self.config["username"]
+                password = self.config["password"]
+
+                self.driver = AsyncGraphDatabase.driver(
+                    uri,
+                    auth=(username, password),
+                    max_connection_lifetime=3600,
+                    max_connection_pool_size=50,
+                    connection_acquisition_timeout=60.0,
+                )
+
+                # Verify connectivity
+                await self.driver.verify_connectivity()
+                self.logger.info(f"Connected to Neo4j at {uri}")
+
+            except AuthError as e:
+                raise ValueError("Invalid Neo4j credentials") from e
+            except ServiceUnavailable as e:
+                raise ValueError(
+                    f"Could not connect to Neo4j at {self.config['uri']}. "
+                    f"Please check if the database is running."
+                ) from e
+            except DriverError as e:
+                raise ValueError(f"Neo4j connection failed: {str(e)}") from e
+            except Exception as e:
+                raise ValueError(f"Neo4j connection failed: {str(e)}") from e
+
+    async def _ensure_connection(self) -> None:
+        """Ensure connection is alive and reconnect if needed."""
+        if self.driver:
+            try:
+                # Test connection with verify_connectivity
+                await self.driver.verify_connectivity()
+            except Exception as e:
+                self.logger.warning(f"Connection lost, reconnecting: {e}")
+                await self.driver.close()
+                self.driver = None
+                await self._connect()
+        else:
+            await self._connect()
+
+    async def _get_node_labels(self) -> List[str]:
+        """Get all node labels from the database.
+
+        Returns:
+            List of node label names
+        """
+        async with self.driver.session() as session:  # type: ignore[union-attr]
+            result = await session.run("CALL db.labels()")
+            labels = [record["label"] async for record in result]
+            return labels
+
+    async def _get_label_properties(self, label: str) -> Dict[str, str]:
+        """Get property information for a specific label.
+
+        Args:
+            label: Node label name
+
+        Returns:
+            Dictionary mapping property names to their types
+        """
+        async with self.driver.session() as session:  # type: ignore[union-attr]
+            # Sample nodes to infer property types
+            query = f"MATCH (n:{label}) RETURN n LIMIT 100"
+            result = await session.run(query)
+
+            properties: Dict[str, Any] = {}
+            async for record in result:
+                node = record["n"]
+                for key, value in node.items():
+                    if key not in properties:
+                        # Infer type from value
+                        if value is None:
+                            properties[key] = "String"  # Default to string for null values
+                        elif isinstance(value, bool):
+                            properties[key] = "Boolean"
+                        elif isinstance(value, int):
+                            properties[key] = "Integer"
+                        elif isinstance(value, float):
+                            properties[key] = "Float"
+                        elif isinstance(value, str):
+                            properties[key] = "String"
+                        elif isinstance(value, datetime):
+                            properties[key] = "DateTime"
+                        elif isinstance(value, list):
+                            properties[key] = "List"
+                        elif isinstance(value, dict):
+                            properties[key] = "Map"
+                        else:
+                            properties[key] = "String"
+
+            return properties
+
+    async def _create_entity_class_for_label(
+        self, label: str, properties: Dict[str, str]
+    ) -> Type[PolymorphicEntity]:
+        """Create a polymorphic entity class for a given label.
+
+        Args:
+            label: Node label name
+            properties: Dictionary mapping property names to types
+
+        Returns:
+            Dynamically created PolymorphicEntity subclass
+        """
+        # Build column metadata similar to PostgreSQL
+        columns: Dict[str, Dict[str, Any]] = {}
+
+        for prop_name, prop_type in properties.items():
+            python_type = NEO4J_TYPE_MAP.get(prop_type, str)
+            normalized_name = self._normalize_model_field_name(prop_name)
+
+            columns[prop_name] = {
+                "name": prop_name,
+                "python_type": python_type,
+                "normalized_name": normalized_name,
+            }
+
+            # Track field mapping
+            label_key = self._get_label_key(label)
+            if label_key not in self.property_field_mappings:
+                self.property_field_mappings[label_key] = {}
+            self.property_field_mappings[label_key][prop_name] = normalized_name
+
+        # Create entity class using PolymorphicEntity factory
+        entity_class = PolymorphicEntity.create_table_entity_class(
+            table_name=label,
+            schema_name="neo4j",
+            columns=columns,
+            primary_keys=["id"],  # Neo4j nodes have internal id
+        )
+
+        return entity_class
+
+    async def _convert_field_values(
+        self, data: Dict[str, Any], model_fields: Dict[str, Any], label_key: str
+    ) -> Dict[str, Any]:
+        """Convert and validate field values to match expected types.
+
+        Args:
+            data: Raw data dictionary
+            model_fields: The model fields from the entity class
+            label_key: Unique identifier for the label to resolve property mappings
+
+        Returns:
+            Dict with processed field values matching the expected types
+        """
+        processed_data = {}
+        property_mapping = self.property_field_mappings.get(label_key, {})
+
+        for field_name, field_value in data.items():
+            model_field_name = property_mapping.get(field_name)
+            if not model_field_name:
+                model_field_name = self._normalize_model_field_name(field_name)
+
+            # Skip if the field doesn't exist in the model
+            if model_field_name not in model_fields:
+                continue
+
+            # If value is None, keep it as None
+            if field_value is None:
+                processed_data[model_field_name] = None
+                continue
+
+            # Get expected type from model field
+            field_info = model_fields[model_field_name]
+            field_type = field_info.annotation
+
+            # Handle Union types (including Optional which is Union[T, None])
+            if hasattr(field_type, "__origin__") and field_type.__origin__ is Union:
+                # For Union types, get the non-None type
+                union_args = field_type.__args__
+                non_none_types = [arg for arg in union_args if arg is not type(None)]
+                if non_none_types:
+                    field_type = non_none_types[0]
+
+            # Simple conversion: if target is string, convert to string
+            if field_type is str and field_value is not None:
+                processed_data[model_field_name] = str(field_value)
+            else:
+                # Let Pydantic handle everything else
+                processed_data[model_field_name] = field_value
+
+        return processed_data
+
+    def _generate_entity_id(self, label: str, node_id: int, data: Dict[str, Any]) -> str:
+        """Generate entity ID from Neo4j node ID or properties.
+
+        Args:
+            label: Node label
+            node_id: Neo4j internal node ID
+            data: Node properties
+
+        Returns:
+            Generated entity ID
+        """
+        label_key = self._get_label_key(label)
+
+        # Try to use common ID properties if available
+        if "id" in data and data["id"] is not None:
+            return f"{label_key}:{data['id']}"
+        if "uuid" in data and data["uuid"] is not None:
+            return f"{label_key}:{data['uuid']}"
+        if "guid" in data and data["guid"] is not None:
+            return f"{label_key}:{data['guid']}"
+
+        # Use Neo4j internal ID
+        return f"{label_key}:{node_id}"
+
+    def _ensure_entity_id_length(self, entity_id: str, label: str) -> str:
+        """Ensure entity ID is within acceptable length limits.
+
+        Args:
+            entity_id: Original entity ID
+            label: Node label
+
+        Returns:
+            Entity ID (possibly hashed if too long)
+        """
+        if len(entity_id) <= 2000:
+            return entity_id
+
+        # Hash if too long
+        entity_hash = hashlib.sha256(entity_id.encode()).hexdigest()
+        label_key = self._get_label_key(label)
+        self.logger.warning(
+            f"Entity ID for {label_key} exceeds 2000 characters. Using hashed ID: {entity_hash}"
+        )
+        return f"{label_key}:hashed_{entity_hash}"
+
+    async def _process_node_to_entity(
+        self,
+        node: Any,
+        label: str,
+        entity_class: Type[PolymorphicEntity],
+    ) -> BaseEntity:
+        """Convert Neo4j node to entity.
+
+        Args:
+            node: Neo4j node object
+            label: Node label
+            entity_class: Entity class to instantiate
+
+        Returns:
+            BaseEntity instance
+        """
+        # Extract node data
+        data = dict(node.items())
+        node_id = node.element_id  # Neo4j 5.x uses element_id instead of id
+
+        # Generate entity ID
+        entity_id = self._generate_entity_id(label, node.id, data)
+        entity_id = self._ensure_entity_id_length(entity_id, label)
+
+        # Convert field values
+        label_key = self._get_label_key(label)
+        processed_data = await self._convert_field_values(data, entity_class.model_fields, label_key)
+
+        # Determine entity name
+        entity_name = (
+            processed_data.get("name_field")
+            or processed_data.get("name")
+            or processed_data.get("title")
+            or f"{label}_{node.id}"
+        )
+
+        # Create entity
+        return entity_class(
+            entity_id=entity_id,
+            breadcrumbs=[],  # Top-level entities
+            name=str(entity_name),
+            created_at=None,
+            updated_at=None,
+            **processed_data,
+        )
+
+    async def _process_label(
+        self, label: str, entity_class: Type[PolymorphicEntity]
+    ) -> AsyncGenerator[BaseEntity, None]:
+        """Process all nodes for a given label with streaming.
+
+        Args:
+            label: Node label to process
+            entity_class: Entity class for this label
+
+        Yields:
+            BaseEntity instances for each node
+        """
+        async with self.driver.session() as session:  # type: ignore[union-attr]
+            # Stream nodes in batches
+            query = f"MATCH (n:{label}) RETURN n"
+            result = await session.run(query)
+
+            buffer = []
+            BUFFER_SIZE = 1000
+
+            async for record in result:
+                node = record["n"]
+                try:
+                    entity = await self._process_node_to_entity(node, label, entity_class)
+                    buffer.append(entity)
+
+                    if len(buffer) >= BUFFER_SIZE:
+                        for e in buffer:
+                            yield e
+                        buffer = []
+
+                except Exception as e:
+                    self.logger.error(f"Error processing node in label {label}: {e}")
+                    continue
+
+            # Yield remaining entities
+            for e in buffer:
+                yield e
+
+    async def generate_entities(self) -> AsyncGenerator[BaseEntity, None]:
+        """Generate entities for all node labels in the Neo4j database."""
+        try:
+            await self._connect()
+            labels = await self._get_node_labels()
+
+            self.logger.info(f"Found {len(labels)} label(s) to sync: {', '.join(labels)}")
+
+            # Process each label
+            for i, label in enumerate(labels, 1):
+                label_key = self._get_label_key(label)
+                self.logger.info(f"Processing label {i}/{len(labels)}: {label_key}")
+
+                # Check connection health before processing each label
+                await self._ensure_connection()
+
+                # Get properties for this label
+                properties = await self._get_label_properties(label)
+
+                # Create entity class
+                entity_class = await self._create_entity_class_for_label(label, properties)
+                self.entity_classes[label_key] = entity_class
+
+                # Process and yield entities
+                async for entity in self._process_label(label, entity_class):
+                    yield entity
+
+            self.logger.info(f"Successfully completed sync for all {len(labels)} label(s)")
+
+        finally:
+            if self.driver:
+                self.logger.info("Closing Neo4j connection")
+                await self.driver.close()
+                self.driver = None
+
+    async def validate(self) -> bool:
+        """Verify Neo4j credentials and database access."""
+        try:
+            await self._connect()
+
+            # Test connection with a simple query
+            async with self.driver.session() as session:  # type: ignore[union-attr]
+                result = await session.run("RETURN 1 AS test")
+                record = await result.single()
+                if record["test"] != 1:
+                    self.logger.error("Validation query returned unexpected result")
+                    return False
+
+            self.logger.info("Neo4j validation successful")
+            return True
+
+        except Exception as e:
+            self.logger.error(f"Validation failed: {e}")
+            return False
+
+        finally:
+            if self.driver:
+                await self.driver.close()
+                self.driver = None

--- a/backend/tests/unit/platform/sources/test_neo4j.py
+++ b/backend/tests/unit/platform/sources/test_neo4j.py
@@ -1,0 +1,539 @@
+"""Tests for Neo4j graph database source connector.
+
+Tests Neo4j connector functionality with mocked driver responses
+matching Neo4j's actual async driver API format.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any, Dict, List
+
+from airweave.platform.sources.neo4j import Neo4jSource
+from airweave.platform.configs.auth import Neo4jAuthConfig
+
+
+# Mock Neo4j node class
+class MockNode:
+    """Mock Neo4j node object."""
+
+    def __init__(self, element_id: str, node_id: int, labels: List[str], properties: Dict[str, Any]):
+        self.element_id = element_id
+        self.id = node_id
+        self._labels = labels
+        self._properties = properties
+
+    def items(self):
+        """Return node properties as items."""
+        return self._properties.items()
+
+    def __getitem__(self, key):
+        """Get property value."""
+        return self._properties[key]
+
+
+# Mock Neo4j query result
+class MockResult:
+    """Mock Neo4j query result."""
+
+    def __init__(self, records: List[Dict[str, Any]]):
+        self._records = records
+        self._index = 0
+
+    def __aiter__(self):
+        """Async iterator."""
+        return self
+
+    async def __anext__(self):
+        """Get next record."""
+        if self._index >= len(self._records):
+            raise StopAsyncIteration
+        record = self._records[self._index]
+        self._index += 1
+        return record
+
+    async def single(self):
+        """Get single record."""
+        if self._records:
+            return self._records[0]
+        return None
+
+
+# Mock data matching exact Neo4j API response format
+MOCK_LABELS_RESULT = MockResult([
+    {"label": "Person"},
+    {"label": "Company"},
+    {"label": "Product"},
+])
+
+MOCK_PERSON_NODES = MockResult([
+    {
+        "n": MockNode(
+            element_id="4:abc123:1",
+            node_id=1,
+            labels=["Person"],
+            properties={
+                "id": "person_001",
+                "name": "John Doe",
+                "email": "john@example.com",
+                "age": 30,
+                "active": True,
+            },
+        )
+    },
+    {
+        "n": MockNode(
+            element_id="4:abc123:2",
+            node_id=2,
+            labels=["Person"],
+            properties={
+                "id": "person_002",
+                "name": "Jane Smith",
+                "email": "jane@example.com",
+                "age": 28,
+                "active": True,
+            },
+        )
+    },
+])
+
+MOCK_COMPANY_NODES = MockResult([
+    {
+        "n": MockNode(
+            element_id="4:abc123:10",
+            node_id=10,
+            labels=["Company"],
+            properties={
+                "id": "company_001",
+                "name": "Acme Corp",
+                "industry": "Technology",
+                "founded": 2010,
+                "public": False,
+            },
+        )
+    },
+])
+
+MOCK_PRODUCT_NODES = MockResult([
+    {
+        "n": MockNode(
+            element_id="4:abc123:20",
+            node_id=20,
+            labels=["Product"],
+            properties={
+                "uuid": "prod-123-456",
+                "name": "Widget Pro",
+                "price": 99.99,
+                "in_stock": True,
+            },
+        )
+    },
+])
+
+# Mock for sampling nodes to infer properties
+MOCK_PERSON_SAMPLE = MockResult([
+    {
+        "n": MockNode(
+            element_id="4:abc123:1",
+            node_id=1,
+            labels=["Person"],
+            properties={
+                "id": "person_001",
+                "name": "John Doe",
+                "email": "john@example.com",
+                "age": 30,
+                "active": True,
+            },
+        )
+    },
+])
+
+MOCK_COMPANY_SAMPLE = MockResult([
+    {
+        "n": MockNode(
+            element_id="4:abc123:10",
+            node_id=10,
+            labels=["Company"],
+            properties={
+                "id": "company_001",
+                "name": "Acme Corp",
+                "industry": "Technology",
+                "founded": 2010,
+                "public": False,
+            },
+        )
+    },
+])
+
+MOCK_PRODUCT_SAMPLE = MockResult([
+    {
+        "n": MockNode(
+            element_id="4:abc123:20",
+            node_id=20,
+            labels=["Product"],
+            properties={
+                "uuid": "prod-123-456",
+                "name": "Widget Pro",
+                "price": 99.99,
+                "in_stock": True,
+            },
+        )
+    },
+])
+
+MOCK_VALIDATION_RESULT = MockResult([{"test": 1}])
+
+
+@pytest.fixture
+def mock_neo4j_driver():
+    """Create a mock Neo4j async driver."""
+    mock_driver = AsyncMock()
+    mock_driver.verify_connectivity = AsyncMock()
+    mock_driver.close = AsyncMock()
+
+    # Mock session context manager
+    mock_session = AsyncMock()
+    mock_driver.session = MagicMock()
+    mock_driver.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_driver.session.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    return mock_driver, mock_session
+
+
+@pytest.fixture
+def neo4j_credentials():
+    """Create test Neo4j credentials."""
+    return {
+        "uri": "neo4j://localhost:7687",
+        "username": "neo4j",
+        "password": "test12345",
+    }
+
+
+@pytest.mark.asyncio
+async def test_neo4j_source_creation(neo4j_credentials):
+    """Test Neo4j source instantiation."""
+    source = await Neo4jSource.create(neo4j_credentials)
+
+    assert source is not None
+    assert source.config["uri"] == "neo4j://localhost:7687"
+    assert source.config["username"] == "neo4j"
+    assert source.config["password"] == "test12345"
+    assert source.driver is None  # Not connected yet
+
+
+@pytest.mark.asyncio
+async def test_neo4j_source_connection(neo4j_credentials, mock_neo4j_driver):
+    """Test Neo4j driver connection establishment."""
+    mock_driver, _ = mock_neo4j_driver
+
+    with patch("airweave.platform.sources.neo4j.AsyncGraphDatabase") as mock_graph_db:
+        mock_graph_db.driver.return_value = mock_driver
+
+        source = await Neo4jSource.create(neo4j_credentials)
+        await source._connect()
+
+        # Verify driver was created with correct URI
+        mock_graph_db.driver.assert_called_once()
+        call_args_str = str(mock_graph_db.driver.call_args)
+        assert "neo4j://localhost:7687" in call_args_str
+        assert "neo4j" in call_args_str  # username
+        assert "test12345" in call_args_str  # password
+
+        # Verify connectivity was tested
+        mock_driver.verify_connectivity.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_neo4j_source_validation(neo4j_credentials, mock_neo4j_driver):
+    """Test Neo4j source validation."""
+    mock_driver, mock_session = mock_neo4j_driver
+    mock_session.run.return_value = MOCK_VALIDATION_RESULT
+
+    with patch("airweave.platform.sources.neo4j.AsyncGraphDatabase") as mock_graph_db:
+        mock_graph_db.driver.return_value = mock_driver
+
+        source = await Neo4jSource.create(neo4j_credentials)
+        is_valid = await source.validate()
+
+        assert is_valid is True
+        mock_session.run.assert_called_once_with("RETURN 1 AS test")
+        mock_driver.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_neo4j_get_node_labels(neo4j_credentials, mock_neo4j_driver):
+    """Test retrieving all node labels from the database."""
+    mock_driver, mock_session = mock_neo4j_driver
+    mock_session.run.return_value = MOCK_LABELS_RESULT
+
+    with patch("airweave.platform.sources.neo4j.AsyncGraphDatabase") as mock_graph_db:
+        mock_graph_db.driver.return_value = mock_driver
+
+        source = await Neo4jSource.create(neo4j_credentials)
+        await source._connect()
+
+        labels = await source._get_node_labels()
+
+        assert len(labels) == 3
+        assert "Person" in labels
+        assert "Company" in labels
+        assert "Product" in labels
+        mock_session.run.assert_called_once_with("CALL db.labels()")
+
+
+@pytest.mark.asyncio
+async def test_neo4j_get_label_properties(neo4j_credentials, mock_neo4j_driver):
+    """Test inferring property types from sample nodes."""
+    mock_driver, mock_session = mock_neo4j_driver
+    mock_session.run.return_value = MOCK_PERSON_SAMPLE
+
+    with patch("airweave.platform.sources.neo4j.AsyncGraphDatabase") as mock_graph_db:
+        mock_graph_db.driver.return_value = mock_driver
+
+        source = await Neo4jSource.create(neo4j_credentials)
+        await source._connect()
+
+        properties = await source._get_label_properties("Person")
+
+        assert "id" in properties
+        assert properties["id"] == "String"
+        assert "name" in properties
+        assert properties["name"] == "String"
+        assert "age" in properties
+        assert properties["age"] == "Integer"
+        assert "active" in properties
+        assert properties["active"] == "Boolean"
+
+
+@pytest.mark.asyncio
+async def test_neo4j_entity_id_generation(neo4j_credentials):
+    """Test entity ID generation from node properties."""
+    source = await Neo4jSource.create(neo4j_credentials)
+
+    # Test with 'id' property
+    entity_id = source._generate_entity_id(
+        "Person", 123, {"id": "person_001", "name": "John"}
+    )
+    assert entity_id == "neo4j:Person:person_001"
+
+    # Test with 'uuid' property
+    entity_id = source._generate_entity_id(
+        "Product", 456, {"uuid": "prod-123", "name": "Widget"}
+    )
+    assert entity_id == "neo4j:Product:prod-123"
+
+    # Test fallback to Neo4j internal ID
+    entity_id = source._generate_entity_id(
+        "Company", 789, {"name": "Acme Corp"}
+    )
+    assert entity_id == "neo4j:Company:789"
+
+
+@pytest.mark.asyncio
+async def test_neo4j_field_name_normalization(neo4j_credentials):
+    """Test property name normalization to avoid collisions."""
+    source = await Neo4jSource.create(neo4j_credentials)
+
+    # Test 'id' gets normalized to 'id_'
+    assert source._normalize_model_field_name("id") == "id_"
+
+    # Test reserved fields get '_field' suffix
+    assert source._normalize_model_field_name("entity_id") == "entity_id_field"
+    assert source._normalize_model_field_name("breadcrumbs") == "breadcrumbs_field"
+    assert source._normalize_model_field_name("name") == "name_field"  # 'name' is also reserved
+
+    # Test normal fields stay unchanged
+    assert source._normalize_model_field_name("email") == "email"
+    assert source._normalize_model_field_name("age") == "age"
+
+
+@pytest.mark.asyncio
+async def test_neo4j_entity_class_creation(neo4j_credentials):
+    """Test dynamic entity class creation for a label."""
+    source = await Neo4jSource.create(neo4j_credentials)
+
+    properties = {
+        "id": "String",
+        "name": "String",
+        "email": "String",
+        "age": "Integer",
+        "active": "Boolean",
+    }
+
+    entity_class = await source._create_entity_class_for_label("Person", properties)
+
+    assert entity_class is not None
+    assert hasattr(entity_class, "model_fields")
+    assert "id_" in entity_class.model_fields  # 'id' normalized to 'id_'
+    assert "name" in entity_class.model_fields
+    assert "email" in entity_class.model_fields
+    assert "age" in entity_class.model_fields
+    assert "active" in entity_class.model_fields
+
+
+@pytest.mark.asyncio
+async def test_neo4j_generate_entities_full_sync(neo4j_credentials, mock_neo4j_driver):
+    """Test complete entity generation from all labels."""
+    mock_driver, mock_session = mock_neo4j_driver
+
+    # Setup mock responses for different queries
+    def mock_run(query, *args, **kwargs):
+        """Return appropriate mock result based on query."""
+        if "CALL db.labels()" in query:
+            return MockResult([
+                {"label": "Person"},
+                {"label": "Company"},
+                {"label": "Product"},
+            ])
+        elif "MATCH (n:Person)" in query:
+            if "LIMIT 100" in query:
+                return MOCK_PERSON_SAMPLE
+            else:
+                return MOCK_PERSON_NODES
+        elif "MATCH (n:Company)" in query:
+            if "LIMIT 100" in query:
+                return MOCK_COMPANY_SAMPLE
+            else:
+                return MOCK_COMPANY_NODES
+        elif "MATCH (n:Product)" in query:
+            if "LIMIT 100" in query:
+                return MOCK_PRODUCT_SAMPLE
+            else:
+                return MOCK_PRODUCT_NODES
+        # Default empty result
+        return MockResult([])
+
+    mock_session.run = AsyncMock(side_effect=mock_run)
+
+    with patch("airweave.platform.sources.neo4j.AsyncGraphDatabase") as mock_graph_db:
+        mock_graph_db.driver.return_value = mock_driver
+
+        source = await Neo4jSource.create(neo4j_credentials)
+
+        entities = []
+        async for entity in source.generate_entities():
+            entities.append(entity)
+
+        # Verify we got entities from all labels
+        # 2 Person + 1 Company + 1 Product = 4 entities
+        assert len(entities) >= 3
+
+        # Verify entity properties
+        person_entities = [e for e in entities if "Person" in e.entity_id]
+        assert len(person_entities) >= 1
+
+        company_entities = [e for e in entities if "Company" in e.entity_id]
+        assert len(company_entities) >= 1
+
+        # Verify driver was closed
+        mock_driver.close.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_neo4j_connection_error_handling(neo4j_credentials):
+    """Test error handling for connection failures."""
+    with patch("airweave.platform.sources.neo4j.AsyncGraphDatabase") as mock_graph_db:
+        # Simulate authentication error
+        from neo4j.exceptions import AuthError
+
+        mock_driver = AsyncMock()
+        mock_driver.verify_connectivity.side_effect = AuthError("Invalid credentials")
+        mock_graph_db.driver.return_value = mock_driver
+
+        source = await Neo4jSource.create(neo4j_credentials)
+
+        with pytest.raises(ValueError, match="Invalid Neo4j credentials"):
+            await source._connect()
+
+
+@pytest.mark.asyncio
+async def test_neo4j_service_unavailable_error(neo4j_credentials):
+    """Test error handling when Neo4j service is unavailable."""
+    with patch("airweave.platform.sources.neo4j.AsyncGraphDatabase") as mock_graph_db:
+        from neo4j.exceptions import ServiceUnavailable
+
+        mock_driver = AsyncMock()
+        mock_driver.verify_connectivity.side_effect = ServiceUnavailable(
+            "Could not connect to database"
+        )
+        mock_graph_db.driver.return_value = mock_driver
+
+        source = await Neo4jSource.create(neo4j_credentials)
+
+        with pytest.raises(ValueError, match="Could not connect to Neo4j"):
+            await source._connect()
+
+
+@pytest.mark.asyncio
+async def test_neo4j_validation_failure(neo4j_credentials, mock_neo4j_driver):
+    """Test validation failure scenarios."""
+    mock_driver, mock_session = mock_neo4j_driver
+    mock_session.run.side_effect = Exception("Query failed")
+
+    with patch("airweave.platform.sources.neo4j.AsyncGraphDatabase") as mock_graph_db:
+        mock_graph_db.driver.return_value = mock_driver
+
+        source = await Neo4jSource.create(neo4j_credentials)
+        is_valid = await source.validate()
+
+        assert is_valid is False
+        mock_driver.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_neo4j_entity_id_length_enforcement(neo4j_credentials):
+    """Test entity ID length is enforced (max 2000 chars)."""
+    source = await Neo4jSource.create(neo4j_credentials)
+
+    # Create a very long entity ID
+    long_id = "a" * 3000
+    entity_id = source._ensure_entity_id_length(f"neo4j:Test:{long_id}", "Test")
+
+    # Should be hashed to fit within limits
+    assert len(entity_id) <= 2000
+    assert "hashed_" in entity_id
+
+
+@pytest.mark.asyncio
+async def test_neo4j_empty_database(neo4j_credentials, mock_neo4j_driver):
+    """Test handling of database with no labels."""
+    mock_driver, mock_session = mock_neo4j_driver
+    mock_session.run.return_value = MockResult([])  # No labels
+
+    with patch("airweave.platform.sources.neo4j.AsyncGraphDatabase") as mock_graph_db:
+        mock_graph_db.driver.return_value = mock_driver
+
+        source = await Neo4jSource.create(neo4j_credentials)
+
+        entities = []
+        async for entity in source.generate_entities():
+            entities.append(entity)
+
+        # Should complete without errors
+        assert len(entities) == 0
+        mock_driver.close.assert_called_once()
+
+
+def test_neo4j_auth_config_validation():
+    """Test Neo4jAuthConfig validation."""
+    from pydantic import ValidationError
+
+    # Valid config
+    config = Neo4jAuthConfig(
+        uri="neo4j://localhost:7687",
+        username="neo4j",
+        password="test12345",
+    )
+    assert config.uri == "neo4j://localhost:7687"
+
+    # Missing URI
+    with pytest.raises(ValidationError):
+        Neo4jAuthConfig(uri="", username="neo4j", password="test12345")
+
+    # Missing username
+    with pytest.raises(ValidationError):
+        Neo4jAuthConfig(uri="neo4j://localhost:7687", username="", password="test12345")
+
+    # Missing password
+    with pytest.raises(ValidationError):
+        Neo4jAuthConfig(uri="neo4j://localhost:7687", username="neo4j", password="")

--- a/frontend/src/components/icons/apps/neo4j.svg
+++ b/frontend/src/components/icons/apps/neo4j.svg
@@ -1,0 +1,28 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <!-- Neo4j Logo - Baltic Blue #0A6190 -->
+  <g>
+    <!-- Central Circle -->
+    <circle cx="100" cy="100" r="70" fill="none" stroke="#0A6190" stroke-width="8"/>
+
+    <!-- Node circles -->
+    <circle cx="100" cy="40" r="12" fill="#0A6190"/>
+    <circle cx="145" cy="70" r="12" fill="#0A6190"/>
+    <circle cx="145" cy="130" r="12" fill="#0A6190"/>
+    <circle cx="100" cy="160" r="12" fill="#0A6190"/>
+    <circle cx="55" cy="130" r="12" fill="#0A6190"/>
+    <circle cx="55" cy="70" r="12" fill="#0A6190"/>
+
+    <!-- Connection lines -->
+    <line x1="100" y1="40" x2="145" y2="70" stroke="#0A6190" stroke-width="3"/>
+    <line x1="145" y1="70" x2="145" y2="130" stroke="#0A6190" stroke-width="3"/>
+    <line x1="145" y1="130" x2="100" y2="160" stroke="#0A6190" stroke-width="3"/>
+    <line x1="100" y1="160" x2="55" y2="130" stroke="#0A6190" stroke-width="3"/>
+    <line x1="55" y1="130" x2="55" y2="70" stroke="#0A6190" stroke-width="3"/>
+    <line x1="55" y1="70" x2="100" y2="40" stroke="#0A6190" stroke-width="3"/>
+
+    <!-- Cross connections -->
+    <line x1="100" y1="40" x2="100" y2="160" stroke="#0A6190" stroke-width="2" opacity="0.4"/>
+    <line x1="55" y1="70" x2="145" y2="130" stroke="#0A6190" stroke-width="2" opacity="0.4"/>
+    <line x1="145" y1="70" x2="55" y2="130" stroke="#0A6190" stroke-width="2" opacity="0.4"/>
+  </g>
+</svg>


### PR DESCRIPTION
##  Issue

Issue #1117 requested integration with Neo4j, a leading graph database platform. The request was minimal ("neo4j as a source would also be helpful"), without specifying requirements, use cases, or what data should be synced.

## Problem Identification

After analyzing the request and Neo4j's capabilities, I identified the following requirements:

1. **Data to Index**: Neo4j stores graph data with two primary components:
   - **Nodes**: Entities with labels (types) and properties
   - **Relationships**: Connections between nodes (can be added in future enhancement)

2. **Authentication**: Neo4j uses URI + username/password authentication:
   - URI: Connection string (e.g., `neo4j://localhost:7687`)
   - Username & Password: Database credentials

3. **Key Use Cases**:
   - "Find all Person nodes in my graph database"
   - "Search for Company entities with specific properties"
   - "What products are stored in my Neo4j database?"
   - Enable AI agents to query graph database contents

4. **Technical Challenges**:
   - Dynamic schema discovery (labels and properties vary by database)
   - Handling different Neo4j property types
   - Memory-efficient streaming of large graph datasets
   - URI validation and normalization

## Solution Design

I designed a solution following Airweave's existing PostgreSQL connector pattern, as Neo4j is also a database:

### Architecture Decisions

1. **Dynamic Entity Creation**:
   - Use `PolymorphicEntity` (like PostgreSQL) for dynamic label-based entities
   - Each Neo4j label becomes a separate entity class
   - Properties become entity fields with appropriate types

2. **Schema Discovery**:
   - Query `CALL db.labels()` to discover all node labels
   - Sample 100 nodes per label to infer property types
   - Create entity class dynamically for each label

3. **Configuration**:
   - Simple auth config with URI, username, password
   - Empty source config (can be extended for label filtering)

4. **Streaming Strategy**:
   - Batch processing with 1000-node buffers
   - Async iteration for memory efficiency
   - Per-label processing to avoid memory overload

5. **Entity ID Generation**:
   - Prefer common ID properties (`id`, `uuid`, `guid`)
   - Fall back to Neo4j's internal node ID
   - Hash-based IDs for very long identifiers (>2000 chars)

6. **Error Handling**:
   - Graceful degradation for auth failures
   - Specific error messages for Neo4j driver exceptions
   - Connection health checks before processing each label

##  Implementation

### Components Delivered

#### 1. Authentication Configuration
Enhanced `Neo4jAuthConfig` with proper field validation:
- URI field with `min_length=1` constraint
- Username and password validation
- Clear field descriptions for UI integration

#### 2. Source Configuration
Simple `Neo4jConfig` class:
- Uses empty `SourceConfig` for now
- Can be extended for label filtering or custom queries

#### 3. Neo4j Source Connector
Built comprehensive connector (`backend/airweave/platform/sources/neo4j.py`, 492 lines):
- Async driver management with connection pooling
- Label discovery via `db.labels()` procedure
- Property type inference from sample nodes
- Dynamic `PolymorphicEntity` creation per label
- Streaming entity generation with buffering
- Proper field name normalization (reserved field handling)
- Entity ID generation with multiple fallback strategies

#### 4. Comprehensive Testing
Wrote 15 unit tests (`backend/tests/unit/platform/sources/test_neo4j.py`, 539 lines):
- Source creation and configuration
- Driver connection and validation
- Label discovery and property inference
- Entity ID generation (with fallbacks)
- Field name normalization
- Entity class creation
- Full entity generation workflow
- Error handling (auth errors, service unavailable)
- Entity ID length enforcement
- Empty database handling
- Auth config validation

All tests use exact mock responses matching Neo4j's driver API format with custom `MockNode` and `MockResult` classes.

#### 5. Frontend Integration
- Added Neo4j icon (SVG) with official Baltic Blue branding (#0A6190)
- Updated README with Neo4j in supported integrations (alphabetically ordered)

### Testing Strategy

Similar to n8n, comprehensive mocking approach:
1. Created `MockNode` class mimicking Neo4j's node structure
2. Created `MockResult` class for async iteration of query results
3. Mocked `AsyncGraphDatabase.driver()` and session management
4. Tested all core functionality with exact API mocks
5. Achieved **100% test pass rate (15/15 tests)**
6. Test runtime: ~2 seconds

## Results

### Test Coverage
- **15/15 unit tests passing (100%)**
- ~2 second test runtime
- Covers all core functionality
- Exact Neo4j driver API mocks
- Complete error scenario coverage

Fixes : #1117 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Neo4j connector to sync graph nodes by label into dynamic entities with type mapping and efficient streaming. Enables quick indexing and search of Neo4j data; addresses #1117.

- **New Features**
  - Direct auth with URI, username, and password validation.
  - Schema discovery via db.labels() and sampled nodes; maps Neo4j types to entity fields.
  - Per-label PolymorphicEntity with field normalization and property-to-field mapping.
  - Streaming sync with a 1000-node buffer and connection health checks.
  - Stable entity IDs (id/uuid/guid → fallback to node ID; hash when too long).
  - Error handling for auth failures and service unavailability, with reconnects.
  - UI/docs: added Neo4j icon and README entry.

- **Testing**
  - 15 unit tests using mocked async driver responses.
  - Covers label discovery, property inference, entity creation, ID rules, errors, and empty DB.
  - ~2s runtime; ensures driver closes after sync.
  - Validates auth config field constraints.

<sup>Written for commit 4d1f3f5c0e9b4afc6ebbeb25bae24fefeec0057b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

