### PR TITLE
 feat(sync): add SyncExecutionConfig for database-persisted sync behavior control

### DIFF
--- a/backend/airweave/api/v1/endpoints/sync.py
+++ b/backend/airweave/api/v1/endpoints/sync.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import json
-from typing import AsyncGenerator, List, Optional, Union
+from typing import Any, AsyncGenerator, List, Optional, Union
 from uuid import UUID
 
 from fastapi import BackgroundTasks, Body, Depends, HTTPException, Query
@@ -175,6 +175,7 @@ async def run_sync(
     sync_id: UUID,
     ctx: ApiContext = Depends(deps.get_context),
     background_tasks: BackgroundTasks,
+    execution_config: Optional[dict[str, Any]] = None,
 ) -> schemas.SyncJob:
     """Trigger a sync run.
 
@@ -184,13 +185,16 @@ async def run_sync(
         sync_id: The ID of the sync to run
         ctx: The current authentication context
         background_tasks: The background tasks
+        execution_config: Optional execution config for controlling sync behavior
 
     Returns:
     --------
         sync_job (schemas.SyncJob): The sync job
     """
     # Trigger the sync run - kinda, not really, we'll do that in the background
-    sync, sync_job = await sync_service.trigger_sync_run(db=db, sync_id=sync_id, ctx=ctx)
+    sync, sync_job = await sync_service.trigger_sync_run(
+        db=db, sync_id=sync_id, ctx=ctx, execution_config=execution_config
+    )
 
     # Get collection and source connection for sync.run
     source_conn = await crud.source_connection.get_by_sync_id(db=db, sync_id=sync.id, ctx=ctx)

--- a/backend/airweave/models/sync_job.py
+++ b/backend/airweave/models/sync_job.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
 from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Index, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from airweave.core.shared_models import SyncJobStatus
@@ -35,6 +36,7 @@ class SyncJob(OrganizationBase, UserMixin):
     error: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     entities_encountered: Mapped[Optional[dict]] = mapped_column(JSON, default={})
     scheduled: Mapped[bool] = mapped_column(Boolean, default=False)
