### PR TITLE
fix: word monke

### DIFF
--- a/monke/configs/word.yaml
+++ b/monke/configs/word.yaml
@@ -12,7 +12,7 @@ connector:
     # - User.Read
     # - offline_access
     # Note: Production syncs only need Files.Read.All
-    account_id: ca_WIOsV2kX2PzH
+    account_id: ca_gVWCWpNlF9in
     auth_config_id: ac_qwZe7KS8pdYT
   config_fields:
     openai_model: "gpt-4.1-mini"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Word connector config to use the correct account_id, fixing authentication and restoring syncs.

<sup>Written for commit 7e5ae01585aea7a322afe7db88c261e3840958ed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

