### PR TITLE
Add PostHog tracking for onboarding completion event

### DIFF
--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -321,6 +321,18 @@ export const Onboarding = () => {
 
       const organization = await createOrgResponse.json();
 
+      // Track successful org creation
+      posthog.capture('onboarding_completed', {
+        org_id: organization.id,
+        org_name: formData.organizationName,
+        subscription_plan: formData.subscriptionPlan,
+        billing_period: billingPeriod,
+        team_members_invited: teamMembers.length,
+        org_size: formData.organizationSize,
+        user_role: formData.userRole,
+        org_type: formData.organizationType,
+      });
+
       // Step 2: Update organization context
       setCurrentOrganization(organization);
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Capture a PostHog 'onboarding_completed' event after successful organization creation to measure final-step completion.

- New Features
  - Fires 'onboarding_completed' right after org creation in Onboarding.tsx.
  - Sends context: org ID/name, plan, billing period, invited team count, org size, user role, and org type.

<sup>Written for commit 6b1cb3b6be4046fc6fabb650156e9cf3eed68c22. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

