### PR TITLE
feat(zephyr): syncing zephyr jira entities behind feature flag

### DIFF
--- a/backend/airweave/core/shared_models.py
+++ b/backend/airweave/core/shared_models.py
@@ -101,6 +101,7 @@ class FeatureFlag(str, Enum):
     S3_DESTINATION = "s3_destination"
     PRIORITY_SUPPORT = "priority_support"
     SOURCE_RATE_LIMITING = "source_rate_limiting"
+    ZEPHYR_SCALE = "zephyr_scale"  # Enables Zephyr Scale test management sync for Jira
 
 
 class AuthMethod(str, Enum):

--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -303,6 +303,19 @@ class JiraConfig(SourceConfig):
         min_length=1,
     )
 
+    # Zephyr Scale integration (requires ZEPHYR_SCALE feature flag)
+    # This field is dynamically shown/hidden based on organization feature flags
+    zephyr_scale_api_token: Optional[str] = Field(
+        default=None,
+        title="Zephyr Scale API Token",
+        description=(
+            "API token for Zephyr Scale test management integration. "
+            "Generate in Jira > Apps > Zephyr Scale > API Keys. "
+            "Leave empty if not using Zephyr Scale."
+        ),
+        json_schema_extra={"feature_flag": "zephyr_scale", "is_secret": True},
+    )
+
 
 class LinearConfig(SourceConfig):
     """Linear configuration schema."""

--- a/backend/airweave/platform/entities/jira.py
+++ b/backend/airweave/platform/entities/jira.py
@@ -1,7 +1,9 @@
 """Jira entity schemas.
 
-Simplified entity schemas for Jira Projects and Issues to demonstrate
-Airweave's capabilities with minimal complexity.
+Entity schemas for Jira Projects, Issues, and Zephyr Scale test management entities.
+
+Zephyr Scale is a test management plugin for Jira that creates separate entities
+(Test Cases, Test Cycles, Test Plans) accessible via the Zephyr Scale API.
 """
 
 from datetime import datetime
@@ -83,4 +85,179 @@ class JiraIssueEntity(BaseEntity):
     @computed_field(return_type=str)
     def web_url(self) -> str:
         """UI link for the Jira issue."""
