### PR TITLE
feat(ARF): do not cancel long running syncs

### DIFF
--- a/backend/airweave/platform/temporal/activities/sync.py
+++ b/backend/airweave/platform/temporal/activities/sync.py
@@ -477,7 +477,7 @@ async def cleanup_stuck_sync_jobs_activity() -> None:
     # Calculate cutoff times
     now = utc_now_naive()
     cancelling_pending_cutoff = now - timedelta(minutes=3)
-    running_cutoff = now - timedelta(minutes=5)
+    running_cutoff = now - timedelta(minutes=15)  # Jobs older than 15 min with no activity
 
     stuck_job_count = 0
     cancelled_count = 0
@@ -510,11 +510,21 @@ async def cleanup_stuck_sync_jobs_activity() -> None:
                 started_before=running_cutoff,
             )
 
-            logger.info(f"Found {len(running_jobs)} RUNNING jobs that started > 5 minutes ago")
+            logger.info(f"Found {len(running_jobs)} RUNNING jobs that started > 15 minutes ago (will check activity)")
 
             # Check which RUNNING jobs have no recent activity (via Redis snapshot)
+            # Skip ARF-only jobs (they don't update entity stats, so no activity expected)
             stuck_running_jobs = []
             for job in running_jobs:
+                # Skip ARF-only backfills (no postgres handler = no stats updates)
+                if job.execution_config_json:
+                    is_arf_only = job.execution_config_json.get('enable_postgres_handler', True) == False
+                    if is_arf_only:
+                        logger.debug(
+                            f"Skipping ARF-only job {job.id} from stuck detection "
+                            f"(no stats updates expected)"
+                        )
+                        continue
                 job_id_str = str(job.id)
                 snapshot_key = f"sync_progress_snapshot:{job_id_str}"
 
@@ -530,6 +540,7 @@ async def cleanup_stuck_sync_jobs_activity() -> None:
 
                     if not last_update_str:
                         # Old snapshot without timestamp - fall back to DB check
+                        # (ARF-only jobs already skipped above, so safe to check DB)
                         latest_entity_time = await crud.entity.get_latest_entity_time_for_job(
                             db=db, sync_job_id=job.id
                         )
@@ -567,6 +578,7 @@ async def cleanup_stuck_sync_jobs_activity() -> None:
                     logger.warning(
                         f"Error checking job {job_id_str}: {e}, falling back to DB check"
                     )
+                    # ARF-only jobs already skipped above, so safe to check DB
                     latest_entity_time = await crud.entity.get_latest_entity_time_for_job(
                         db=db, sync_job_id=job.id
                     )
@@ -574,7 +586,7 @@ async def cleanup_stuck_sync_jobs_activity() -> None:
                         stuck_running_jobs.append(job)
 
             logger.info(
-                f"Found {len(stuck_running_jobs)} RUNNING jobs with no activity in last 5 minutes"
+                f"Found {len(stuck_running_jobs)} RUNNING jobs with no activity in last 15 minutes"
             )
 
             # Combine all stuck jobs


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents false cancellation of long-running ARF syncs by adjusting stuck job detection. ARF-only backfills are excluded, and the inactivity window for RUNNING jobs is increased to 15 minutes.

- **Bug Fixes**
  - Skip ARF-only jobs (enable_postgres_handler = False) in activity checks since they don’t update entity stats.
  - Increase RUNNING job cutoff from 5 to 15 minutes and update related logs.

<sup>Written for commit 7f09dfc9d3f3c90fcaeccbb53e59d650d5f6dc35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

