### PR TITLE
feat(docker): add Vespa alongside Qdrant for dual vector store support

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -120,8 +120,27 @@ services:
       timeout: 5s
       retries: 3
     restart: on-failure
+  # Vespa single-node for development (config server + content + container combined)
+  vespa:
+    container_name: airweave-vespa
+    image: vespaengine/vespa:8
+    hostname: vespa
+    ports:
+      - "8081:8081"   # Query/Document API
+      - "19071:19071" # Config server (for deployment)
+    volumes:
+      - vespa_data:/opt/vespa/var
+      - ./vespa-config:/app
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:19071/state/v1/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+    restart: on-failure
+
 volumes:
   postgres_data:
   redis_data:
   qdrant_data:
   minio_data:
+  vespa_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -214,7 +214,26 @@ services:
         condition: service_healthy
     restart: on-failure
 
+  # Vespa single-node for development (config server + content + container combined)
+  vespa:
+    container_name: airweave-vespa
+    image: vespaengine/vespa:8
+    hostname: vespa
+    ports:
+      - "8081:8081"   # Query/Document API
+      - "19071:19071" # Config server (for deployment)
+    volumes:
+      - vespa_data:/opt/vespa/var
+      - ./vespa-config:/app
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:19071/state/v1/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+    restart: on-failure
+
 volumes:
   postgres_data:
   redis_data:
   qdrant_data:
+  vespa_data:

--- a/docker/vespa-config/deploy.sh
+++ b/docker/vespa-config/deploy.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deploy Vespa application package to config server
+# Usage: ./deploy.sh [config_server_url]
+
+CONFIG_SERVER="${1:-http://localhost:19071}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Waiting for config server to be ready at ${CONFIG_SERVER}..."
+until curl -s "${CONFIG_SERVER}/state/v1/health" | grep -q '"up"'; do
+    echo "  Config server not ready, waiting..."
+    sleep 5
+done
+echo "Config server is ready!"
+
+echo ""
+echo "Creating application package zip..."
+cd "${SCRIPT_DIR}"
+rm -f app.zip
+zip -r app.zip hosts.xml services.xml schemas/ -x ".*" -x "deploy.sh" -x "app.zip"
+
+echo ""
+echo "Deploying application package..."
+curl -s --header "Content-Type:application/zip" \
+    --data-binary @app.zip \
+    "${CONFIG_SERVER}/application/v2/tenant/default/prepareandactivate" | jq .
+
+echo ""
+echo "Deployment complete!"
+echo ""
+echo "Waiting for application to be ready..."
+sleep 10
+
+echo ""
+echo "Checking cluster status..."
+curl -s "${CONFIG_SERVER}/application/v2/tenant/default/application/default/environment/prod/region/default/instance/default/serviceconverge" | jq .
+
+echo ""
+echo "=== Vespa is ready! ==="
+echo ""
+echo "Test document API:"
+echo "  curl http://localhost:8081/document/v1/airweave/chunk/docid/test1"
+echo ""

--- a/docker/vespa-config/hosts.xml
+++ b/docker/vespa-config/hosts.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<hosts>
+  <!-- Single-node development setup -->
+  <host name="localhost">
+    <alias>node1</alias>
+  </host>
+</hosts>

