### PR TITLE
backfill: bump inactivity time to 15 min

### DIFF
--- a/backend/airweave/platform/temporal/workflows/sync.py
+++ b/backend/airweave/platform/temporal/workflows/sync.py
@@ -116,7 +116,7 @@ class RunSourceConnectionWorkflow:
         try:
             # Use longer heartbeat timeout in local development for debugging
             local_development = ctx_dict.get("local_development", False)
-            heartbeat_timeout = timedelta(hours=1) if local_development else timedelta(minutes=5)
+            heartbeat_timeout = timedelta(hours=1) if local_development else timedelta(minutes=15)
 
             await workflow.execute_activity(
                 run_sync_activity,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the Temporal activity heartbeat timeout in the sync workflow from 5 to 15 minutes for non-local environments, keeping 1 hour for local development. This prevents premature timeouts during backfills and longer sync runs.

<sup>Written for commit e476ef30473cf8a92b31e604288f03b75d2a0532. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

