### PR TITLE
feat: filter Vespa sync jobs by ARF replay

### DIFF
--- a/backend/airweave/search/service.py
+++ b/backend/airweave/search/service.py
@@ -77,6 +77,7 @@ class SearchService:
         }
 
         # Track the search event with state for automatic metrics extraction
+        # TODO: use background task to track search completion, not blocking the response
         track_search_completion(
             ctx=ctx,
             query=search_context.query,
@@ -91,6 +92,7 @@ class SearchService:
         )
 
         # Persist search data to database
+        # TODO: use background task to persist search data, not blocking the response
         await search_helpers.persist_search_data(
             db=db,
             search_context=search_context,


### PR DESCRIPTION
Updates the admin endpoint to filter Vespa sync jobs based on whether they are replayed from ARF and actually write to Vespa, rather than just filtering by 'skip_qdrant'.

Also, adds TODOs to track search completion and persist search data using background tasks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admin endpoint now filters for ARF-to-Vespa jobs that actually write to Vespa (replay_from_arf=true and skip_vespa != true), replacing the skip_qdrant-only check. Removed last_vespa_job_config and added TODOs to move search tracking and persistence into background tasks.

<sup>Written for commit 56cf700c448af713907449c2d358805c5c236134. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

