### PR TITLE
feat: exclude local storage from hot reload

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,8 @@
             "module": "uvicorn",
             "args": [
                 "--reload",
+                "--reload-exclude",
+                "local_storage",
                 "--host",
                 "127.0.0.1",
                 "--port",


### PR DESCRIPTION
Configures the development environment to ignore changes within the local storage directory during hot reloading. This prevents unnecessary restarts when data changes occur in local storage, improving development efficiency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the local_storage directory from Uvicorn hot reload to prevent unnecessary restarts when local data changes. Updated .vscode/launch.json to pass --reload-exclude local_storage for a smoother dev loop.

<sup>Written for commit 5820b5c0b3047b02d5daf6ff27f707f4a637b6d1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

