### PR TITLE
chore: Local development QoL improvements

### DIFF
--- a/.cursor/rules/monke.mdc
+++ b/.cursor/rules/monke.mdc
@@ -291,3 +291,81 @@ verification:
 8. **Configurable**: Test flows customizable per connector
 
 ---
+
+## Common Pitfalls & Troubleshooting
+
+### Entity ID Collisions Across Types
+
+**Problem**: When a source has multiple entity types (e.g., Pipedrive has persons, deals, notes), different types can share the same numeric ID from the external API (e.g., `deal/75` and `note/75` both exist).
+
+**Symptoms**:
+- `verify_partial_deletion` fails because wrong entities are matched
+- Entities "found" in Qdrant that should be deleted
+- UUID collisions in vector storage
+
+**Solution**: Use **type-prefixed IDs** for internal tracking:
+```python
+ent = {
+    "type": "deal",
+    "id": f"deal_{pipedrive_id}",      # Unique internal ID: "deal_75"
+    "pipedrive_id": pipedrive_id,       # Raw API ID: 75
+    "token": token,
+    # ...
+}
+```
+- Use `id` for Monke tracking, comparison, and Qdrant paths
+- Use `pipedrive_id` (or equivalent) for actual API calls
+
+### Deletion Order for Linked Entities
+
+**Problem**: APIs often prevent deleting parent entities while children reference them.
+
+**Solution**: Delete in dependency order (children first):
+```python
+# Notes → Activities → Leads → Deals → Persons → Organizations → Products
+all_entities = (
+    self._notes           # Depend on persons/deals
+    + self._activities    # Depend on persons/deals/orgs
+    + self._leads         # Depend on persons/orgs
+    + self._deals         # Depend on persons/orgs
+    + self._persons       # Depend on orgs
+    + self._organizations # Independent
+    + self._products      # Independent
+)
+```
+
+### Token Embedding in Searchable Fields
+
+**Problem**: Qdrant verification searches for tokens. If the token isn't in an embeddable field, verification fails.
+
+**Solution**:
+1. Schema: Mark searchable fields with `embeddable=True` in Pydantic schemas
+2. Generator: Embed token in the searchable field (e.g., `title`, `name`, `content`)
+3. Bongo: Explicitly ensure token presence when creating:
+```python
+# Ensure token is in searchable field even if generator omits it
+title_with_token = f"{deal.title} [{token}]"
+payload = {"title": title_with_token, ...}
+```
+
+### Debugging Entity Verification
+
+Add diagnostic logging to trace what's being created vs what's searched:
+```python
+self.logger.info(f"📝 DIAGNOSTIC: Creating deal with title='{title_with_token}'")
+# After API response
+actual_title = deal_data.get("title", "")
+if token not in actual_title:
+    self.logger.warning(f"⚠️ Token {token} not in returned title: {actual_title}")
+```
+
+### Syntax Errors After Editing Bongos
+
+**Problem**: Indentation errors after multi-line edits to Python files.
+
+**Solution**: Always verify syntax after editing:
+```bash
+python3 -m py_compile monke/bongos/{connector}.py && echo "Syntax OK"
+```
+
+---

--- a/.vscode/run_worker_reload.py
+++ b/.vscode/run_worker_reload.py
@@ -1,6 +1,6 @@
-"""Development runner to hot-reload Temporal worker and attach debugger.
+"""Development runner to hot-reload Temporal worker and optionally attach debugger.
 
