### PR TITLE
feat: allow more margin for test retries

### DIFF
--- a/.github/workflows/test-public-api.yml
+++ b/.github/workflows/test-public-api.yml
@@ -179,8 +179,8 @@ jobs:
           echo "Detected $FAILURES test failure(s)"
 
           # If 3 or more failures, don't retry
-          if [ "$FAILURES" -ge 3 ]; then
-            echo "3 or more tests failed. Not retrying."
+          if [ "$FAILURES" -ge 5 ]; then
+            echo "5 or more tests failed. Not retrying."
             exit 1
           fi
 
@@ -191,7 +191,7 @@ jobs:
             echo "=========================================="
             echo "Retry attempt $ATTEMPT of $MAX_RETRIES (running ONLY failed tests)"
             echo "=========================================="
-            sleep 5
+            sleep 10
 
             set +e
             pytest tests/e2e/smoke -m "not rate_limit" --lf -n 3 -v --tb=short 2>&1 | tee pytest_retry_output.txt


### PR DESCRIPTION
Increases the threshold for test failures before halting retries to 5, aiming to reduce false negatives due to transient issues.

Also increases the sleep duration before retries to 10 seconds, giving the system more time to stabilize between attempts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase tolerance for flaky E2E tests to reduce false negatives in the public API workflow. We now stop retrying only when 5+ tests fail and wait 10s before each retry to let services stabilize.

<sup>Written for commit 9c4dd939de32665fe548f917b1c19e3c6477db05. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

