### PR TITLE
feat: allows ARF replay source to masquerade

### DIFF
--- a/backend/airweave/platform/builders/source.py
+++ b/backend/airweave/platform/builders/source.py
@@ -125,14 +125,26 @@ class SourceContextBuilder:
         """
         from airweave.platform.storage.replay_source import ArfReplaySource
 
+        ctx = infra.ctx
         logger = infra.logger
-        logger.info(f"🔄 ARF Replay mode: Creating ArfReplaySource for sync {sync.id}")
 
-        # Create the ARF replay source
+        # Get original source short_name from DB
+        source_connection = await crud.source_connection.get_by_sync_id(
+            db, sync_id=sync.id, ctx=ctx
+        )
+        original_short_name = source_connection.short_name if source_connection else None
+
+        logger.info(
+            f"🔄 ARF Replay mode: Creating ArfReplaySource for sync {sync.id} "
+            f"(masquerading as '{original_short_name}')"
+        )
+
+        # Create the ARF replay source with original source identity
         source = await ArfReplaySource.create(
             sync_id=sync.id,
             logger=logger,
             restore_files=True,
+            original_short_name=original_short_name,
         )
 
         # Set logger on source


### PR DESCRIPTION
Enables the ARF replay source to masquerade as the original source by retrieving the original source's short name from the database. This ensures entities appear to originate from the correct source during replay.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows ARF replay to show entities as coming from the original source by using the source’s short_name from the database. This keeps source identity consistent during replays.

- **New Features**
  - Builder fetches the original source short_name (via sync_id) and passes it to ArfReplaySource.
  - ArfReplaySource accepts original_short_name and overrides its _short_name and name to masquerade accordingly.

<sup>Written for commit a19eb8fcf0459df21c291b4c77fdf817aa0d19f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

