### PR TITLE
fix: update default redirect URL in SourceConfigView 

### DIFF
--- a/frontend/src/components/creation-views/SourceConfigView.tsx
+++ b/frontend/src/components/creation-views/SourceConfigView.tsx
@@ -113,7 +113,8 @@ export const SourceConfigView: React.FC<SourceConfigViewProps> = ({ humanReadabl
   const getDefaultRedirectUrl = () => {
     const origin = window.location.origin;
     // Use the current protocol (don't force HTTPS for local dev)
-    return `${origin}?oauth_return=true`;
+    // Include /collections path so the OAuth callback is handled correctly
+    return `${origin}/collections?oauth_return=true`;
   };
 
   // Update store when connection name changes


### PR DESCRIPTION
update default redirect URL in SourceConfigView to include /collections path for correct OAuth handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the default OAuth redirect in SourceConfigView to use /collections?oauth_return=true so callbacks are handled by the correct route.

<sup>Written for commit df0a03001404a776992bd2890d2106fbf8b1dbc4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

