### PR TITLE
docs: add new links for LlamaIndex and Vercel AI SDK integrations

### DIFF
--- a/fern/docs/pages/framework-integrations/llamaindex.mdx
+++ b/fern/docs/pages/framework-integrations/llamaindex.mdx
@@ -239,4 +239,5 @@ agent = FunctionAgent(
 ### Learn More
 
 - [LlamaIndex Documentation](https://docs.llamaindex.ai/)
+- [LlamaIndex Airweave Tool on LlamaHub](https://llamahub.ai/l/tools/llama-index-tools-airweave?from=all)
 - [Airweave GitHub](https://github.com/airweave-ai/airweave)

--- a/fern/docs/pages/framework-integrations/vercel-ai-sdk.mdx
+++ b/fern/docs/pages/framework-integrations/vercel-ai-sdk.mdx
@@ -135,5 +135,5 @@ interface AirweaveSearchResultItem {
 ### Learn More
 
 - [Vercel AI SDK Documentation](https://ai-sdk.dev/docs/introduction)
-
+- [Airweave on Vercel Tool Registry](https://ai-sdk.dev/tools-registry/airweave)
 - [Airweave GitHub](https://github.com/airweave-ai/airweave)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added resource links to the LlamaIndex and Vercel AI SDK integration docs to make Airweave tools easier to find. Includes links to the LlamaHub Airweave Tool and the Vercel AI SDK Tools Registry entry.

<sup>Written for commit 6c5c39375fe495fae37d1b228296ac642a575349. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

