### PR TITLE
feat: add Qdrant to destination IDs list

### DIFF
--- a/backend/airweave/core/source_connection_service_helpers.py
+++ b/backend/airweave/core/source_connection_service_helpers.py
@@ -58,18 +58,24 @@ class SourceConnectionHelpers:
     ) -> list[UUID]:
         """Get destination connection IDs based on feature flags.
 
+        By default, writes to BOTH Qdrant and Vespa:
+        - Qdrant: Primary search destination (default for search queries)
+        - Vespa: Secondary destination (for future advanced search features)
+
         Args:
             db: Database session
             ctx: API context with organization and feature flags
 
         Returns:
-            List of destination connection IDs (always includes Qdrant, adds S3 if enabled)
+            List of destination connection IDs (always includes Qdrant + Vespa, adds S3 if enabled)
         """
         from sqlalchemy import and_, select
 
         from airweave.models.connection import Connection
 
-        destination_ids = [NATIVE_VESPA_UUID]  # Use Vespa as primary destination
+        # Write to both Qdrant and Vespa by default
+        # TODO: Remove Qdrant once we Vespa is fully supported
+        destination_ids = [NATIVE_QDRANT_UUID, NATIVE_VESPA_UUID]
 
         # Add S3 if feature flag enabled
         if ctx.has_feature(FeatureFlag.S3_DESTINATION):


### PR DESCRIPTION
Ensures writes to both Qdrant and Vespa by default. Qdrant is the primary search destination and Vespa is for future advanced search features.

TODO: Remove Qdrant once Vespa is fully supported.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Destination writes now include both Qdrant and Vespa by default to keep search stable and prepare advanced features. Qdrant remains primary; Vespa is written in parallel, and S3 is still added when the feature flag is enabled.

<sup>Written for commit 678aa5c6a7de819f95f6e1594e51ccb05472a572. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

