### PR TITLE
refactor: update QueryKeywords to use a list for keywords with enforc…

### DIFF
--- a/backend/airweave/search/operations/federated_search.py
+++ b/backend/airweave/search/operations/federated_search.py
@@ -6,7 +6,7 @@ with vector database results using Reciprocal Rank Fusion (RRF).
 """
 
 import asyncio
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 from pydantic import BaseModel, Field
 
@@ -24,12 +24,14 @@ class QueryKeywords(BaseModel):
     model_config = {"extra": "forbid"}
 
     # Enforce exactly 5 keywords using a fixed-size tuple (Cerebras prefixItems)
-    keywords: Tuple[str, str, str, str, str] = Field(
+    keywords: List[str] = Field(
         description=(
             "Return EXACTLY 5 highly relevant keywords or short phrases. Include a mix of "
             "single words and 2-3 word phrases that best represent the shared intent. "
             "These will be used directly in search API queries."
-        )
+        ),
+        min_length=5,
+        max_length=5,
     )
 
 


### PR DESCRIPTION
## Fix: Keywords Schema in Slack Federated Search

- Fixes OpenAI structured output schema error causing `Error Code 400`
- Replaced tuple-like keywords with `List[str]`
- Enforced exact length using `min_length=5` and `max_length=5`
- Resolves `array schema missing items` error
- OpenAI API now returns 200


<img width="1085" height="480" alt="Screenshot 2025-12-17 at 7 59 36 PM" src="https://github.com/user-attachments/assets/7ea4ab80-1647-4839-8885-55684457a9d3" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch QueryKeywords.keywords from a fixed tuple to List[str] with min/max length of 5 to fix the structured output schema in Slack Federated Search. Resolves OpenAI 400 "array schema missing items" and restores successful responses.

<sup>Written for commit 4064eeedd98814ba3816c4965273046bc54fb8ea. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

