### PR TITLE
fix: sync job duration metric

### DIFF
--- a/backend/airweave/platform/temporal/worker.py
+++ b/backend/airweave/platform/temporal/worker.py
@@ -270,7 +270,7 @@ class TemporalWorker:
                 sync["workers_allocated"] = worker_counts_map.get(sync["sync_id"], 0)
                 # Add duration if available from activities
                 for activity in metrics["active_activities"]:
-                    if activity.get("sync_id") == sync["sync_id"]:
+                    if activity.get("sync_job_id") == sync["sync_job_id"]:
                         sync["duration_seconds"] = activity.get("duration_seconds", 0)
                         break
                 else:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes sync job duration reporting in the Temporal worker by matching active activities using sync_job_id instead of sync_id, so duration_seconds is correctly populated in the JSON status.

<sup>Written for commit 3f88d7289dbd94f039a4ffea5382acf68fe5dc11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