+    execution_config_json: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
 
     sync: Mapped["Sync"] = relationship(
         "Sync",

--- a/backend/airweave/platform/sync/config.py
+++ b/backend/airweave/platform/sync/config.py
@@ -1,0 +1,78 @@
+"""Sync execution configuration for controlling sync behavior."""
+
+import warnings
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class SyncExecutionConfig(BaseModel):
+    """Declarative sync execution configuration.
+
+    Each component reads only the flags it needs - highly modular.
+    Config is persisted in sync_job.execution_config_json to avoid Temporal bloat.
+    """
+
+    # Destination selection
+    target_destinations: Optional[List[UUID]] = Field(
+        None, description="If set, ONLY write to these destinations"
+    )
+    exclude_destinations: Optional[List[UUID]] = Field(None, description="Skip these destinations")
+
+    # Handler toggles
+    enable_vector_handlers: bool = Field(True, description="Enable VectorDBHandler")
+    enable_raw_data_handler: bool = Field(True, description="Enable RawDataHandler (ARF)")
+    enable_postgres_handler: bool = Field(True, description="Enable PostgresMetadataHandler")
+
+    # Behavior flags
+    skip_hash_comparison: bool = Field(False, description="Force INSERT for all entities")
+    skip_cursor_load: bool = Field(False, description="Don't load cursor (fetch all entities)")
+    skip_cursor_updates: bool = Field(
+        False, description="Don't save cursor progress (for ARF-only syncs)"
+    )
+
+    @model_validator(mode="after")
+    def validate_config_logic(self):
+        """Validate that config combinations make sense."""
+
+        # 1. Detect conflicts between target and exclude destinations
+        if self.target_destinations and self.exclude_destinations:
+            overlap = set(self.target_destinations) & set(self.exclude_destinations)
+            if overlap:
+                raise ValueError(
+                    f"Cannot have same destination in both target_destinations and "
+                    f"exclude_destinations: {overlap}"
+                )
+
+        # 2. Warn about replay configs that re-write to ARF
+        if self.target_destinations and self.enable_raw_data_handler:
+            warnings.warn(
+                "Writing to specific destinations with raw_data_handler enabled may duplicate ARF data. "
+                "Consider disable_raw_data_handler if replaying from ARF.",
+                stacklevel=2,
+            )
+
+        return self
+
+    @classmethod
+    def default(cls) -> "SyncExecutionConfig":
+        """Normal sync to all destinations."""
+        return cls()
+
+    @classmethod
+    def arf_capture_only(cls) -> "SyncExecutionConfig":
+        """Capture to ARF without vector DBs or postgres metadata.
+
+        Fetches all entities (skips cursor) to ensure complete ARF backfill.
+        Skips hash comparison to force all entities to be captured, not just changed ones.
+        Disables postgres handler so no metadata/hashes are written to database.
+        Useful for backfilling ARF storage without impacting production databases.
+        """
+        return cls(
+            enable_vector_handlers=False,
+            enable_postgres_handler=False,
+            skip_hash_comparison=True,
+            skip_cursor_load=True,
+            skip_cursor_updates=True,
+        )

--- a/backend/airweave/platform/sync/context.py
+++ b/backend/airweave/platform/sync/context.py
@@ -1,5 +1,6 @@
 """Module for sync context."""
 
+from typing import Optional
 from uuid import UUID
 
 from airweave import schemas
@@ -9,6 +10,7 @@ from airweave.core.logging import ContextualLogger
 from airweave.platform.destinations._base import BaseDestination
 from airweave.platform.entities._base import BaseEntity
 from airweave.platform.sources._base import BaseSource
+from airweave.platform.sync.config import SyncExecutionConfig
 from airweave.platform.sync.cursor import SyncCursor
 from airweave.platform.sync.pipeline.entity_tracker import EntityTracker
 from airweave.platform.sync.state_publisher import SyncStatePublisher
@@ -60,6 +62,9 @@ class SyncContext:
     batch_size: int = 64
     max_batch_latency_ms: int = 200
 
+    # Optional execution config for controlling sync behavior
+    execution_config: Optional[SyncExecutionConfig] = None
+
     def __init__(
         self,
         source: BaseSource,
@@ -81,6 +86,7 @@ class SyncContext:
         batch_size: int = 64,
         max_batch_latency_ms: int = 200,
         has_keyword_index: bool = False,
+        execution_config: Optional[SyncExecutionConfig] = None,
     ):
         """Initialize the sync context."""
         self.source = source
@@ -104,3 +110,5 @@ class SyncContext:
         self.max_batch_latency_ms = max_batch_latency_ms
         # Destination capabilities (precomputed)
         self.has_keyword_index = has_keyword_index
+        # Execution config for controlling sync behavior
+        self.execution_config = execution_config

--- a/backend/airweave/platform/sync/factory.py
+++ b/backend/airweave/platform/sync/factory.py
@@ -23,6 +23,7 @@ from airweave.platform.entities._base import BaseEntity
 from airweave.platform.locator import resource_locator
 from airweave.platform.sources._base import BaseSource
 from airweave.platform.sync.actions import ActionDispatcher, ActionResolver
+from airweave.platform.sync.config import SyncExecutionConfig
 from airweave.platform.sync.context import SyncContext
 from airweave.platform.sync.cursor import SyncCursor
 from airweave.platform.sync.entity_pipeline import EntityPipeline
@@ -53,11 +54,12 @@ class SyncFactory:
         sync: schemas.Sync,
         sync_job: schemas.SyncJob,
         collection: schemas.Collection,
-        connection: schemas.Connection,  # Passed but unused - we load from DB
+        connection: schemas.Connection,
         ctx: ApiContext,
         access_token: Optional[str] = None,
         max_workers: int = None,
         force_full_sync: bool = False,
+        execution_config: Optional[SyncExecutionConfig] = None,
     ) -> SyncOrchestrator:
         """Create a dedicated orchestrator instance for a sync run.
 
@@ -69,11 +71,12 @@ class SyncFactory:
             sync: The sync configuration
             sync_job: The sync job
             collection: The collection to sync to
-            connection: The connection (unused - we load source connection from DB)
+            connection: The connection
             ctx: The API context
             access_token: Optional token to use instead of stored credentials
             max_workers: Maximum number of concurrent workers (default: from settings)
             force_full_sync: If True, forces a full sync with orphaned entity deletion
+            execution_config: Optional execution config for controlling sync behavior
 
         Returns:
             A dedicated SyncOrchestrator instance
@@ -94,10 +97,11 @@ class SyncFactory:
             sync=sync,
             sync_job=sync_job,
             collection=collection,
-            connection=connection,  # Unused parameter
+            connection=connection,
             ctx=ctx,
             access_token=access_token,
             force_full_sync=force_full_sync,
+            execution_config=execution_config,
         )
         logger.debug(f"Sync context created in {time.time() - context_start:.2f}s")
 
@@ -107,10 +111,38 @@ class SyncFactory:
         # 1. Action Resolver
         action_resolver = ActionResolver(entity_map=sync_context.entity_map)
 
-        # 2. Handlers - grouped by destination processing requirements
-        handlers = cls._create_destination_handlers(sync_context)
-        handlers.append(RawDataHandler())  # Raw data storage
-        handlers.append(PostgresMetadataHandler())  # Metadata (runs last)
+        # 2. Handlers - conditionally created based on execution_config
+        config = sync_context.execution_config
+        enable_vector = config is None or config.enable_vector_handlers
+        enable_raw = config is None or config.enable_raw_data_handler
+        enable_postgres = config is None or config.enable_postgres_handler
+
+        handlers = []
+
+        # Add VectorDBHandler if enabled
+        if enable_vector:
+            vector_handlers = cls._create_destination_handlers(sync_context)
+            handlers.extend(vector_handlers)
+        elif sync_context.destinations:
+            logger.info(
+                f"Skipping VectorDBHandler (disabled by execution_config) for "
+                f"{len(sync_context.destinations)} destination(s)"
+            )
+
+        # Add RawDataHandler if enabled
+        if enable_raw:
+            handlers.append(RawDataHandler())
+        else:
+            logger.info("Skipping RawDataHandler (disabled by execution_config)")
+
+        # Add PostgresMetadataHandler if enabled (always runs last)
+        if enable_postgres:
+            handlers.append(PostgresMetadataHandler())
+        else:
+            logger.info("Skipping PostgresMetadataHandler (disabled by execution_config)")
+
+        if not handlers:
+            logger.warning("No handlers created - sync will fetch entities but not persist them")
 
         # 3. Action Dispatcher
         action_dispatcher = ActionDispatcher(handlers=handlers)
@@ -154,6 +186,7 @@ class SyncFactory:
         ctx: ApiContext,
         access_token: Optional[str] = None,
         force_full_sync: bool = False,
+        execution_config: Optional[SyncExecutionConfig] = None,
     ) -> SyncContext:
         """Create a sync context.
 
