### PR TITLE
fix(docs): correct typo in Pipedream integration subtitle

### DIFF
--- a/fern/docs/pages/framework-integrations/pipedream.mdx
+++ b/fern/docs/pages/framework-integrations/pipedream.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pipedream
-subtitle: Connect Airweave with your Pipedream workflows to enmpower your agents and automations with intelligent, context-aware data from all your connected apps and databases.
+subtitle: Connect Airweave with your Pipedream workflows to empower your agents and automations with intelligent, context-aware data from all your connected apps and databases.
 slug: framework-integrations/pipedream
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected a typo in the Pipedream integration docs subtitle to improve clarity: "enmpower" → "empower".

<sup>Written for commit e09d5b35330fb8542cf8ea89e6da1ce2106639e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

