### PR TITLE
fix: use correct env var path for custom tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,7 +58,7 @@
                 "PYTHONPATH": "${workspaceFolder}/backend",
                 "TESTING": "true"
             },
-            "envFile": "${workspaceFolder}/backend/tests/e2e/.env.test",
+            "envFile": "${workspaceFolder}/.env",
             "python": "${command:python.interpreterPath}"
         },
         {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update VSCode launch config to use the root .env for custom tests, ensuring the correct environment variables load and preventing failures from the old .env.test path.

<sup>Written for commit d77c3293372a5b0b9271814a890fc40ef6735d82. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

