### PR TITLE
feat: batch read from arf

### DIFF
--- a/backend/airweave/platform/sync/arf/service.py
+++ b/backend/airweave/platform/sync/arf/service.py
@@ -292,28 +292,50 @@ class ArfService:
         except StorageNotFoundError:
             return None
 
-    async def iter_entities(self, sync_id: str) -> AsyncGenerator[Dict[str, Any], None]:
-        """Iterate over all entities in a sync's ARF store.
+    async def iter_entities(
+        self, sync_id: str, batch_size: int = 50
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Iterate over all entities in a sync's ARF store with batched concurrent reads.
+
+        Reads entities in concurrent batches to dramatically improve performance
+        when reading from cloud storage (Azure Blob, S3, etc).
+
+        For 2000 entities:
+        - Sequential: ~100-200s (50-100ms per file)
+        - Batched (50 concurrent): ~5-10s (40 batches × 100ms)
 
         Args:
             sync_id: Sync ID
+            batch_size: Number of files to read concurrently (default: 50)
 
         Yields:
             Entity dicts
         """
+        import asyncio
+
         entities_dir = f"{self._sync_path(sync_id)}/entities"
         try:
             files = await self.storage.list_files(entities_dir)
         except Exception:
             return
 
-        for file_path in files:
-            if file_path.endswith(".json"):
-                try:
-                    entity_dict = await self.storage.read_json(file_path)
-                    yield entity_dict
-                except Exception:
-                    continue
+        # Filter to .json files only
+        json_files = [f for f in files if f.endswith(".json")]
+
+        # Read files in concurrent batches
+        for i in range(0, len(json_files), batch_size):
+            batch = json_files[i : i + batch_size]
+
+            # Read batch concurrently
+            results = await asyncio.gather(
+                *[self.storage.read_json(file_path) for file_path in batch],
+                return_exceptions=True,
+            )
+
+            # Yield successful results, skip exceptions
+            for result in results:
+                if not isinstance(result, Exception):
+                    yield result
 
     async def get_all_entities(self, sync_id: str) -> List[Dict[str, Any]]:
         """Load all entities into memory.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds batched concurrent reads for ARF entities to significantly speed up entity loading from cloud storage. Default batch size is 50, delivering large performance gains on large datasets.

- **New Features**
  - iter_entity_dicts(...) and iter_entities(...) now read files in concurrent batches using asyncio.gather.
  - New batch_size parameter (default 50); service filters to .json files.
  - Errors are logged (reader) or skipped (service) without stopping iteration.

<sup>Written for commit 9279d9ec78c71c4efb69805ce93a5cb0ba8e6821. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