+        return self.web_url_value or ""
+
+
+# =============================================================================
+# Zephyr Scale Entities
+# =============================================================================
+# These entities are from the Zephyr Scale test management plugin for Jira.
+# They are accessed via the Zephyr Scale API (https://api.zephyrscale.smartbear.com/v2),
+# not the Jira REST API, and require a separate Zephyr Scale API token.
+
+
+class ZephyrTestCaseEntity(BaseEntity):
+    """Schema for a Zephyr Scale Test Case.
+
+    Test cases have keys in the format PROJECT-T<number> (e.g., PROJ-T1, PROJ-T2).
+
+    Reference:
+        https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cases
+    """
+
+    test_case_id: str = AirweaveField(
+        ..., description="Unique internal identifier for the test case.", is_entity_id=True
+    )
+    test_case_key: str = AirweaveField(
+        ...,
+        description="Zephyr Scale key for the test case (e.g., 'PROJ-T1').",
+        embeddable=True,
+    )
+    name: str = AirweaveField(
+        ..., description="Name/title of the test case.", embeddable=True, is_name=True
+    )
+    objective: Optional[str] = AirweaveField(
+        None, description="Objective or purpose of the test case.", embeddable=True
+    )
+    precondition: Optional[str] = AirweaveField(
+        None, description="Preconditions required before executing the test.", embeddable=True
+    )
+    status_name: Optional[str] = AirweaveField(
+        None,
+        description="Current status of the test case (e.g., Draft, Approved).",
+        embeddable=True,
+    )
+    priority_name: Optional[str] = AirweaveField(
+        None, description="Priority level of the test case.", embeddable=True
+    )
+    folder_path: Optional[str] = AirweaveField(
+        None, description="Folder path where the test case is organized.", embeddable=True
+    )
+    project_key: str = AirweaveField(
+        ..., description="Key of the Jira project this test case belongs to.", embeddable=True
+    )
+    created_time: datetime = AirweaveField(
+        ..., description="Timestamp when the test case was created.", is_created_at=True
+    )
+    updated_time: datetime = AirweaveField(
+        ..., description="Timestamp when the test case was last updated.", is_updated_at=True
+    )
+    web_url_value: Optional[str] = AirweaveField(
+        None,
+        description="Link to the test case in Zephyr Scale.",
+        embeddable=False,
+        unhashable=True,
+    )
+
+    @computed_field(return_type=str)
+    def web_url(self) -> str:
+        """UI link for the Zephyr Scale test case."""
+        return self.web_url_value or ""
+
+
+class ZephyrTestCycleEntity(BaseEntity):
+    """Schema for a Zephyr Scale Test Cycle.
+
+    Test cycles have keys in the format PROJECT-R<number> (e.g., PROJ-R1, PROJ-R2).
+    They represent a collection of test executions for a specific testing iteration.
+
+    Reference:
+        https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cycles
+    """
+
+    test_cycle_id: str = AirweaveField(
+        ..., description="Unique internal identifier for the test cycle.", is_entity_id=True
+    )
+    test_cycle_key: str = AirweaveField(
+        ...,
+        description="Zephyr Scale key for the test cycle (e.g., 'PROJ-R1').",
+        embeddable=True,
+    )
+    name: str = AirweaveField(
+        ..., description="Name/title of the test cycle.", embeddable=True, is_name=True
+    )
+    description: Optional[str] = AirweaveField(
+        None, description="Description of the test cycle.", embeddable=True
+    )
+    status_name: Optional[str] = AirweaveField(
+        None,
+        description="Current status of the test cycle (e.g., Not Executed, In Progress, Done).",
+        embeddable=True,
+    )
+    folder_path: Optional[str] = AirweaveField(
+        None, description="Folder path where the test cycle is organized.", embeddable=True
+    )
+    project_key: str = AirweaveField(
+        ..., description="Key of the Jira project this test cycle belongs to.", embeddable=True
+    )
+    created_time: datetime = AirweaveField(
+        ..., description="Timestamp when the test cycle was created.", is_created_at=True
+    )
+    updated_time: datetime = AirweaveField(
+        ..., description="Timestamp when the test cycle was last updated.", is_updated_at=True
+    )
+    web_url_value: Optional[str] = AirweaveField(
+        None,
+        description="Link to the test cycle in Zephyr Scale.",
+        embeddable=False,
+        unhashable=True,
+    )
+
+    @computed_field(return_type=str)
+    def web_url(self) -> str:
+        """UI link for the Zephyr Scale test cycle."""
+        return self.web_url_value or ""
+
+
+class ZephyrTestPlanEntity(BaseEntity):
+    """Schema for a Zephyr Scale Test Plan.
+
+    Test plans have keys in the format PROJECT-P<number> (e.g., PROJ-P1, PROJ-P2).
+    They represent a high-level collection of test cycles for release planning.
+
+    Reference:
+        https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Plans
+    """
+
+    test_plan_id: str = AirweaveField(
+        ..., description="Unique internal identifier for the test plan.", is_entity_id=True
+    )
+    test_plan_key: str = AirweaveField(
+        ...,
+        description="Zephyr Scale key for the test plan (e.g., 'PROJ-P1').",
+        embeddable=True,
+    )
+    name: str = AirweaveField(
+        ..., description="Name/title of the test plan.", embeddable=True, is_name=True
+    )
+    objective: Optional[str] = AirweaveField(
+        None, description="Objective or purpose of the test plan.", embeddable=True
+    )
+    status_name: Optional[str] = AirweaveField(
+        None,
+        description="Current status of the test plan (e.g., Draft, Approved, Archived).",
+        embeddable=True,
+    )
+    folder_path: Optional[str] = AirweaveField(
+        None, description="Folder path where the test plan is organized.", embeddable=True
+    )
+    project_key: str = AirweaveField(
+        ..., description="Key of the Jira project this test plan belongs to.", embeddable=True
+    )
+    created_time: datetime = AirweaveField(
+        ..., description="Timestamp when the test plan was created.", is_created_at=True
+    )
+    updated_time: datetime = AirweaveField(
+        ..., description="Timestamp when the test plan was last updated.", is_updated_at=True
+    )
+    web_url_value: Optional[str] = AirweaveField(
+        None,
+        description="Link to the test plan in Zephyr Scale.",
+        embeddable=False,
+        unhashable=True,
+    )
+
+    @computed_field(return_type=str)
+    def web_url(self) -> str:
+        """UI link for the Zephyr Scale test plan."""
         return self.web_url_value or ""


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Zephyr Scale sync to the Jira source behind the zephyr_scale feature flag. Orgs with the flag and a Zephyr API token can sync test cases, cycles, and plans; others won’t see or use Zephyr fields.

- **New Features**
  - Sync Zephyr Scale entities (Test Cases, Test Cycles, Test Plans) when zephyr_scale is enabled and zephyr_scale_api_token is set.
  - New zephyr_scale feature flag and secret config field zephyr_scale_api_token; config fields are hidden when the flag is off.
  - Retry helpers now cover connection errors and log backoff attempts.

- **Refactors**
  - API enforces feature-flagged config fields and returns 403 if a hidden field is used via API.
  - Jira source supports JiraAuthConfig and credential dicts (including rotating refresh).
  - Sync factory prefetches oauth_type and source_connection_id to avoid lazy loading issues.

<sup>Written for commit 4940a89bae9fd46f877f5c44ff2c9b1526fbbf5f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

