### PR TITLE
fix(chunker): Add tiktoken recount step to CodeChunker to fix token limit bypass

### DIFF
--- a/backend/airweave/platform/chunkers/code.py
+++ b/backend/airweave/platform/chunkers/code.py
@@ -101,6 +101,7 @@ class CodeChunker(BaseChunker):
         """Chunk a batch of code texts with two-stage approach.
 
         Stage 1: CodeChunker chunks at AST boundaries (functions, classes)
+        Stage 1.5: Recount tokens with tiktoken cl100k_base (Chonkie reports incorrect counts)
         Stage 2: TokenChunker force-splits any chunks exceeding MAX_TOKENS_PER_CHUNK (hard limit)
 
         Uses run_in_thread_pool because Chonkie is synchronous (avoids blocking event loop).
@@ -123,8 +124,17 @@ class CodeChunker(BaseChunker):
             # CodeChunker failure = sync failure (not entity-level)
             raise SyncFailureError(f"CodeChunker batch processing failed: {e}")
 
-        # Stage 2: Safety net (batched for efficiency)
-        final_results = await run_in_thread_pool(self._apply_safety_net_batched, code_results)
+        # Stage 1.5: Recount tokens with tiktoken (Chonkie's CodeChunker reports incorrect counts)
+        # Chonkie counts tokens from individual AST nodes, but the final chunk text includes
+        # whitespace/gaps between nodes plus leading/trailing content, causing underestimates.
+        code_results_with_tiktoken = await run_in_thread_pool(
+            self._recount_tokens_with_tiktoken, code_results
+        )
+
+        # Stage 2: Safety net (batched for efficiency, now uses accurate tiktoken counts)
+        final_results = await run_in_thread_pool(
+            self._apply_safety_net_batched, code_results_with_tiktoken
+        )
 
         # Validate all chunks meet requirements
         for doc_chunks in final_results:
@@ -215,18 +225,46 @@ class CodeChunker(BaseChunker):
 
         return final_results
 
+    def _recount_tokens_with_tiktoken(self, code_results: List[List[Any]]) -> List[List[Any]]:
+        """Recount all chunks with tiktoken cl100k_base for accurate token counts.
+
+        Chonkie's CodeChunker reports incorrect token counts because it counts tokens
+        from individual AST nodes, but the final chunk text includes:
+        - Whitespace/gaps between AST nodes
+        - Leading content before the first node
+        - Trailing content after the last node
+
+        This causes token counts to be significantly understated. We recount with
+        tiktoken to get accurate token counts before the safety net check.
+
+        Args:
+            code_results: Chunks from CodeChunker with potentially incorrect token counts
+
+        Returns:
+            Same chunks but with token_count field updated to accurate tiktoken counts
+        """
+        for chunks in code_results:
+            for chunk in chunks:
+                # Recount with tiktoken (actual chunk text may be larger than reported)
+                chunk.token_count = len(self._tiktoken_tokenizer.encode(chunk.text))
+
+        return code_results
+
     def _convert_chunk(self, chunk) -> Dict[str, Any]:
         """Convert Chonkie Chunk object to dict format.
 
+        Token counts have already been recounted with tiktoken in
+        _recount_tokens_with_tiktoken(), so we just use them directly.
+
         Args:
-            chunk: Chonkie Chunk object with text, start_index, end_index, token_count
+            chunk: Chonkie Chunk object with tiktoken token_count
 
         Returns:
-            Dict with chunk data
+            Dict with chunk data and accurate OpenAI token count
         """
         return {
             "text": chunk.text,
             "start_index": chunk.start_index,
             "end_index": chunk.end_index,
-            "token_count": chunk.token_count,
+            "token_count": chunk.token_count,  # Already tiktoken count
         }


### PR DESCRIPTION
Root cause: Chonkie's CodeChunker reports incorrect (understated) token counts because it counts tokens from individual AST nodes only, but the final chunk text includes whitespace/gaps between nodes plus leading/trailing content.

This caused chunks with 9760+ actual tokens to slip through the 8192-token safety net (which checked the incorrect Chonkie count), resulting in OpenAI embedding API errors in production.

Fix: Add Stage 1.5 (_recount_tokens_with_tiktoken) between AST chunking and the safety net, identical to how SemanticChunker already handles this. The safety net now uses accurate tiktoken counts and correctly triggers TokenChunker fallback for oversized chunks.

Fixes token limit exceeded errors for GitHub code file syncs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recounts CodeChunker chunk tokens with tiktoken before the safety net, fixing oversized chunks slipping past limits and causing OpenAI embedding errors in GitHub code syncs. Safety net correctly triggers TokenChunker fallback when needed.

- **Bug Fixes**
  - Added Stage 1.5: _recount_tokens_with_tiktoken (cl100k_base).
  - Safety net uses the recounted totals in batched checks.
  - Aligns recount behavior with SemanticChunker.

<sup>Written for commit 48985dd4ba4f288376763832fee640c672a1b5f7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