-Starts the worker under debugpy on a fixed port so VS Code can attach reliably.
+Starts the worker with optional debugpy support. Set AIRWEAVE_WORKER_DEBUG=true to enable.
 """
 
 import os
@@ -12,31 +12,44 @@ from watchfiles import run_process
 
 
 def build_worker_command() -> list[str]:
-    """Return the command list to start the worker under debugpy on a fixed port."""
-    port = os.getenv("AIRWEAVE_DEBUGPY_WORKER_PORT", "5679")
-    return [
-        sys.executable,
-        "-m",
-        "debugpy",
-        "--listen",
-        f"127.0.0.1:{port}",
-        "--wait-for-client",
-        "-m",
-        "airweave.platform.temporal.worker",
-    ]
+    """Return the command list to start the worker, optionally under debugpy."""
+    enable_debug = os.getenv("AIRWEAVE_WORKER_DEBUG", "false").lower() == "true"
+
+    if enable_debug:
+        port = os.getenv("AIRWEAVE_DEBUGPY_WORKER_PORT", "5679")
+        wait_for_client = os.getenv("AIRWEAVE_DEBUGPY_WAIT_FOR_CLIENT", "false").lower() == "true"
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "debugpy",
+            "--listen",
+            f"127.0.0.1:{port}",
+        ]
+
+        if wait_for_client:
+            cmd.append("--wait-for-client")
+
+        cmd.extend(["-m", "airweave.platform.temporal.worker"])
+    else:
+        # Run directly without debugpy
+        cmd = [sys.executable, "-m", "airweave.platform.temporal.worker"]
+
+    return cmd
 
 
 if __name__ == "__main__":
     backend_dir = Path(__file__).resolve().parents[1]
-    preferred_watch = backend_dir / "airweave"
+    preferred_watch = backend_dir / "backend" / "airweave"
     if preferred_watch.exists():
         watch_paths = [str(preferred_watch)]
     else:
+        fallback = backend_dir / "backend"
         print(
-            f"[dev] Watch path not found: {preferred_watch}. Falling back to backend root.",
+            f"[dev] Watch path not found: {preferred_watch}. Falling back to {fallback}.",
             flush=True,
         )
-        watch_paths = [str(backend_dir)]
+        watch_paths = [str(fallback)]
     cmd = build_worker_command()
     cmd_str = shlex.join(cmd)
     print("[dev] Starting Temporal worker:", cmd_str, flush=True)

--- a/monke/runner.py
+++ b/monke/runner.py
@@ -22,7 +22,7 @@ except ImportError:
 
 from monke.core import events
 from monke.core.runner import TestRunner
-from monke.utils.logging import get_logger
+from monke.utils.logging import get_logger, setup_file_logging
 
 # Check if we're in CI environment
 IS_CI = os.getenv("CI") == "true" or os.getenv("GITHUB_ACTIONS") == "true"
@@ -316,6 +316,10 @@ Examples:
     parser.add_argument("--no-ui", action="store_true", help="Disable Rich UI even if available")
 
     args = parser.parse_args()
+
+     # Set up file logging
+    log_dir = setup_file_logging()
+    print(f"📝 Logs will be written to: {log_dir}/monke.log")
 
     # Load environment variables (if not in CI)
     if load_dotenv and not IS_CI:


### PR DESCRIPTION
## Summary

Quality-of-life improvements for local development workflow.

## Changes

### Temporal Worker Hot-Reload Script (`.vscode/run_worker_reload.py`)
- **Make debugpy optional**: Worker now starts without debugpy by default. Set `AIRWEAVE_WORKER_DEBUG=true` to enable debugging
- **Make `--wait-for-client` optional**: No longer blocks startup waiting for debugger. Set `AIRWEAVE_DEBUGPY_WAIT_FOR_CLIENT=true` if needed
- **Fix watch paths**: Corrected paths for file watching to properly detect changes

### Temporal Worker Graceful Shutdown (`worker.py`)
- **Fix AttributeError on shutdown**: Handle case where metrics server isn't fully initialized during cleanup, preventing crashes during worker shutdown

### Monke Documentation (`.cursor/rules/monke.mdc`)
- **Added troubleshooting guide** covering:
  - Entity ID collisions across types (use type-prefixed IDs)
  - Deletion order for linked entities (children before parents)
  - Token embedding in searchable fields
  - Debugging entity verification
  - Syntax error prevention

### Minor Changes
- Minor import reorganization in worker.py
- Monke logging improvements

## Testing
- Verified worker starts without debugger blocking
- Verified graceful shutdown works when metrics server not initialized

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves local dev workflow by making the Temporal worker debugger optional, fixing hot-reload paths, and adding Monke logging and troubleshooting docs for faster debugging.

- **New Features**
  - Optional debugpy for the worker: set AIRWEAVE_WORKER_DEBUG=true; to wait on attach set AIRWEAVE_DEBUGPY_WAIT_FOR_CLIENT=true.
  - Monke now writes timestamped logs to monke/logs and prints the path to the console.
  - Added troubleshooting guide covering ID collisions, deletion order, token embedding, verification diagnostics, and syntax checks.

- **Bug Fixes**
  - Graceful worker shutdown even if the metrics server isn’t fully initialized.
  - Corrected VS Code hot-reload watch paths to backend/airweave with a safe fallback to backend.

<sup>Written for commit 23a04fcd3955a7758a0ce39365cf4a089d7ad7d8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

