### PR TITLE
fix(chunkers): add encode_batch and decode_batch methods to TiktokenWrapperForChonkie

### DIFF
--- a/backend/airweave/platform/chunkers/tiktoken_wrapper.py
+++ b/backend/airweave/platform/chunkers/tiktoken_wrapper.py
@@ -7,7 +7,7 @@ AutoTokenizer._get_backend() detects it as a tiktoken backend via the type strin
 This ensures our encode() method (with allowed_special="all") is called.
 """
 
-from typing import Sequence, Union
+from typing import List, Sequence, Union
 
 
 class TiktokenWrapperForChonkie:
@@ -45,6 +45,17 @@ class TiktokenWrapperForChonkie:
         """
         return self._encoding.encode(text, allowed_special="all")
 
+    def encode_batch(self, texts: List[str]) -> List[List[int]]:
+        """Encode multiple texts to token IDs, allowing all special tokens.
+
+        Args:
+            texts: List of texts to encode
+
+        Returns:
+            List of token ID sequences
+        """
+        return [self._encoding.encode(text, allowed_special="all") for text in texts]
+
     def decode(self, tokens: Sequence[int]) -> str:
         """Decode token IDs back to text.
 
@@ -55,6 +66,17 @@ class TiktokenWrapperForChonkie:
             Decoded text string
         """
         return self._encoding.decode(list(tokens))
+
+    def decode_batch(self, token_lists: List[List[int]]) -> List[str]:
+        """Decode multiple token sequences back to text.
+
+        Args:
+            token_lists: List of token ID sequences
+
+        Returns:
+            List of decoded text strings
+        """
+        return [self._encoding.decode(tokens) for tokens in token_lists]
 
     def tokenize(self, text: str) -> Sequence[Union[str, int]]:
         """Tokenize text into token IDs.


### PR DESCRIPTION
## Summary

Chonkie's SemanticChunker now calls `encode_batch`/`decode_batch` on the tokenizer, which were missing from our custom wrapper. This caused sync failures with:

```
SyncFailureError: SemanticChunker failed: 'TiktokenWrapperForChonkie' object has no attribute 'encode_batch'
```

## Changes

Added `encode_batch` and `decode_batch` methods to `TiktokenWrapperForChonkie` that handle batches with `allowed_special='all'` to maintain compatibility with special tokens like `<|endoftext|>`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed sync failures by adding encode_batch and decode_batch to TiktokenWrapperForChonkie to match SemanticChunker’s API. Both methods handle batches and allow all special tokens (allowed_special="all") for compatibility.

<sup>Written for commit 30da5108ca28fe64e01120dad825e594b4777c46. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

