### PR TITLE
feat(migration): add Vespa destination to all existing syncs with Qdrant

### DIFF
--- a/backend/alembic/versions/m6n7o8p9q0r1_add_vespa_to_existing_syncs.py
+++ b/backend/alembic/versions/m6n7o8p9q0r1_add_vespa_to_existing_syncs.py
@@ -1,0 +1,56 @@
+"""Add Vespa destination to existing syncs.
+
+Revision ID: m6n7o8p9q0r1
+Revises: h1i2j3k4l5m6
+Create Date: 2026-01-08 23:30:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "m6n7o8p9q0r1"
+down_revision = "h1i2j3k4l5m6"
+branch_labels = None
+depends_on = None
+
+# Native destination connection UUIDs (must match core/constants/reserved_ids.py)
+QDRANT_CONNECTION_ID = "11111111-1111-1111-1111-111111111111"
+VESPA_CONNECTION_ID = "33333333-3333-3333-3333-333333333333"
+
+
+def upgrade():
+    """Add Vespa destination connection to all syncs that have Qdrant but not Vespa."""
+    op.execute(f"""
+        INSERT INTO sync_connection (sync_id, connection_id)
+        SELECT 
+            sc.sync_id,
+            '{VESPA_CONNECTION_ID}'::uuid
+        FROM sync_connection sc
+        WHERE sc.connection_id = '{QDRANT_CONNECTION_ID}'::uuid
+          AND NOT EXISTS (
+            SELECT 1 
+            FROM sync_connection sc2 
+            WHERE sc2.sync_id = sc.sync_id 
+              AND sc2.connection_id = '{VESPA_CONNECTION_ID}'::uuid
+          )
+        ON CONFLICT DO NOTHING;
+    """)
+
+
+def downgrade():
+    """Remove Vespa destination connections that were added by this migration.
+    
+    NOTE: This is conservative and only removes Vespa connections for syncs
+    that also have Qdrant (to avoid removing manually added Vespa connections).
+    """
+    op.execute(f"""
+        DELETE FROM sync_connection
+        WHERE connection_id = '{VESPA_CONNECTION_ID}'::uuid
+          AND sync_id IN (
+            SELECT sync_id 
+            FROM sync_connection 
+            WHERE connection_id = '{QDRANT_CONNECTION_ID}'::uuid
+          );
+    """)
+


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a migration that adds the Vespa destination to all existing syncs that already use Qdrant, without creating duplicates. The downgrade only removes Vespa from those syncs that also have Qdrant to avoid touching manually added connections.

<sup>Written for commit fe8966f5d60692375b8beb652839d5ef172e792b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