@@ -162,10 +195,11 @@ class SyncFactory:
             sync: The sync configuration
             sync_job: The sync job
             collection: The collection to sync to
-            connection: The connection (unused - we load source connection from DB)
+            connection: The connection
             ctx: The API context
             access_token: Optional token to use instead of stored credentials
             force_full_sync: If True, forces a full sync with orphaned entity deletion
+            execution_config: Optional execution config for controlling sync behavior
 
         Returns:
             SyncContext object with all required components
@@ -201,6 +235,7 @@ class SyncFactory:
             collection=collection,
             ctx=ctx,
             logger=logger,
+            execution_config=execution_config,
         )
         entity_map = await cls._get_entity_definition_map(db=db)
 
@@ -259,6 +294,11 @@ class SyncFactory:
                 "for accurate orphaned entity cleanup. Will still track cursor for next sync."
             )
             cursor_data = None  # Force full sync by not providing previous cursor data
+        elif execution_config and execution_config.skip_cursor_load:
+            logger.info(
+                "🔄 SKIP CURSOR LOAD: Fetching all entities (execution_config.skip_cursor_load=True)"
+            )
+            cursor_data = None  # Skip cursor loading as requested by execution config
         else:
             # Normal incremental sync - load cursor data
             cursor_data = await sync_cursor_service.get_cursor_data(db=db, sync_id=sync.id, ctx=ctx)
@@ -292,7 +332,7 @@ class SyncFactory:
             sync=sync,
             sync_job=sync_job,
             collection=collection,
-            connection=connection,  # Unused parameter
+            connection=connection,
             entity_tracker=entity_tracker,
             state_publisher=state_publisher,
             cursor=cursor,
@@ -302,6 +342,7 @@ class SyncFactory:
             guard_rail=guard_rail,
             force_full_sync=force_full_sync,
             has_keyword_index=has_keyword_index,
+            execution_config=execution_config,
         )
 
         # Set cursor on source so it can access cursor data
@@ -667,6 +708,7 @@ class SyncFactory:
         collection: schemas.Collection,
         ctx: ApiContext,
         logger: ContextualLogger,
