### PR TITLE
fix(chunkers): add encode_batch method to TiktokenWrapperForChonkie

### DIFF
--- a/backend/airweave/platform/chunkers/tiktoken_wrapper.py
+++ b/backend/airweave/platform/chunkers/tiktoken_wrapper.py
@@ -7,7 +7,7 @@ AutoTokenizer._get_backend() detects it as a tiktoken backend via the type strin
 This ensures our encode() method (with allowed_special="all") is called.
 """
 
-from typing import Sequence, Union
+from typing import List, Sequence, Union
 
 
 class TiktokenWrapperForChonkie:
@@ -44,6 +44,17 @@ class TiktokenWrapperForChonkie:
             Sequence of token IDs
         """
         return self._encoding.encode(text, allowed_special="all")
+
+    def encode_batch(self, texts: List[str]) -> List[List[int]]:
+        """Encode multiple texts to token IDs, allowing all special tokens.
+
+        Args:
+            texts: List of texts to encode
+
+        Returns:
+            List of token ID sequences
+        """
+        return [self._encoding.encode(text, allowed_special="all") for text in texts]
 
     def decode(self, tokens: Sequence[int]) -> str:
         """Decode token IDs back to text.


### PR DESCRIPTION
Chonkie's SemanticChunker now calls encode_batch on the tokenizer, which was missing from our custom wrapper. This caused sync failures with: 'TiktokenWrapperForChonkie' object has no attribute 'encode_batch'

The new method encodes multiple texts with allowed_special='all' to maintain compatibility with special tokens like <|endoftext|>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sync failures in Chonkie’s SemanticChunker by adding encode_batch to TiktokenWrapperForChonkie. The method encodes multiple texts with allowed_special='all' to preserve special tokens (e.g., <|endoftext|>).

<sup>Written for commit d97ef502407c6cce0545c71c9265fbee3a661dfe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

