### PR TITLE
Feature/OpenAI markitdown integration

### DIFF
--- a/backend/airweave/platform/auth/yaml/dev.integrations.yaml
+++ b/backend/airweave/platform/auth/yaml/dev.integrations.yaml
@@ -158,8 +158,8 @@ integrations:
     url: "https://accounts.google.com/o/oauth2/auth"
     backend_url: "https://oauth2.googleapis.com/token"
     grant_type: "authorization_code"
-    client_id: "976410117544-apnlsluj4nc0l7lolc9oklm2tfv5f7et.apps.googleusercontent.com"
-    client_secret: "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"
+    client_id: "placeholder_client_id" # REPLACED FOR SECURITY
+    client_secret: "placeholder_secret" # REPLACED FOR SECURITY
     content_type: "application/x-www-form-urlencoded"
     client_credential_location: "body"
     scope: "https://www.googleapis.com/auth/docs https://www.googleapis.com/auth/drive.photos.readonly https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.metadata https://www.googleapis.com/auth/drive.metadata.readonly https://www.googleapis.com/auth/gmail.readonly"

--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -260,6 +260,19 @@ class GoogleDriveConfig(SourceConfig):
             return [p.strip() for p in value.split(",") if p.strip()]
         return value
 
+    model: str = Field(
+        default="local",
+        title="Conversion Model",
+        description=(
+            "Select the model to use for document conversion. "
+            "OpenAI (Best Quality, requires Key), Mistral (Good, requires Key), or Local (Free, Private)."
+        ),
+        json_schema_extra={
+            "enum": ["openai", "mistral", "local"],
+            "ui_component": "select",
+        },
+    )
+
 
 class GoogleSlidesConfig(SourceConfig):
     """Google Slides configuration schema."""

--- a/backend/airweave/platform/converters/__init__.py
+++ b/backend/airweave/platform/converters/__init__.py
@@ -5,12 +5,14 @@ from .html_converter import HtmlConverter
 from .markitdown_converter import MarkItDownConverter
 from .mistral_converter import MistralConverter
 from .txt_converter import TxtConverter
+from .smart_converter import SmartConverter
 from .web_converter import WebConverter
 from .xlsx_converter import XlsxConverter
 
 # Singleton instances
 mistral_converter = MistralConverter()
 markitdown_converter = MarkItDownConverter()
+smart_converter = SmartConverter()
 html_converter = HtmlConverter()
 xlsx_converter = XlsxConverter()  # Local openpyxl extraction (not Mistral)
 txt_converter = TxtConverter()
@@ -18,11 +20,11 @@ code_converter = CodeConverter()
 web_converter = WebConverter()  # URL fetching and HTML to markdown
 
 # Aliases for backward compatibility
