### PR TITLE
Fix snapshot source file path handling for ARF replay

### DIFF
--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -719,17 +719,12 @@ class PipedreamConfig(AuthProviderConfig):
 class SnapshotConfig(BaseConfig):
     """Configuration for SnapshotSource.
 
-    Specifies the path to raw data captured during a previous sync.
-    Supports both local filesystem paths and Azure blob URLs.
+    Specifies the sync_id for replaying raw data captured during a previous sync.
     """
 
-    path: str = Field(
-        title="Raw Data Path",
-        description=(
-            "Path to the raw data directory containing manifest.json, entities/, and files/. "
-            "Can be a local filesystem path (e.g., '/path/to/raw/sync-id') or "
-            "Azure blob URL (e.g., 'https://account.blob.core.windows.net/container/raw/sync-id')"
-        ),
+    sync_id: str = Field(
+        title="Sync ID",
+        description="UUID of the sync to replay from raw data storage (e.g., '7dd989e8-0634-447e-9406-5dba481569cd')",
         min_length=1,
     )
 
@@ -739,10 +734,10 @@ class SnapshotConfig(BaseConfig):
         description="Whether to restore file attachments from the files/ directory",
     )
 
-    @field_validator("path")
+    @field_validator("sync_id")
     @classmethod
-    def validate_path(cls, v: str) -> str:
-        """Validate and normalize path."""
+    def validate_sync_id(cls, v: str) -> str:
+        """Validate sync_id."""
         if not v or not v.strip():
-            raise ValueError("Path is required")
-        return v.strip().rstrip("/")
+            raise ValueError("sync_id is required")
+        return v.strip()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes snapshot file handling for ARF replay by moving to StorageBackend with sync_id. File attachments now restore correctly and local_path is accurate.

- **Bug Fixes**
  - Use storage paths (raw/{sync_id}/...) when restoring files.
  - Remove stale local_path for FileEntities; set it only after a successful restore.
  - Log a warning when a referenced file or entity cannot be restored.

- **Migration**
  - SnapshotConfig: replace path with sync_id and update source connections accordingly.

<sup>Written for commit ac432333f219b23fcc47d695e38baec3561011fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