--- a/docker/vespa-config/schemas/chunk.sd
+++ b/docker/vespa-config/schemas/chunk.sd
@@ -1,0 +1,126 @@
+schema chunk {
+    document chunk {
+        field entity_id type string {
+            indexing: summary | attribute
+            attribute: fast-search
+        }
+
+        field collection_id type string {
+            indexing: summary | attribute
+            attribute: fast-search
+            rank: filter
+        }
+
+        field organization_id type string {
+            indexing: summary | attribute
+            attribute: fast-search
+            rank: filter
+        }
+
+        field sync_id type string {
+            indexing: summary | attribute
+            attribute: fast-search
+        }
+
+        field db_entity_id type string {
+            indexing: summary | attribute
+            attribute: fast-search
+        }
+
+        field original_entity_id type string {
+            indexing: summary | attribute
+            attribute: fast-search
+        }
+
+        field source_name type string {
+            indexing: summary | attribute
+            attribute: fast-search
+        }
+
+        field content type string {
+            indexing: summary | index
+            index: enable-bm25
+        }
+
+        field title type string {
+            indexing: summary | index
+            index: enable-bm25
+        }
+
+        field embedding type tensor<bfloat16>(x[3072]) {
+            indexing: attribute | index
+            attribute {
+                distance-metric: angular
+                paged
+            }
+            index {
+                hnsw {
+                    max-links-per-node: 16
+                    neighbors-to-explore-at-insert: 200
+                }
+            }
+        }
+
+        field metadata type string {
+            indexing: summary | attribute
+        }
+
+        field breadcrumbs type array<string> {
+            indexing: summary | attribute
+        }
+
+        field url type string {
+            indexing: summary | attribute
+        }
+
+        field updated_at type long {
+            indexing: summary | attribute
+            attribute: fast-search
+        }
+
+        field created_at type long {
+            indexing: summary | attribute
+            attribute: fast-search
+        }
+    }
+
+    fieldset default {
+        fields: content, title
+    }
+
+    rank-profile default {
+        inputs {
+            query(embedding) tensor<bfloat16>(x[3072])
+        }
+        first-phase {
+            expression: closeness(field, embedding)
+        }
+    }
+
+    rank-profile hybrid inherits default {
+        first-phase {
+            expression: closeness(field, embedding) + bm25(content) + bm25(title)
+        }
+    }
+
+    rank-profile neural inherits default {
+        first-phase {
+            expression: closeness(field, embedding)
+        }
+    }
+
+    rank-profile keyword {
+        first-phase {
+            expression: bm25(content) + bm25(title)
+        }
+    }
+
+    rank-profile hybrid_temporal inherits hybrid {
+        function recency() {
+            expression: if(attribute(updated_at) > 0, 1 / (1 + age(updated_at)), 0)
+        }
+        first-phase {
+            expression: closeness(field, embedding) + bm25(content) + bm25(title) + 0.1 * recency
+        }
+    }
+}

--- a/docker/vespa-config/services.xml
+++ b/docker/vespa-config/services.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<services version="1.0">
+
+  <admin version="2.0">
+    <adminserver hostalias="node1"/>
+  </admin>
+
+  <!-- Container cluster: handles queries and document API -->
+  <container id="default" version="1.0">
+    <http>
+      <server id="default" port="8081"/>
+    </http>
+    <search/>
+    <document-api/>
+    <document-processing/>
+    <nodes>
+      <node hostalias="node1"/>
+    </nodes>
+  </container>
+
+  <!-- Content cluster: stores and indexes documents -->
+  <content id="airweave" version="1.0">
+    <redundancy>1</redundancy>
+    <documents>
+      <document type="chunk" mode="index"/>
+    </documents>
+    <nodes>
+      <node hostalias="node1" distribution-key="0"/>
+    </nodes>
+  </content>
+
+</services>


### PR DESCRIPTION
## Summary
Adds Vespa as a second vector store option alongside Qdrant in the Docker Compose configuration.

## Changes
- Add single-node Vespa service to `docker-compose.yml` and `docker-compose.dev.yml`
- Add `docker/vespa-config/` with configuration files:
  - `hosts.xml` - Single-node host configuration
  - `services.xml` - Container & content cluster config
  - `schemas/chunk.sd` - Chunk schema with hybrid search rank profiles
  - `deploy.sh` - Script to deploy the application package

## Ports
| Service | Port | Purpose |
|---------|------|---------|
| Qdrant | 6333 | Existing vector store |
| Vespa | 8081 | Query/Document API |
| Vespa | 19071 | Config server (for deployment) |

## Usage
After starting the containers:
```bash
docker compose -f docker/docker-compose.dev.yml up -d

# Wait for Vespa to be healthy, then deploy the app config:
cd docker/vespa-config && ./deploy.sh
```

## Notes
- Vespa runs as a single-node setup (config server + container + content combined) - ideal for dev
- Both Qdrant and Vespa run simultaneously, allowing gradual migration or A/B testing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Vespa as a second vector store in Docker Compose, running alongside Qdrant to enable dual-store development and gradual migration or A/B testing.

- **New Features**
  - Vespa single-node service in docker-compose (ports 8081 API, 19071 config) with persistent volume.
  - Vespa app package under docker/vespa-config (hosts.xml, services.xml, schemas/chunk.sd with hybrid rank profiles).
  - deploy.sh to zip and deploy the app to the Vespa config server.
  - Qdrant remains unchanged; both stores can run together.

- **Migration**
  - Start services: docker compose -f docker/docker-compose.dev.yml up -d
  - Deploy Vespa app: cd docker/vespa-config && ./deploy.sh

<sup>Written for commit 56270cfb4808c97915b3f7799ce6452d257cd929. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

