### PR TITLE
fix: exclude textual representation on deep copy

### DIFF
--- a/backend/airweave/platform/sync/file_types.py
+++ b/backend/airweave/platform/sync/file_types.py
@@ -14,6 +14,8 @@ SUPPORTED_FILE_EXTENSIONS = {
     ".jpg",
     ".jpeg",
     ".png",
+    # Spreadsheets (local extraction)
+    ".xlsx",
     # HTML
     ".html",
     ".htm",

--- a/backend/airweave/platform/sync/handlers/vector_db.py
+++ b/backend/airweave/platform/sync/handlers/vector_db.py
@@ -488,8 +488,9 @@ class VectorDBHandler(ActionHandler):
                     failed_count += 1
                     break
 
-                chunk_entity = entity.model_copy(deep=True)
-                chunk_entity.textual_representation = chunk_text
+                chunk_entity = entity.model_copy(
+                    update={'textual_representation': chunk_text}, deep=True
+                )
                 chunk_entity.entity_id = f"{original_entity_id}__chunk_{chunk_idx}"
 
                 if chunk_entity.airweave_system_metadata is None:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Exclude textual_representation during deep copy when creating chunk entities, so chunks only contain their own text and avoid memory bloat. Also add .xlsx to supported file types for local extraction.

<sup>Written for commit e741a1a8a1cd3a0bccd19d6a8c0fd13ee92be4cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

