### PR TITLE
Fix: Use AsyncCerebras to prevent backend freeze during search

### DIFF
--- a/backend/airweave/platform/chunkers/semantic.py
+++ b/backend/airweave/platform/chunkers/semantic.py
@@ -191,8 +191,7 @@ class SemanticChunker(BaseChunker):
         for doc_chunks in final_results:
             # Remove empty chunks in-place
             doc_chunks[:] = [
-                chunk for chunk in doc_chunks
-                if chunk["text"] and chunk["text"].strip()
+                chunk for chunk in doc_chunks if chunk["text"] and chunk["text"].strip()
             ]
 
             for chunk in doc_chunks:

--- a/backend/airweave/search/providers/cerebras.py
+++ b/backend/airweave/search/providers/cerebras.py
@@ -7,7 +7,7 @@ Does not support embeddings or reranking.
 import json
 from typing import Any, Dict, List, Optional
 
-from cerebras.cloud.sdk import Cerebras
+from cerebras.cloud.sdk import AsyncCerebras
 from pydantic import BaseModel
 from tiktoken import Encoding
 
@@ -28,7 +28,8 @@ class CerebrasProvider(BaseProvider):
         super().__init__(api_key, model_spec, ctx)
 
         try:
-            self.client = Cerebras(api_key=api_key)
+            # Set 30s timeout to prevent indefinite hangs
+            self.client = AsyncCerebras(api_key=api_key, timeout=30.0)
         except Exception as e:
             raise RuntimeError(f"Failed to initialize Cerebras client: {e}") from e
 
@@ -48,7 +49,7 @@ class CerebrasProvider(BaseProvider):
             raise ValueError("Cannot generate completion with empty messages")
 
         try:
-            response = self.client.chat.completions.create(
+            response = await self.client.chat.completions.create(
                 model=self.model_spec.llm_model.name,
                 messages=messages,
                 max_completion_tokens=self.MAX_COMPLETION_TOKENS,
@@ -88,7 +89,7 @@ class CerebrasProvider(BaseProvider):
 
         try:
             # Strict schema mode (preferred)
-            response = self.client.chat.completions.create(
+            response = await self.client.chat.completions.create(
                 model=self.model_spec.llm_model.name,
                 messages=messages,
                 response_format={


### PR DESCRIPTION
Tested in dev.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents backend freezes during search by making Cerebras requests non-blocking and bounded.

- **Bug Fixes**
  - Instantiate AsyncCerebras in the provider.
  - Await chat.completions.create in generate and structured_output.
  - Add a 30s client timeout to avoid indefinite hangs.

<sup>Written for commit 78ab8ae9d9010d3f57726449e7186ec6837dbad4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