+        execution_config: Optional[SyncExecutionConfig] = None,
     ) -> list[BaseDestination]:
         """Create destination instances with unified credentials pattern (matches sources).
 
@@ -681,6 +723,7 @@ class SyncFactory:
             collection (schemas.Collection): The collection object
             ctx (ApiContext): The API context
             logger (ContextualLogger): The contextual logger with sync metadata
+            execution_config (Optional[SyncExecutionConfig]): Optional execution config for filtering destinations
 
         Returns:
         --------
@@ -692,8 +735,13 @@ class SyncFactory:
         """
         destinations = []
 
-        # Create all destinations from destination_connection_ids
-        for destination_connection_id in sync.destination_connection_ids:
+        # Filter destination IDs based on execution_config
+        destination_ids = cls._filter_destination_ids(
+            sync.destination_connection_ids, execution_config, logger
+        )
+
+        # Create all destinations from filtered destination_connection_ids
+        for destination_connection_id in destination_ids:
             try:
                 # Special case: Native Qdrant (uses settings, no DB connection)
                 if destination_connection_id == NATIVE_QDRANT_UUID:
@@ -802,6 +850,55 @@ class SyncFactory:
 
     # NOTE: Transformers removed - chunking now happens in VectorDBHandler
     # (for destinations requiring CHUNKS_AND_EMBEDDINGS processing)
+
+    @staticmethod
+    def _filter_destination_ids(
+        destination_ids: list[UUID],
+        execution_config: Optional[SyncExecutionConfig],
+        logger: ContextualLogger,
+    ) -> list[UUID]:
+        """Filter destination IDs based on execution config.
+
+        Priority:
+        1. If target_destinations is set, use only those
+        2. If exclude_destinations is set, filter them out
+        3. Otherwise use all provided IDs
+
+        Args:
+            destination_ids: Original list of destination IDs from sync
+            execution_config: Optional execution config
+            logger: Logger for info messages
+
+        Returns:
+            Filtered list of destination IDs
+        """
+        if not execution_config:
+            return destination_ids
+
+        # Priority 1: If target_destinations is set, use only those
+        if execution_config.target_destinations:
+            logger.info(
+                f"Using target_destinations from config: {execution_config.target_destinations}"
+            )
+            return execution_config.target_destinations
+
+        # Priority 2: If exclude_destinations is set, filter them out
+        if execution_config.exclude_destinations:
+            original_count = len(destination_ids)
+            filtered_ids = [
+                dest_id
+                for dest_id in destination_ids
+                if dest_id not in execution_config.exclude_destinations
+            ]
+            excluded_count = original_count - len(filtered_ids)
+            if excluded_count > 0:
+                logger.info(
+                    f"Excluded {excluded_count} destination(s) from execution_config.exclude_destinations"
+                )
+            return filtered_ids
+
+        # No filtering
+        return destination_ids
 
     @classmethod
     async def _get_entity_definition_map(cls, db: AsyncSession) -> dict[type[BaseEntity], UUID]:

--- a/backend/airweave/platform/sync/orchestrator.py
+++ b/backend/airweave/platform/sync/orchestrator.py
@@ -541,6 +541,14 @@ class SyncOrchestrator:
 
     async def _save_cursor_data(self) -> None:
         """Save cursor data to database if it exists."""
