### PR TITLE
fix: use correct env var path for testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,7 +41,7 @@
                 "PYTHONPATH": "${workspaceFolder}/backend",
                 "TESTING": "true"
             },
-            "envFile": "${workspaceFolder}/backend/tests/e2e/.env.test",
+            "envFile": "${workspaceFolder}/.env",
             "python": "${command:python.interpreterPath}"
         },
         {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated VS Code launch.json to use ${workspaceFolder}/.env for test runs. This ensures tests load the correct environment variables instead of the e2e test file.

<sup>Written for commit bd19b888bfc837fb35495736a53f7599ded765b2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

