### PR TITLE
fix: disable xlsx files

### DIFF
--- a/backend/airweave/platform/sync/file_types.py
+++ b/backend/airweave/platform/sync/file_types.py
@@ -14,8 +14,6 @@ SUPPORTED_FILE_EXTENSIONS = {
     ".jpg",
     ".jpeg",
     ".png",
-    # Spreadsheets (local extraction)
-    ".xlsx",
     # HTML
     ".html",
     ".htm",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disabled XLSX file ingestion in the sync pipeline by removing ".xlsx" from allowed file types. This prevents spreadsheet uploads until extraction is supported.

<sup>Written for commit 53e44c92d3fd545323b9f39478626eb32580b99c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

