### PR TITLE
feat(search): enrich logger with collection context at factory time

### DIFF
--- a/backend/airweave/search/factory.py
+++ b/backend/airweave/search/factory.py
@@ -67,6 +67,9 @@ class SearchFactory:
         db: AsyncSession,
     ) -> SearchContext:
         """Build SearchContext from request with validated YAML defaults."""
+        # Enrich logger with collection context for all downstream logs
+        ctx.logger = ctx.logger.with_context(collection=readable_collection_id)
+
         if not search_request.query or not search_request.query.strip():
             raise HTTPException(status_code=422, detail="Query is required")
 


### PR DESCRIPTION
Add collection readable_id to logger context in SearchFactory.build() so all downstream search operations include collection in their logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the collection readable_id to the search logger context during SearchFactory.build() so all downstream search logs include the collection. This improves traceability and makes log filtering by collection straightforward.

<sup>Written for commit af0aa8bb1b432227600b99649743568af9768675. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

