### PR TITLE
fix(sync): use async file I/O in ARF storage to prevent event loop blocking

### DIFF
--- a/backend/airweave/platform/temporal/activities/sync.py
+++ b/backend/airweave/platform/temporal/activities/sync.py
@@ -510,7 +510,9 @@ async def cleanup_stuck_sync_jobs_activity() -> None:
                 started_before=running_cutoff,
             )
 
-            logger.info(f"Found {len(running_jobs)} RUNNING jobs that started > 15 minutes ago (will check activity)")
+            logger.info(
+                f"Found {len(running_jobs)} RUNNING jobs that started > 15 minutes ago (will check activity)"
+            )
 
             # Check which RUNNING jobs have no recent activity (via Redis snapshot)
             # Skip ARF-only jobs (they don't update entity stats, so no activity expected)
@@ -518,7 +520,9 @@ async def cleanup_stuck_sync_jobs_activity() -> None:
             for job in running_jobs:
                 # Skip ARF-only backfills (no postgres handler = no stats updates)
                 if job.execution_config_json:
-                    is_arf_only = job.execution_config_json.get('enable_postgres_handler', True) == False
+                    is_arf_only = (
+                        job.execution_config_json.get("enable_postgres_handler", True) == False
+                    )
                     if is_arf_only:
                         logger.debug(
                             f"Skipping ARF-only job {job.id} from stuck detection "


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch ARF raw data storage to async file I/O to avoid blocking the event loop during file reads/writes. Add manifest-backed entity and file counts for faster and more accurate stats.

- **Bug Fixes**
  - Use aiofiles for reading local files and writing restored files.
  - Avoid event loop blocking on large file operations.

- **New Features**
  - Manifest tracks entity_count and file_count; updated on upsert and delete.
  - get_entity_count and replay stats now read counts from the manifest.

<sup>Written for commit fa0d539c6fc11096c1fc011d8142d7dbad09191c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

