### PR TITLE
fix(migration): add id and timestamps to sync_connection insert

### DIFF
--- a/backend/alembic/versions/m6n7o8p9q0r1_add_vespa_to_existing_syncs.py
+++ b/backend/alembic/versions/m6n7o8p9q0r1_add_vespa_to_existing_syncs.py
@@ -22,10 +22,13 @@ VESPA_CONNECTION_ID = "33333333-3333-3333-3333-333333333333"
 def upgrade():
     """Add Vespa destination connection to all syncs that have Qdrant but not Vespa."""
     op.execute(f"""
-        INSERT INTO sync_connection (sync_id, connection_id)
+        INSERT INTO sync_connection (id, sync_id, connection_id, created_at, modified_at)
         SELECT 
+            gen_random_uuid(),
             sc.sync_id,
-            '{VESPA_CONNECTION_ID}'::uuid
+            '{VESPA_CONNECTION_ID}'::uuid,
+            NOW(),
+            NOW()
         FROM sync_connection sc
         WHERE sc.connection_id = '{QDRANT_CONNECTION_ID}'::uuid
           AND NOT EXISTS (
@@ -33,8 +36,7 @@ def upgrade():
             FROM sync_connection sc2 
             WHERE sc2.sync_id = sc.sync_id 
               AND sc2.connection_id = '{VESPA_CONNECTION_ID}'::uuid
-          )
-        ON CONFLICT DO NOTHING;
+          );
     """)
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add id and timestamps to the migration that backfills Vespa connections in sync_connection. This satisfies NOT NULL constraints and lets the migration run cleanly.

- **Bug Fixes**
  - Use gen_random_uuid() for id and NOW() for created_at/modified_at.
  - Remove ON CONFLICT DO NOTHING; NOT EXISTS prevents duplicates.

<sup>Written for commit c0d2417e56f0331ea05bb59b1dfee083309e6ec4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

