### PR TITLE
fix: use entity_id instead of id in outlook source logging

### DIFF
--- a/backend/airweave/platform/sources/outlook_calendar.py
+++ b/backend/airweave/platform/sources/outlook_calendar.py
@@ -551,7 +551,7 @@ class OutlookCalendarSource(BaseSource):
                     ):
                         entity_count += 1
                         entity_type = type(event_entity).__name__
-                        entity_id = event_entity.id
+                        entity_id = event_entity.entity_id
                         self.logger.info(
                             f"Yielding entity #{entity_count}: {entity_type} with ID {entity_id}"
                         )

--- a/backend/airweave/platform/sources/outlook_mail.py
+++ b/backend/airweave/platform/sources/outlook_mail.py
@@ -1240,7 +1240,7 @@ class OutlookMailSource(BaseSource):
                         self.logger.debug(
                             (
                                 f"Yielding delta entity #{entity_count}: {entity_type} "
-                                f"with ID {entity.id}"
+                                f"with ID {entity.entity_id}"
                             )
                         )
                         yield entity
@@ -1256,7 +1256,7 @@ class OutlookMailSource(BaseSource):
                         self.logger.debug(
                             (
                                 f"Yielding full sync entity #{entity_count}: {entity_type} "
-                                f"with ID {entity.id}"
+                                f"with ID {entity.entity_id}"
                             )
                         )
                         yield entity


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use entity_id instead of id in Outlook Calendar and Mail source logging to show the correct unique identifier for entities. This fixes misleading logs and improves debugging and traceability during syncs.

<sup>Written for commit 296aaf50247ecda89fde117d905c9539cf7615ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