+        # Check if cursor updates are disabled
+        if (
+            self.sync_context.execution_config
+            and self.sync_context.execution_config.skip_cursor_updates
+        ):
+            self.sync_context.logger.info("⏭️ Skipping cursor update (disabled by execution_config)")
+            return
+
         if not hasattr(self.sync_context, "cursor") or not self.sync_context.cursor.cursor_data:
             if self.sync_context.force_full_sync:
                 self.sync_context.logger.info(

--- a/backend/airweave/platform/temporal/activities/sync.py
+++ b/backend/airweave/platform/temporal/activities/sync.py
@@ -21,18 +21,35 @@ async def _run_sync_task(
     force_full_sync=False,
 ):
     """Run the actual sync service."""
+    from airweave import crud
     from airweave.core.exceptions import NotFoundException
     from airweave.core.sync_service import sync_service
+    from airweave.db.session import get_db_context
+    from airweave.platform.sync.config import SyncExecutionConfig
+
+    # Refetch sync_job from DB to get execution_config_json
+    execution_config = None
+    try:
+        async with get_db_context() as db:
+            sync_job_model = await crud.sync_job.get(db, id=sync_job.id, ctx=ctx)
+            if sync_job_model and sync_job_model.execution_config_json:
+                execution_config = SyncExecutionConfig(**sync_job_model.execution_config_json)
+                ctx.logger.info(
+                    f"Loaded execution config from DB: {sync_job_model.execution_config_json}"
+                )
+    except Exception as e:
+        ctx.logger.warning(f"Failed to load execution config from DB: {e}")
 
     try:
         return await sync_service.run(
             sync=sync,
             sync_job=sync_job,
             collection=collection,
-            source_connection=connection,  # sync_service expects this parameter name
+            source_connection=connection,
             ctx=ctx,
             access_token=access_token,
             force_full_sync=force_full_sync,
+            execution_config=execution_config,
         )
     except NotFoundException as e:
         # Check if this is the specific "Source connection record not found" error

--- a/backend/airweave/schemas/sync_job.py
+++ b/backend/airweave/schemas/sync_job.py
@@ -6,7 +6,7 @@ tracking of sync progress, performance metrics, and error reporting.
 """
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, EmailStr, Field
@@ -31,6 +31,7 @@ class SyncJobBase(BaseModel):
     failed_at: Optional[datetime] = None
     error: Optional[str] = None
     access_token: Optional[str] = None
+    execution_config_json: Optional[Dict[str, Any]] = None
 
     class Config:
         """Pydantic config for SyncJobBase."""

--- a/backend/alembic/versions/h1i2j3k4l5m6_add_execution_config_json_to_sync_job.py
+++ b/backend/alembic/versions/h1i2j3k4l5m6_add_execution_config_json_to_sync_job.py
@@ -1,0 +1,30 @@
+"""add_execution_config_json_to_sync_job
+
+Revision ID: h1i2j3k4l5m6
+Revises: g0a9b8c7d6e5
+Create Date: 2026-01-03 17:27:16.572060
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'h1i2j3k4l5m6'
+down_revision = 'g0a9b8c7d6e5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Add execution_config_json column to sync_job table."""
+    op.add_column(
+        "sync_job",
+        sa.Column("execution_config_json", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade():
+    """Remove execution_config_json column from sync_job table."""
+    op.drop_column("sync_job", "execution_config_json")
+


### PR DESCRIPTION
- Add SyncExecutionConfig Pydantic model for controlling sync behavior
- Add execution_config_json JSONB column to sync_job table
- Add execution_config parameter throughout sync pipeline:
  - sync_service.run() and trigger_sync_run()
  - temporal activities (_run_sync_task)
  - SyncFactory.create_orchestrator()
  - SyncContext initialization
- Load execution config from database in temporal worker
- Support flags: skip_cursor_load, skip_cursor_updates, skip_hash_*
- Support handler toggles: enable_vector/raw_data/postgres_handler
- Support destination filtering: target_destinations, exclude_destinations
- Add helper methods: default(), arf_capture_only(), replay_to_destination(), dry_run()

This enables advanced sync control without Temporal bloat:
- ARF-only capture syncs
- Destination-specific replays
- Dry runs for testing
- Configurable handler behavior

```
curl -X POST "http://localhost:8001/admin/resync/5b4013b8-c553-4051-afef-ff777bb3103c" \
  -H "Content-Type: application/json" \
  -H "X-Organization-ID: 027dfdcd-e417-4340-b794-735d90c13390" \
  -d '{
    "enable_vector_handlers": false,
    "enable_postgres_handler": false,
    "enable_raw_data_handler": true,
    "skip_hash_comparison": true,
    "skip_hash_updates": true,
    "skip_cursor_load": true,
    "skip_cursor_updates": true
  }'
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a SyncExecutionConfig model stored on sync_job (JSONB) to control sync behavior end-to-end, loaded by the Temporal worker to avoid large payloads. Enables ARF-only capture, destination-specific replay, and dry runs.

- **New Features**
  - Destination filters: target_destinations and exclude_destinations.
  - Handler toggles: enable_vector_handlers, enable_raw_data_handler, enable_postgres_handler.
  - Cursor/hash controls: skip_cursor_load, skip_cursor_updates, skip_hash_comparison.
  - Plumbed execution_config across API run endpoint, admin resync endpoint, run(), trigger_sync_run(), create_orchestrator(), SyncContext; worker reads execution_config_json from DB.

- **Migration**
  - Add execution_config_json JSONB to sync_job; run Alembic upgrade.

<sup>Written for commit 630ba0da6549cfb61fdc061cc519b96e12ae70ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