-# Use MarkItDown (local) instead of Mistral (cloud)
-pdf_converter = markitdown_converter
-docx_converter = markitdown_converter
-pptx_converter = markitdown_converter
-img_converter = markitdown_converter
+# Use SmartConverter to dynamically select the best strategy
+pdf_converter = smart_converter
+docx_converter = smart_converter
+pptx_converter = smart_converter
+img_converter = smart_converter
 
 __all__ = [
     "mistral_converter",

--- a/backend/airweave/platform/converters/__init__.py
+++ b/backend/airweave/platform/converters/__init__.py
@@ -2,6 +2,7 @@
 
 from .code_converter import CodeConverter
 from .html_converter import HtmlConverter
+from .markitdown_converter import MarkItDownConverter
 from .mistral_converter import MistralConverter
 from .txt_converter import TxtConverter
 from .web_converter import WebConverter
@@ -9,6 +10,7 @@ from .xlsx_converter import XlsxConverter
 
 # Singleton instances
 mistral_converter = MistralConverter()
+markitdown_converter = MarkItDownConverter()
 html_converter = HtmlConverter()
 xlsx_converter = XlsxConverter()  # Local openpyxl extraction (not Mistral)
 txt_converter = TxtConverter()
@@ -16,10 +18,11 @@ code_converter = CodeConverter()
 web_converter = WebConverter()  # URL fetching and HTML to markdown
 
 # Aliases for backward compatibility
-pdf_converter = mistral_converter  # PDF uses Mistral OCR
-docx_converter = mistral_converter  # DOCX uses Mistral OCR
-pptx_converter = mistral_converter  # PPTX uses Mistral OCR
-img_converter = mistral_converter  # Images use Mistral OCR
+# Use MarkItDown (local) instead of Mistral (cloud)
+pdf_converter = markitdown_converter
+docx_converter = markitdown_converter
+pptx_converter = markitdown_converter
+img_converter = markitdown_converter
 
 __all__ = [
     "mistral_converter",

--- a/backend/airweave/platform/converters/markitdown_converter.py
+++ b/backend/airweave/platform/converters/markitdown_converter.py
@@ -1,0 +1,79 @@
+"""Converter for documents and images using MarkItDown (Local)."""
+
+from typing import Dict, List, Optional
+
+from airweave.core.logging import logger
+from airweave.platform.converters._base import BaseTextConverter
+from airweave.platform.sync.async_helpers import run_in_thread_pool
+from airweave.platform.sync.exceptions import EntityProcessingError, SyncFailureError
+
+
+class MarkItDownConverter(BaseTextConverter):
+    """Converts documents and images to markdown using MarkItDown (Local).
+    
+    Supported formats:
+    - Documents: PDF, DOCX, PPTX, XLSX
+    - Images: JPG, JPEG, PNG
+    """
+
+    def __init__(self):
+        """Initialize converter with optional OpenAI support."""
+        try:
+            from markitdown import MarkItDown
+            from airweave.core.config import settings
+            
+            llm_client = None
+            llm_model = None
+            
+            if hasattr(settings, "OPENAI_API_KEY") and settings.OPENAI_API_KEY:
+                try:
+                    from openai import OpenAI
+                    llm_client = OpenAI(api_key=settings.OPENAI_API_KEY)
+                    llm_model = "gpt-4o"
+                    logger.info("MarkItDown initialized with OpenAI (gpt-4o) support")
+                except ImportError:
+                    logger.warning("openai package not found, falling back to basic MarkItDown")
+                except Exception as e:
+                    logger.warning(f"Failed to initialize OpenAI client: {e}")
+
+            self._md = MarkItDown(llm_client=llm_client, llm_model=llm_model)
+            if not llm_client:
+                logger.info("MarkItDown initialized in basic mode (local only)")
+                
+        except ImportError:
+            logger.error("markitdown package not found")
+            self._md = None
+
+    async def convert_batch(self, file_paths: List[str]) -> Dict[str, str]:
+        """Convert document files to markdown text using MarkItDown.
+
+        Args:
+            file_paths: List of document file paths to convert
+
+        Returns:
+            Dict mapping file_path -> markdown text content (None if failed)
+        """
+        if not self._md:
+             raise SyncFailureError("markitdown package required but not installed")
+
+        results = {}
+        
+        # Process files sequentially (MarkItDown might not be thread-safe or CPU bound)
+        # We can try parallelizing if needed, but for now safe sequential in thread pool
+        for path in file_paths:
+            try:
+                text = await self._convert_single(path)
+                results[path] = text
+            except Exception as e:
+                logger.error(f"Failed to convert {path} with MarkItDown: {e}")
+                results[path] = None
+                
+        return results
+
+    async def _convert_single(self, file_path: str) -> str:
+        """Convert a single file."""
+        def _convert():
+            result = self._md.convert(file_path)
+            return result.text_content
+
+        return await run_in_thread_pool(_convert)

--- a/backend/airweave/platform/converters/smart_converter.py
+++ b/backend/airweave/platform/converters/smart_converter.py
@@ -1,0 +1,132 @@
+from typing import Any, Dict, List, Optional
+
+from airweave.core.config import settings
+from airweave.core.logging import logger
+from airweave.platform.converters.markitdown_converter import MarkItDownConverter
+from airweave.platform.converters.mistral_converter import MistralConverter
+
+
+class SmartConverter:
+    """A smart converter that selects the best available conversion strategy.
+
+    Priority:
+    1. OpenAI (via MarkItDown) - Best for Vision/OCR/Complex Docs
+    2. Mistral (via MistralConverter) - Good OCR
+    3. Local (via MarkItDown) - Basic text extraction (fallback)
+    """
+
+    def __init__(self):
+        self.openai_converter = None
+        self.mistral_converter = None
+        self.local_converter = None
+        self._initialize_strategies()
+
+    @property
+    def openai_available(self) -> bool:
+        return self.openai_converter is not None
+
+    @property
+    def mistral_available(self) -> bool:
+        return self.mistral_converter is not None
+
+    def _initialize_strategies(self):
+        """Initialize available strategies based on configuration."""
+        # 1. OpenAI Strategy (Best)
+        if hasattr(settings, "OPENAI_API_KEY") and settings.OPENAI_API_KEY:
+            try:
+                # MarkItDownConverter automatically uses OpenAI if key is present in settings
+                # We create a specific instance for it
+                openai_converter = MarkItDownConverter()
+                # Verify it actually has the client (it should, based on its __init__)
+                if openai_converter._md._llm_client:
+                    self.openai_converter = openai_converter
+                    logger.info("SmartConverter: OpenAI strategy available")
+            except Exception as e:
+                logger.warning(f"SmartConverter: Failed to initialize OpenAI strategy: {e}")
+
+        # 2. Mistral Strategy (Good)
+        if hasattr(settings, "MISTRAL_API_KEY") and settings.MISTRAL_API_KEY:
+            try:
+                self.mistral_converter = MistralConverter()
+                logger.info("SmartConverter: Mistral strategy available")
+            except Exception as e:
+                logger.warning(f"SmartConverter: Failed to initialize Mistral strategy: {e}")
+
+        # 3. Local Strategy (Fallback)
+        # Always available via MarkItDown (it falls back to local if no LLM client)
+        try:
+            self.local_converter = MarkItDownConverter()
+            logger.info("SmartConverter: Local strategy available")
+        except Exception as e:
+            logger.error(f"SmartConverter: Failed to initialize Local strategy: {e}")
+
+    def _get_converter(self, preferred_model: Optional[str] = None) -> Any:
+        """Determine which converter to use based on preference and availability."""
+        
+        # 1. Honor preference if valid and available
+        if preferred_model == "openai" and self.openai_available:
+            return self.openai_converter
+        if preferred_model == "mistral" and self.mistral_available:
+            return self.mistral_converter
+        if preferred_model == "local":
+            return self.local_converter
+
+        # 2. Fallback to default priority logic
+        if self.openai_available:
+            return self.openai_converter
+        elif self.mistral_available:
+            return self.mistral_converter
+        else:
+            # Fallback to local if nothing else is available
+            return self.local_converter
+
+    async def convert(self, file_path: str, preferred_model: Optional[str] = None) -> str:
+        """Convert a single file using the best available or preferred strategy.
+
+        Args:
+            file_path: Path to the file to convert.
+            preferred_model: Optional preferred model ("openai", "mistral", "local").
+
+        Returns:
+            Converted text content.
+        """
+        converter = self._get_converter(preferred_model)
+        if not converter:
+             raise RuntimeError(f"No suitable converter found (preferred: {preferred_model})")
+
+        # Handle different converter interfaces
+        if hasattr(converter, "convert"):
+            return await converter.convert(file_path)
+        elif hasattr(converter, "convert_batch"):
+            results = await converter.convert_batch([file_path])
+            if results and results.get(file_path):
+                return results[file_path]
+            raise ValueError(f"Converter returned empty result for {file_path}")
+        else:
+            raise NotImplementedError(f"Converter {converter.__class__.__name__} has no compatible convert method")
+
+    async def convert_batch(self, file_paths: List[str], preferred_model: Optional[str] = None) -> Dict[str, str]:
+        """Convert a batch of files using the best available or preferred strategy.
+
+        Args:
+            file_paths: List of file paths to convert.
+            preferred_model: Optional preferred model ("openai", "mistral", "local").
+
+        Returns:
+            Dictionary mapping file paths to converted text content.
+        """
+        converter = self._get_converter(preferred_model)
+        if not converter:
+             raise RuntimeError(f"No suitable converter found (preferred: {preferred_model})")
+
+        if hasattr(converter, "convert_batch"):
+            return await converter.convert_batch(file_paths)
+        else:
+            # Fallback to loop if converter doesn't support batching
+            results = {}
+            for path in file_paths:
+                try:
+                    results[path] = await self.convert(path, preferred_model)
+                except Exception as e:
+                    logger.warning(f"Failed to convert {path}: {e}")
+            return results

--- a/backend/airweave/platform/destinations/weaviate.py
+++ b/backend/airweave/platform/destinations/weaviate.py
@@ -1,0 +1,174 @@
+"""Weaviate destination implementation."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+from uuid import UUID
+
+import weaviate
+from weaviate.classes.config import Configure, Property, DataType
+from weaviate.classes.query import Filter
+
+from airweave.core.logging import ContextualLogger
+from airweave.core.logging import logger as default_logger
+from airweave.platform.configs.auth import WeaviateAuthConfig
+from airweave.platform.decorators import destination
+from airweave.platform.destinations._base import VectorDBDestination
+from airweave.platform.entities._base import BaseEntity
+
+
+@destination("Weaviate", "weaviate", auth_config_class=WeaviateAuthConfig, supports_vector=True)
+class WeaviateDestination(VectorDBDestination):
+    """Weaviate destination implementation."""
+
+    def __init__(self):
+        """Initialize defaults."""
+        super().__init__()
+        self.client: weaviate.WeaviateAsyncClient | None = None
+        self.collection_name: str | None = None
+        self.collection_id: UUID | None = None
+        self.vector_size: int = 3072  # Default, will be updated in create/setup
+
+    @classmethod
+    async def create(
+        cls,
+        collection_id: UUID,
+        organization_id: Optional[UUID] = None,
+        vector_size: Optional[int] = None,
+        credentials: Optional[WeaviateAuthConfig] = None,
+        config: Optional[dict] = None,
+        logger: Optional[ContextualLogger] = None,
+    ) -> "WeaviateDestination":
+        """Create and return a connected destination."""
+        instance = cls()
+        instance.set_logger(logger or default_logger)
+        instance.collection_id = collection_id
+        instance.vector_size = vector_size or 3072
+        
+        # Weaviate collection names must start with a capital letter and be alphanumeric
+        # We'll use a prefix + sanitized collection ID
+        sanitized_id = str(collection_id).replace("-", "")
+        instance.collection_name = f"Airweave_{sanitized_id}"
+
+        if credentials:
+            instance.client = weaviate.use_async_with_params(
+                client=weaviate.connect.ConnectionParams.from_params(
+                    http_host=credentials.cluster_url.replace("http://", "").replace("https://", "").split(":")[0],
+                    http_port=int(credentials.cluster_url.split(":")[-1]) if ":" in credentials.cluster_url else 8080,
+                    http_secure=credentials.cluster_url.startswith("https"),
+                    grpc_host=credentials.cluster_url.replace("http://", "").replace("https://", "").split(":")[0],
+                    grpc_port=50051, # Default gRPC port
+                    grpc_secure=credentials.cluster_url.startswith("https"),
+                ),
+                auth_client_secret=weaviate.auth.AuthApiKey(credentials.api_key) if credentials.api_key else None
+            )
+        else:
+            # Default local connection
+            instance.client = weaviate.connect_to_local(
+                port=8080,
+                grpc_port=50051
+            )
+
+        await asyncio.to_thread(instance.client.connect)
+        return instance
+
+    async def setup_collection(self, vector_size: int | None = None) -> None:
+        """Set up the Weaviate collection."""
+        if not self.client.is_connected():
+            await asyncio.to_thread(self.client.connect)
+            
+        if await asyncio.to_thread(self.client.collections.exists, self.collection_name):
+            return
+
+        await asyncio.to_thread(
+            self.client.collections.create,
+            name=self.collection_name,
+            vectorizer_config=Configure.Vectorizer.none(),
+            properties=[
+                Property(name="text", data_type=DataType.TEXT),
+                Property(name="source_id", data_type=DataType.UUID),
+                Property(name="sync_id", data_type=DataType.UUID),
+                Property(name="entity_id", data_type=DataType.TEXT),
+                Property(name="url", data_type=DataType.TEXT),
+                Property(name="metadata", data_type=DataType.TEXT),
+            ]
+        )
+
+    async def insert(self, entity: BaseEntity) -> None:
+        """Insert a single entity."""
+        await self.bulk_insert([entity])
+
+    async def bulk_insert(self, entities: list[BaseEntity]) -> None:
+        """Bulk insert entities."""
+        if not entities:
+            return
+
+        if not self.client.is_connected():
+            await asyncio.to_thread(self.client.connect)
+
+        collection = self.client.collections.get(self.collection_name)
+        
+        objects = []
+        import json
+        for entity in entities:
+            if not entity.airweave_system_metadata or not entity.airweave_system_metadata.vectors:
+                continue
+
+            props = entity.model_dump(exclude={"airweave_system_metadata"})
+            # Flatten metadata for Weaviate or store as JSON object
+            
+            objects.append(
+                weaviate.classes.data.DataObject(
+                    properties={
+                        "text": entity.textual_representation or entity.name or "",
+                        "source_id": str(entity.source_id) if hasattr(entity, "source_id") else None,
+                        "sync_id": str(entity.airweave_system_metadata.sync_id),
+                        "entity_id": entity.entity_id,
+                        "url": entity.url if hasattr(entity, "url") else None,
+                        "metadata": json.dumps(props)
+                    },
+                    vector=entity.airweave_system_metadata.vectors[0]
+                )
+            )
+
+        await asyncio.to_thread(collection.data.insert_many, objects)
+
+    async def delete(self, db_entity_id: UUID) -> None:
+        """Delete a single entity."""
+        # Not implemented for this PoC
+        pass
+
+    async def bulk_delete(self, entity_ids: list[str], sync_id: UUID) -> None:
+        """Bulk delete entities."""
+        # Not implemented for this PoC
+        pass
+
+    async def delete_by_sync_id(self, sync_id: UUID) -> None:
+        """Delete entities by sync ID."""
+        if not self.client.is_connected():
+            await asyncio.to_thread(self.client.connect)
+            
+        collection = self.client.collections.get(self.collection_name)
+        await asyncio.to_thread(
+            collection.data.delete_many,
+            where=Filter.by_property("sync_id").equal(str(sync_id))
+        )
+
+    async def bulk_delete_by_parent_id(self, parent_id: str, sync_id: UUID) -> None:
+        """Delete by parent ID."""
+        # Not implemented for this PoC
+        pass
+
+    async def search(self, query_vector: list[float]) -> None:
+        """Search."""
+        # Not implemented for this PoC
+        pass
+
+    async def has_keyword_index(self) -> bool:
+        """Check for keyword index."""
+        return True
+
+    async def get_vector_config_names(self) -> list[str]:
+        """Get vector config names."""
+        return ["default"]

--- a/backend/airweave/platform/sources/google_drive.py
+++ b/backend/airweave/platform/sources/google_drive.py
@@ -713,8 +713,8 @@ class GoogleDriveSource(BaseSource):
         if not folder_segments:
             return [], filename_glob or "*"
 
-        self.logger.debug(
-            f"Resolved pattern '{pattern}' to {len(parent_ids or [])} folder(s), "
+        self.logger.info(
+            f"Resolved pattern '{pattern}' to {len(parent_ids or [])} folder(s): {parent_ids}, "
             f"filename_glob={filename_glob}"
         )
         return parent_ids or [], filename_glob
@@ -896,7 +896,7 @@ class GoogleDriveSource(BaseSource):
             file_entity = self._build_file_entity(file_obj, parent_breadcrumb)
             if not file_entity:
                 return None
-            self.logger.debug(f"Processing file entity: {file_entity.file_id} '{file_entity.name}'")
+            self.logger.info(f"Processing file entity: {file_entity.file_id} '{file_entity.name}'")
 
             # Download file using downloader
             try:
@@ -1020,7 +1020,7 @@ class GoogleDriveSource(BaseSource):
 
             async with self.http_client() as client:
                 patterns: List[str] = getattr(self, "include_patterns", []) or []
-                self.logger.debug(f"Include patterns: {patterns}")
+                self.logger.info(f"Include patterns configuration: {patterns}")
 
                 drive_objs: List[Dict[str, Any]] = []
                 try:

--- a/backend/airweave/platform/sources/google_drive.py
+++ b/backend/airweave/platform/sources/google_drive.py
@@ -84,6 +84,9 @@ class GoogleDriveSource(BaseSource):
         instance.preserve_order = bool(config.get("preserve_order", False))
         instance.stop_on_error = bool(config.get("stop_on_error", False))
 
+        # Model selection
+        instance.model = config.get("model")
+
         return instance
 
     @staticmethod

--- a/backend/airweave/platform/sync/entity_pipeline.py
+++ b/backend/airweave/platform/sync/entity_pipeline.py
@@ -996,8 +996,15 @@ class EntityPipeline:
                 keys = [key for _, key in sub_batch]
 
                 try:
+                    # Get preferred model from source config if available
+                    preferred_model = getattr(sync_context.source, "model", None)
+
                     # Batch convert returns Dict[key, text_content]
-                    results = await converter.convert_batch(keys)
+                    # Pass preferred_model to SmartConverter (or others that support it)
+                    if hasattr(converter, "convert_batch") and "preferred_model" in converter.convert_batch.__code__.co_varnames:
+                         results = await converter.convert_batch(keys, preferred_model=preferred_model)
+                    else:
+                         results = await converter.convert_batch(keys)
 
                     # Append content to each entity's textual_representation
                     for entity, key in sub_batch:

--- a/backend/airweave/platform/sync/entity_pipeline.py
+++ b/backend/airweave/platform/sync/entity_pipeline.py
@@ -886,14 +886,14 @@ class EntityPipeline:
 
         # Map extensions to converter modules
         converter_map = {
-            # Mistral OCR - Documents
-            ".pdf": converters.mistral_converter,
-            ".docx": converters.mistral_converter,
-            ".pptx": converters.mistral_converter,
-            # Mistral OCR - Images
-            ".jpg": converters.mistral_converter,
-            ".jpeg": converters.mistral_converter,
-            ".png": converters.mistral_converter,
+            # Documents - use aliases from __init__.py (defaults to MarkItDown)
+            ".pdf": converters.pdf_converter,
+            ".docx": converters.docx_converter,
+            ".pptx": converters.pptx_converter,
+            # Images - use aliases from __init__.py (defaults to MarkItDown)
+            ".jpg": converters.img_converter,
+            ".jpeg": converters.img_converter,
+            ".png": converters.img_converter,
             # XLSX - local extraction
             ".xlsx": converters.xlsx_converter,
             # HTML

--- a/backend/local.py
+++ b/backend/local.py
@@ -1,143 +1,104 @@
-"""Local script for testing various source connectors (e.g. Asana, Notion) and verifying results."""
-
 import asyncio
 import uuid
+import os
+from typing import List
 
-import weaviate.classes as wvc
-from weaviate.collections import Collection
+from dotenv import load_dotenv
+load_dotenv()
 
 from airweave import schemas
+from airweave.core.logging import ContextualLogger
 from airweave.platform.destinations.weaviate import WeaviateDestination
-from airweave.platform.embedding_models.local_text2vec import LocalText2Vec
+from airweave.platform.embedders.openai import DenseEmbedder
 from airweave.platform.sources._base import BaseSource
-from airweave.platform.sources.asana import AsanaSource
-from airweave.platform.sources.notion import NotionSource
-from airweave.vector_db.weaviate_service import WeaviateService
+# from airweave.platform.sync.context import SyncContext
 
-
-async def process_source_chunks(
-    source: BaseSource, weaviate_dest: WeaviateDestination, buffer_size: int = 50
-):
-    """Helper to fetch chunks from a given source connector and optionally insert them into Weaviate in bulk."""
-    chunks_buffer = []
-    async for chunk in source.generate_chunks():
-        chunks_buffer.append(chunk)
-
-        # When buffer is full, bulk insert
-        if len(chunks_buffer) >= buffer_size:
-            await weaviate_dest.bulk_insert(chunks_buffer)
-            print(f"Inserted {len(chunks_buffer)} chunks from {source.__class__.__name__}")
-            chunks_buffer.clear()
-
-    # If any remain after the loop, insert them as well
-    if chunks_buffer:
-        await weaviate_dest.bulk_insert(chunks_buffer)
-        print(f"Inserted final {len(chunks_buffer)} chunks from {source.__class__.__name__}")
-
-    return chunks_buffer
-
-
-async def verify_chunks_in_weaviate(sync_id: uuid.UUID):
-    """Check total chunk count in the corresponding Weaviate collection,
-    and print some sample documents.
-    """
-    print("\n=== Verifying Sync Results ===")
-    async with WeaviateService() as service:
-        sanitized_sync_id = str(sync_id).replace("-", "_")
-        collection: Collection = await service.get_weaviate_collection(
-            f"Chunks_{sanitized_sync_id}"
-        )
-
-        # Count how many chunk objects are in this collection
-        count = (await collection.aggregate.over_all(total_count=True)).total_count
-        print(f"\nTotal documents in 'Chunks_{sanitized_sync_id}' collection: {count}")
-
-        # Fetch some sample documents (no filter)
-        results = await collection.query.fetch_objects(limit=5, include_vector=False)
-        print("\nSample objects:")
-        for obj in results.objects:
-            print(f"\nName: {obj.properties.get('name')}")
-            print(f"Source: {obj.properties.get('source_name')}")
-            print(f"Created: {obj.metadata.creation_time}")
-            print(f"Breadcrumbs: {obj.properties.get('breadcrumbs')}")
-
-
-async def verify_asana_tasks_in_weaviate(sync_id: uuid.UUID):
-    """Example of a more connector-specific verification for Asana:
-    filtering tasks using Weaviate's property filter and printing details.
-    """
-    print("\n=== Verifying Asana Tasks in Weaviate ===")
-    async with WeaviateService() as service:
-        sanitized_sync_id = str(sync_id).replace("-", "_")
-        collection: Collection = await service.get_weaviate_collection(
-            f"Chunks_{sanitized_sync_id}"
-        )
-
-        # Query tasks with filters (e.g. resource_subtype == default_task)
-        tasks = await collection.query.fetch_objects(
-            limit=5,
-            filters=wvc.query.Filter.by_property("resource_subtype").equal("default_task"),
-            return_metadata=wvc.query.MetadataQuery(creation_time=True),
-        )
-
-        print("\nSample tasks:")
-        for task in tasks.objects:
-            print(f"Task: {task.properties.get('name')}")
-            print(f"Created: {task.metadata.creation_time}")
-            print(f"Completed: {task.properties.get('completed')}")
-            print(f"Due at: {task.properties.get('due_at')}")
-            print("-----")
-
+class MockSyncContext:
+    def __init__(self, logger):
+        self.logger = logger
 
 async def main():
     """Entrypoint to test multiple connectors (Asana, Notion, Dropbox, etc.) end-to-end."""
     # Create a test user and a unique sync ID for this sync run
+    organization_id = uuid.uuid4()
     user = schemas.User(
         id=uuid.uuid4(),
         email="test@test.com",
         full_name="Test User",
-        organization_id=uuid.uuid4(),
+        primary_organization_id=organization_id,
     )
     sync_id = uuid.uuid4()
+    collection_id = uuid.uuid4()
 
-    # Initialize an embedding model
-    embedding_model = LocalText2Vec()
+    # Initialize logger and sync context
+    from airweave.core.logging import LoggerConfigurator
+    logger = LoggerConfigurator.configure_logger(__name__)
+    sync_context = MockSyncContext(logger)
+
+    # Initialize an embedding model (OpenAI)
+    # Ensure OPENAI_API_KEY is set in environment
+    if not os.getenv("OPENAI_API_KEY"):
+        print("WARNING: OPENAI_API_KEY not set. Embedding will fail.")
+    
+    embedding_model = DenseEmbedder(vector_size=3072)
 
     # Create a Weaviate destination for storing chunks
-    weaviate_dest = await WeaviateDestination.create(sync_id, embedding_model)
+    print("=== Initializing Weaviate Destination ===")
+    weaviate_dest = await WeaviateDestination.create(collection_id=collection_id)
+    await weaviate_dest.setup_collection()
+    print("=== Weaviate Destination Initialized ===")
+
+    print("=== Verifying Weaviate Connection ===")
+    if weaviate_dest.client.is_connected():
+        print("Weaviate is ready and connected!")
+    else:
+        print("Failed to connect to Weaviate.")
 
     # -------------------------------------------------------------------------
-    # Test Asana Source Connector
+    # Test Dummy Entity Insertion
     # -------------------------------------------------------------------------
-    print("=== Testing Asana Connector ===")
-    access_token = "..."
-    asana_source = await AsanaSource.create(access_token)
-    asana_chunks = await process_source_chunks(asana_source, weaviate_dest, buffer_size=50)
-    print(f"Asana source generated {len(asana_chunks)} chunks total.\n")
+    # -------------------------------------------------------------------------
+    # Test Dummy Entity Insertion
+    # -------------------------------------------------------------------------
+    print("=== Testing Dummy Entity Insertion ===")
+    from airweave.platform.entities._base import BaseEntity, AirweaveSystemMetadata
+    from airweave.platform.entities._airweave_field import AirweaveField
+
+    class DummyEntity(BaseEntity):
+        entity_id: str = AirweaveField(..., description="ID", is_entity_id=True)
+        name: str = AirweaveField(..., description="Name", is_name=True)
+        url: str = AirweaveField(..., description="URL")
+
+    dummy_entity = DummyEntity(
+        entity_id="dummy_1",
+        name="Dummy Entity",
+        textual_representation="This is a test entity to verify Weaviate insertion.",
+        source_id=uuid.uuid4(),
+        url="http://example.com/dummy",
+        breadcrumbs=[]
+    )
+    
+    # Embed
+    print("Generating embedding...")
+    vectors = await embedding_model.embed_many([dummy_entity.textual_representation], sync_context)
+    dummy_entity.airweave_system_metadata = AirweaveSystemMetadata(
+        sync_id=sync_id,
+        vectors=[vectors[0]]
+    )
+    
+    # Insert
+    print("Inserting into Weaviate...")
+    await weaviate_dest.insert(dummy_entity)
+    print("Successfully inserted dummy entity!")
 
     # -------------------------------------------------------------------------
-    # Test Notion Source Connector
+    # Test Google Drive Source Connector (Placeholder)
     # -------------------------------------------------------------------------
-    print("=== Testing Notion Connector ===")
-    notion_source = await NotionSource.create(user, sync_id)
-    notion_chunks = await process_source_chunks(notion_source, weaviate_dest, buffer_size=50)
-    print(f"Notion source generated {len(notion_chunks)} chunks total.\n")
-
-    # -------------------------------------------------------------------------
-    # Test Dropbox Source Connector
-    # -------------------------------------------------------------------------
-    print("=== Testing Dropbox Connector ===")
-    from airweave.platform.sources.dropbox import DropboxSource
-
-    dropbox_source = await DropboxSource.create(user, sync_id)
-    dropbox_chunks = await process_source_chunks(dropbox_source, weaviate_dest, buffer_size=50)
-    print(f"Dropbox source generated {len(dropbox_chunks)} chunks total.\n")
-
-    # Optionally, verify chunks inserted
-    await verify_chunks_in_weaviate(sync_id)
-
-    # Optionally, add more connector-specific verifications here (like verify_asana_tasks_in_weaviate)
-    # await verify_dropbox_folders_in_weaviate(sync_id)  # e.g. a function you might create
+    # To test with real data, uncomment and configure:
+    # print("=== Testing Google Drive Connector ===")
+    # from airweave.platform.sources.google_drive import GoogleDriveSource
+    # google_drive_source = await GoogleDriveSource.create(user, sync_id)
+    # await process_source_chunks(google_drive_source, weaviate_dest, embedding_model, sync_context)
 
 
 if __name__ == "__main__":

--- a/docker-compose.weaviate.yml
+++ b/docker-compose.weaviate.yml
@@ -1,0 +1,27 @@
+version: '3.4'
+services:
+  weaviate:
+    command:
+      - --host
+      - 0.0.0.0
+      - --port
+      - '8080'
+      - --scheme
+      - http
+    image: semitechnologies/weaviate:1.27.0
+    ports:
+      - 8090:8080
+      - 50051:50051
+    volumes:
+      - weaviate_data:/var/lib/weaviate
+    restart: on-failure:0
+    environment:
+      QUERY_DEFAULTS_LIMIT: 25
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+      DEFAULT_VECTORIZER_MODULE: 'none'
+      ENABLE_MODULES: 'text2vec-openai,text2vec-cohere,text2vec-huggingface,text2vec-palm'
+      CLUSTER_HOSTNAME: 'node1'
+
+volumes:
+  weaviate_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,8 +44,10 @@ services:
 
   backend:
     container_name: airweave-backend
-    # Use pre-built image of latest release, or override with BACKEND_IMAGE env var for testing
-    image: ${BACKEND_IMAGE:-ghcr.io/airweave-ai/airweave-backend:latest}
+    # Build from source for local dev (fixes platform mismatch on M1/M2)
+    build:
+      context: ../backend
+      dockerfile: Dockerfile
     # Import all variables from .env file
     env_file:
       - ../.env
@@ -88,8 +90,10 @@ services:
 
   frontend:
     container_name: airweave-frontend
-    # Use pre-built image of latest release, or override with FRONTEND_IMAGE env var for testing
-    image: ${FRONTEND_IMAGE:-ghcr.io/airweave-ai/airweave-frontend:latest}
+    # Build from source for local dev
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile
     # Profile: only start if explicitly enabled with --profile frontend
     # Not needed for backend-only testing (API tests, connector tests)
     profiles:
@@ -183,8 +187,10 @@ services:
 
   temporal-worker:
     container_name: airweave-temporal-worker
-    # Use pre-built image of latest release, or override with BACKEND_IMAGE env var for testing
-    image: ${BACKEND_IMAGE:-ghcr.io/airweave-ai/airweave-backend:latest}
+    # Build from source for local dev
+    build:
+      context: ../backend
+      dockerfile: Dockerfile
     # Import all variables from .env file (same as backend)
     env_file:
       - ../.env

--- a/frontend/src/components/creation-views/SourceConfigView.tsx
+++ b/frontend/src/components/creation-views/SourceConfigView.tsx
@@ -44,6 +44,8 @@ interface SourceDetails {
       description?: string;
       type?: string;
       required?: boolean;
+      options?: string[];
+      ui_component?: string;
     }>;
   };
 }
@@ -687,11 +689,31 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
                               placeholder={`Enter ${field.title?.toLowerCase() || field.name} and press Enter...`}
                               transformInput={sourceDetails?.short_name === 'jira' && field.name === 'project_keys' ? (v) => v.toUpperCase() : undefined}
                             />
+                          ) : field.ui_component === 'select' || (field.options && field.options.length > 0) ? (
+                            <select
+                              value={configData[field.name] as string || ''}
+                              onChange={(e) => setConfigData({ ...configData, [field.name]: e.target.value })}
+                              className={cn(
+                                "w-full px-4 py-2 rounded-lg text-sm",
+                                "border bg-transparent",
+                                "focus:outline-none focus:border-gray-400 dark:focus:border-gray-600",
+                                isDark
+                                  ? "border-gray-800 text-white placeholder:text-gray-600 bg-gray-900"
+                                  : "border-gray-200 text-gray-900 placeholder:text-gray-400 bg-white"
+                              )}
+                            >
+                              <option value="" disabled>Select an option...</option>
+                              {field.options?.map((option) => (
+                                <option key={option} value={option}>
+                                  {option}
+                                </option>
+                              ))}
+                            </select>
                           ) : (
                             <input
                               type="text"
                               placeholder=""
-                              value={configData[field.name] || ''}
+                              value={configData[field.name] as string || ''}
                               onChange={(e) => setConfigData({ ...configData, [field.name]: e.target.value })}
                               className={cn(
                                 "w-full px-4 py-2 rounded-lg text-sm",

--- a/scripts/inspect_qdrant.py
+++ b/scripts/inspect_qdrant.py
@@ -1,0 +1,36 @@
+from qdrant_client import QdrantClient
+import json
+
+def inspect_chunks(limit=10):
+    print("Connecting to Qdrant at http://localhost:6333...")
+    
+    client = QdrantClient(url="http://localhost:6333")
+    
+    try:
+        collections = client.get_collections()
+        print(f"Found {len(collections.collections)} collections: {[c.name for c in collections.collections]}")
+        
+        for collection in collections.collections:
+            name = collection.name
+            print(f"\n--- Inspecting Collection: {name} ---")
+            
+            # Scroll through points
+            result, _ = client.scroll(
+                collection_name=name,
+                limit=limit,
+                with_payload=True,
+                with_vectors=False # Set to True to see vectors
+            )
+            
+            print(f"Found {len(result)} chunks (showing max {limit}):")
+            
+            for i, point in enumerate(result):
+                print(f"\n[Chunk {i+1}]")
+                print(f"ID: {point.id}")
+                print(f"Payload: {json.dumps(point.payload, indent=2)}")
+
+    except Exception as e:
+        print(f"Error inspecting Qdrant: {e}")
+
+if __name__ == "__main__":
+    inspect_chunks()

--- a/scripts/inspect_weaviate.py
+++ b/scripts/inspect_weaviate.py
@@ -1,0 +1,46 @@
+import weaviate
+import json
+import os
+
+def inspect_chunks(limit=10):
+    print(f"Connecting to Weaviate at http://localhost:8090...")
+    
+    # Connect to local Weaviate using v4 client
+    client = weaviate.connect_to_local(port=8090, grpc_port=50051)
+    
+    try:
+        # Get all collections
+        collections = client.collections.list_all()
+        print(f"Found collections: {list(collections.keys())}")
+
+        for name, collection in collections.items():
+            print(f"\n--- Inspecting Collection: {name} ---")
+            
+            # Fetch objects
+            response = collection.query.fetch_objects(
+                limit=limit,
+                include_vector=True
+            )
+            
+            objects = response.objects
+            print(f"Found {len(objects)} chunks (showing max {limit}):")
+            
+            for i, obj in enumerate(objects):
+                print(f"\n[Chunk {i+1}]")
+                print(f"ID: {obj.uuid}")
+                print(f"Properties: {json.dumps(obj.properties, indent=2)}")
+                if obj.vector:
+                     # Handle both list and dict vector formats if applicable, though usually list in v4
+                    vector_len = len(obj.vector['default']) if isinstance(obj.vector, dict) else len(obj.vector)
+                    print(f"Vector Length: {vector_len}")
+                else:
+                    print("Vector: Not retrieved")
+
+    finally:
+        client.close()
+
+if __name__ == "__main__":
+    try:
+        inspect_chunks()
+    except Exception as e:
+        print(f"Error: {e}")


### PR DESCRIPTION
## Summary
This PR implements a user-selectable document conversion model feature for Google Drive sources. Users can now choose between "OpenAI", "Mistral", or "Local" (MarkItDown) when configuring a source.

## Changes
- **Frontend**: Added a dropdown to `SourceConfigView` to select the conversion model.
- **Backend**:
    - Updated `GoogleDriveConfig` to include the `model` field with UI hints.
    - Refactored `SmartConverter` to accept and prioritize a `preferred_model` argument.
    - Updated `EntityPipeline` to pass the user's selection from the source config to the converter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a user-selectable document conversion model for Google Drive and introduced a SmartConverter that supports MarkItDown (local), OpenAI, and Mistral for better control and quality.

- **New Features**
  - Model dropdown in SourceConfigView to choose "openai", "mistral", or "local".
  - GoogleDriveConfig includes a model field with enum and UI hints; backend config fields now support options and ui_component.
  - SmartConverter honors the preferred model and falls back by availability; MarkItDown can use OpenAI when a key is set. EntityPipeline passes the preference to batch conversions.
  - PDF/DOCX/PPTX/IMG routes updated to go through SmartConverter.
  - Added Weaviate destination, local docker-compose, and inspection scripts for testing.

- **Migration**
  - Set OPENAI_API_KEY or MISTRAL_API_KEY to enable those models; "local" works without keys.
  - Install markitdown (and openai if using OpenAI) for conversion.
  - Use docker-compose.weaviate.yml to run Weaviate locally if testing the new destination.

<sup>Written for commit 908fb64c950115a44a62b4eeec4426c454bd8966. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

