### PR TITLE
fix(admin): Enhance admin endpoints for cross-org sync operations

### DIFF
--- a/backend/airweave/api/v1/endpoints/admin.py
+++ b/backend/airweave/api/v1/endpoints/admin.py
@@ -1,4 +1,10 @@
-"""Admin-only API endpoints for organization management."""
+"""Admin-only API endpoints for organization management.
+
+TODO: Enhance CRUD layer to support bypassing organization filtering cleanly.
+Currently admin endpoints manually construct SQLAlchemy queries to bypass ctx-based
+org filtering. Consider adding a `skip_org_filter=True` parameter to CRUD methods
+or a dedicated `crud_admin` module for cross-org operations.
+"""
 
 from datetime import datetime
 from enum import Enum


### PR DESCRIPTION
## Summary

Fixes admin endpoints to properly bypass organization filtering, enabling cross-org sync management for migration tooling.

## Changes

### Bug Fixes
- **Admin resync endpoint**: Fully bypass org filtering for all queries (sync, active jobs, source connection, collection, connection)
- **Admin sync listing**: Handle status as string or enum to prevent `.value` errors

### Enhancements
- **Vespa job tracking**: Filter for ARF → Vespa replay jobs (`replay_from_arf=true` AND `skip_vespa!=true`)
- **TODO**: Document need for cleaner CRUD layer org filter bypass

## Technical Details

The admin resync endpoint now manually constructs SQLAlchemy queries instead of using `crud.*.get()` methods which apply organization filtering via `ctx`. This allows:
- Triggering syncs across any organization
- Checking for active jobs without org restrictions  
- Looking up source connections, collections, and connections for any sync

## Testing

Tested with CLI tool against dev environment:
- `/admin/syncs` - Lists syncs across orgs ✅
- `/admin/resync/{sync_id}` - Triggers cross-org syncs ✅
- `/admin/sync-jobs/{job_id}/cancel` - Cancels cross-org jobs ✅
- `/admin/collections/{id}/search` - Searches any collection ✅


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables cross-org admin operations by bypassing org filtering for syncs and jobs. Fixes status handling and improves Vespa replay job tracking.

- **Bug Fixes**
  - Resync endpoint uses direct SQLAlchemy queries to ignore org filtering for sync, active jobs, source connection, collection, and connection.
  - Sync listing accepts status as string or enum to avoid `.value` errors.

- **Enhancements**
  - Vespa job tracking filters ARF→Vespa replays (`replay_from_arf=true` and `skip_vespa!=true`).

<sup>Written for commit 12fdf127da1a9cac89a63fc815d88e55cb1cc09b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

