### PR TITLE
feat: Add Auth0 callback route with conflict error handling

### DIFF
--- a/MIGRATION_SPEC.md
+++ b/MIGRATION_SPEC.md
@@ -399,7 +399,7 @@ updateOrganizationFeatures(token, orgId, features)  // Admin only
 
 | Feature | Priority | Notes |
 ||-|-|
-| Auth0 conflict error UI | Medium | Detailed error handling |
+| Auth0 conflict error UI | ✅ Complete | `/callback` route with error UI |
 | Request queuing | Low | Until auth ready |
 
 
@@ -545,7 +545,7 @@ The frontend-v2 uses a new Orange/Amber primary color. This is intentional and s
 - [x] Port TagInput component
 - [x] Port CollapsibleCard component
 - [x] Enhance CodeBlock component
-- [ ] Auth0 conflict error handling UI
+- [x] Auth0 conflict error handling UI
 
 
 
@@ -769,3 +769,19 @@ Phase 5 is now complete. Next suggested task: SemanticMcp Page (Phase 6) or Port
 - Added Billing tab to settings-layout navigation
 - Build verified passing
 Next suggested tasks: Port `/billing/setup` route (initial billing setup page) or `/billing/portal` route (Stripe portal redirect), or Phase 7 polish (TagInput, CollapsibleCard components).
+
+**2026-01-08**: Phase 7 Auth0 conflict error handling UI complete. Changes made:
+- Created `/callback` route at `frontend-v2/src/routes/callback.tsx` that handles user sync with backend
+- Added `createOrUpdateUser` API function to `lib/api/users.ts` with proper conflict error handling
+- Updated `config/auth.ts` to redirect to `/callback` path after Auth0 authentication
+- The callback page calls `POST /users/create_or_update` to sync user data after Auth0 auth
+- On 409 conflict (auth0_id_conflict), displays friendly error UI with:
+  - "Account Conflict" message
+  - Explanation of what happened
+  - Next steps (try different login, contact support, use different email)
+  - Auto-logout after 10 seconds
+  - Debug info in development mode
+- Build verified passing
+Phase 7 is now COMPLETE. Remaining items:
+- ValidatedInput component (optional - validation system is already ported)
+- Edit member roles (blocked on backend API)

--- a/SHARED_TASK_NOTES.md
+++ b/SHARED_TASK_NOTES.md
@@ -4,50 +4,60 @@ Context for the next iteration of frontend migration work.
 
 ## What Was Done (Latest)
 
-- **Phase 7 Polish - CodeBlock Enhancement COMPLETE**
-  - Created `frontend-v2/src/components/ui/code-block.tsx` with:
-    - Syntax highlighting via `react-syntax-highlighter` with Prism themes
-    - Theme-aware styling (dark: materialOceanic, light: oneLight)
-    - Badge, title, and footer support
-    - Copy-to-clipboard with toast notification
-    - Configurable height, line numbers, and line wrapping
-  - Created `frontend-v2/src/hooks/use-resolved-theme.ts` helper hook
-  - Updated `ApiIntegrationModal` to use new CodeBlock (syntax highlighting for cURL, Python, Node.js, JSON)
-  - Updated `components.$componentName.tsx` to use new CodeBlock
-  - Installed `react-syntax-highlighter` and `@types/react-syntax-highlighter`
+- **Phase 7 COMPLETE - Auth0 Conflict Error Handling**
+  - Created `/callback` route at `frontend-v2/src/routes/callback.tsx`
+  - Route syncs user with backend after Auth0 authentication
+  - Handles 409 conflict (auth0_id_conflict) with friendly error UI
+  - Added `createOrUpdateUser` API function to `lib/api/users.ts`
+  - Updated `config/auth.ts` to redirect to `/callback` after Auth0 auth
   - Build verified passing
 
-## Next Suggested Tasks (in priority order)
+## Migration Status
 
-1. **Auth0 conflict error handling UI (LOW)**
-   - Handle Auth0 account conflict errors gracefully in UI
-   - Check old frontend for error handling patterns
-   - Last remaining Phase 7 polish item
+**Phase 7 (Polish) is now COMPLETE.** All core migration work is done:
+- All Phase 1-6 features complete
+- All Phase 7 polish items complete:
+  - TagInput component ✅
+  - CollapsibleCard component ✅
+  - CodeBlock component with syntax highlighting ✅
+  - Auth0 conflict error handling UI ✅
 
-2. **Port ValidatedInput component (LOW)**
+## Remaining Items (Optional/Blocked)
+
+1. **ValidatedInput component (OPTIONAL)**
    - Validation system is already ported (rules.ts, types.ts)
-   - Create wrapper for TanStack Form integration
+   - Would create a wrapper component for TanStack Form
+   - Not blocking any functionality
 
-3. **Edit Member Roles (BLOCKED)**
+2. **Edit Member Roles (BLOCKED)**
    - Requires backend `PATCH /organizations/{id}/members/{memberId}` endpoint
-   - UI is prepared in members settings page, just needs backend API
+   - UI placeholder exists in members settings page
+   - Cannot proceed until backend API is implemented
 
 ## Key Files Reference
 
+- Callback route: `frontend-v2/src/routes/callback.tsx`
+- Users API: `frontend-v2/src/lib/api/users.ts`
+- Auth config: `frontend-v2/src/config/auth.ts`
 - CodeBlock: `frontend-v2/src/components/ui/code-block.tsx`
-- Theme hook: `frontend-v2/src/hooks/use-resolved-theme.ts`
 - TagInput: `frontend-v2/src/components/ui/tag-input.tsx`
 - CollapsibleCard: `frontend-v2/src/components/ui/collapsible-card.tsx`
 - Validation rules: `frontend-v2/src/lib/validation/rules.ts`
 
-## Migration Status Summary
+## Project Completion Status
 
-All core routes and features are now complete:
-- All Phase 1-6 features complete
-- Phase 7 Polish nearly complete:
-  - TagInput component
-  - CollapsibleCard component
-  - CodeBlock component with syntax highlighting
-  - Auth0 conflict error handling UI (remaining)
-  - ValidatedInput component (optional enhancement)
-  - Edit member roles (blocked on backend API)
+The frontend migration from `frontend` to `frontend-v2` is essentially complete. All required routes, features, and components have been ported with the following status:
+- Core routes: All implemented
+- Billing: Complete
+- Settings (org, members, usage, billing): Complete
+- Admin dashboard: Complete
+- Real-time sync: Complete
+- PostHog integration: Complete
+- S3 configuration: Complete (feature-flagged)
+- All UI components: Complete
+
+The only remaining items are:
+1. ValidatedInput wrapper (optional enhancement)
+2. Edit member roles (blocked on backend)
+
+The project may be considered complete pending verification of all functionality.

--- a/frontend-v2/src/config/auth.ts
+++ b/frontend-v2/src/config/auth.ts
@@ -1,6 +1,7 @@
 /**
  * Get the redirect URL for Auth0.
  * Uses https://app.airweave.ai for localhost, otherwise uses current origin.
+ * Always redirects to /callback to handle user sync and Auth0 conflicts.
  */
 export function getRedirectUrl(): string {
   if (typeof window === "undefined") return "";
@@ -9,7 +10,7 @@ export function getRedirectUrl(): string {
   if (origin.includes("localhost") || origin.includes("127.0.0.1")) {
     return "https://app.airweave.ai/callback";
   }
-  return origin;
+  return `${origin}/callback`;
 }
 
 /**

--- a/frontend-v2/src/lib/api/users.ts
+++ b/frontend-v2/src/lib/api/users.ts
@@ -11,6 +11,28 @@ export interface User {
   is_admin: boolean;
 }
 
+export interface UserCreate {
+  email: string;
+  full_name?: string;
+  picture?: string;
+  auth0_id?: string;
+  email_verified?: boolean;
+}
+
+export interface Auth0ConflictError {
+  error: "auth0_id_conflict";
+  message: string;
+  existing_auth0_id?: string;
+  incoming_auth0_id?: string;
+}
+
+export interface CreateOrUpdateUserResult {
+  success: boolean;
+  user?: User;
+  conflictError?: Auth0ConflictError;
+  error?: string;
+}
+
 /**
  * Fetch the current user's profile
  */
@@ -29,4 +51,54 @@ export async function fetchCurrentUser(token: string): Promise<User> {
   }
 
   return response.json();
+}
+
+/**
+ * Create or update user in backend after Auth0 authentication.
+ * Returns a result object to handle auth0_id_conflict errors gracefully.
+ */
+export async function createOrUpdateUser(
+  token: string,
+  userData: UserCreate
+): Promise<CreateOrUpdateUserResult> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/users/create_or_update`, {
+      method: "POST",
+      headers: getAuthHeaders(token),
+      body: JSON.stringify(userData),
+    });
+
+    if (response.ok) {
+      const user = await response.json();
+      return { success: true, user };
+    }
+
+    // Check for Auth0 ID conflict (409)
+    if (response.status === 409) {
+      const errorData = await response.json();
+      if (errorData.detail?.error === "auth0_id_conflict") {
+        return {
+          success: false,
+          conflictError: {
+            error: "auth0_id_conflict",
+            message: errorData.detail.message,
+            existing_auth0_id: errorData.detail.existing_auth0_id,
+            incoming_auth0_id: errorData.detail.incoming_auth0_id,
+          },
+        };
+      }
+    }
+
+    // Other errors
+    const message = await parseErrorResponse(
+      response,
+      "Failed to create or update user"
+    );
+    return { success: false, error: message };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Unknown error occurred",
+    };
+  }
 }

--- a/frontend-v2/src/routeTree.gen.ts
+++ b/frontend-v2/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as SemanticMcpRouteImport } from './routes/semantic-mcp'
 import { Route as OnboardingRouteImport } from './routes/onboarding'
 import { Route as ComponentsRouteImport } from './routes/components'
+import { Route as CallbackRouteImport } from './routes/callback'
 import { Route as AdminRouteImport } from './routes/admin'
 import { Route as OrgSlugRouteRouteImport } from './routes/$orgSlug/route'
 import { Route as IndexRouteImport } from './routes/index'
@@ -46,6 +47,11 @@ const OnboardingRoute = OnboardingRouteImport.update({
 const ComponentsRoute = ComponentsRouteImport.update({
   id: '/components',
   path: '/components',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CallbackRoute = CallbackRouteImport.update({
+  id: '/callback',
+  path: '/callback',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AdminRoute = AdminRouteImport.update({
@@ -154,6 +160,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$orgSlug': typeof OrgSlugRouteRouteWithChildren
   '/admin': typeof AdminRoute
+  '/callback': typeof CallbackRoute
   '/components': typeof ComponentsRouteWithChildren
   '/onboarding': typeof OnboardingRoute
   '/semantic-mcp': typeof SemanticMcpRoute
@@ -178,6 +185,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/admin': typeof AdminRoute
+  '/callback': typeof CallbackRoute
   '/onboarding': typeof OnboardingRoute
   '/semantic-mcp': typeof SemanticMcpRoute
   '/$orgSlug/api-keys': typeof OrgSlugApiKeysRoute
@@ -203,6 +211,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/$orgSlug': typeof OrgSlugRouteRouteWithChildren
   '/admin': typeof AdminRoute
+  '/callback': typeof CallbackRoute
   '/components': typeof ComponentsRouteWithChildren
   '/onboarding': typeof OnboardingRoute
   '/semantic-mcp': typeof SemanticMcpRoute
@@ -230,6 +239,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$orgSlug'
     | '/admin'
+    | '/callback'
     | '/components'
     | '/onboarding'
     | '/semantic-mcp'
@@ -254,6 +264,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/admin'
+    | '/callback'
     | '/onboarding'
     | '/semantic-mcp'
     | '/$orgSlug/api-keys'
@@ -278,6 +289,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$orgSlug'
     | '/admin'
+    | '/callback'
     | '/components'
     | '/onboarding'
     | '/semantic-mcp'
@@ -304,6 +316,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   OrgSlugRouteRoute: typeof OrgSlugRouteRouteWithChildren
   AdminRoute: typeof AdminRoute
+  CallbackRoute: typeof CallbackRoute
   ComponentsRoute: typeof ComponentsRouteWithChildren
   OnboardingRoute: typeof OnboardingRoute
   SemanticMcpRoute: typeof SemanticMcpRoute
@@ -334,6 +347,13 @@ declare module '@tanstack/react-router' {
       path: '/components'
       fullPath: '/components'
       preLoaderRoute: typeof ComponentsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/callback': {
+      id: '/callback'
+      path: '/callback'
+      fullPath: '/callback'
+      preLoaderRoute: typeof CallbackRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/admin': {
@@ -529,6 +549,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   OrgSlugRouteRoute: OrgSlugRouteRouteWithChildren,
   AdminRoute: AdminRoute,
+  CallbackRoute: CallbackRoute,
   ComponentsRoute: ComponentsRouteWithChildren,
   OnboardingRoute: OnboardingRoute,
   SemanticMcpRoute: SemanticMcpRoute,

--- a/frontend-v2/src/routes/callback.tsx
+++ b/frontend-v2/src/routes/callback.tsx
@@ -1,0 +1,198 @@
+import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
+import { AlertTriangle, HelpCircle, Loader2, Mail } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Auth0ConflictError,
+  createOrUpdateUser,
+} from "@/lib/api/users";
+import { useAuth0 } from "@/lib/auth-provider";
+
+export const Route = createFileRoute("/callback")({
+  component: CallbackPage,
+  validateSearch: (search: Record<string, unknown>) => ({
+    organizationName: (search.organizationName as string) || undefined,
+  }),
+});
+
+function CallbackPage() {
+  const { isAuthenticated, isLoading, user, logout, getAccessTokenSilently } =
+    useAuth0();
+  const navigate = useNavigate();
+  const search = useSearch({ from: "/callback" });
+
+  const syncAttempted = useRef(false);
+  const [authConflictError, setAuthConflictError] =
+    useState<Auth0ConflictError | null>(null);
+
+  // Sync user with backend after Auth0 authentication
+  useEffect(() => {
+    const syncUser = async () => {
+      if (
+        isAuthenticated &&
+        user &&
+        !isLoading &&
+        !syncAttempted.current &&
+        !authConflictError
+      ) {
+        syncAttempted.current = true;
+
+        try {
+          const token = await getAccessTokenSilently();
+
+          if (!token) {
+            console.error("No token available for API call");
+            navigate({ to: "/" });
+            return;
+          }
+
+          const result = await createOrUpdateUser(token, {
+            email: user.email || "",
+            full_name: user.name,
+            picture: user.picture,
+            auth0_id: user.sub,
+            email_verified: user.email_verified,
+          });
+
+          if (result.success) {
+            navigate({ to: "/" });
+          } else if (result.conflictError) {
+            setAuthConflictError(result.conflictError);
+          } else {
+            console.error("Failed to sync user:", result.error);
+            // Redirect anyway on other errors
+            navigate({ to: "/" });
+          }
+        } catch (err) {
+          console.error("Error syncing user with backend:", err);
+          navigate({ to: "/" });
+        }
+      }
+    };
+
+    syncUser();
+  }, [
+    isAuthenticated,
+    user,
+    isLoading,
+    authConflictError,
+    getAccessTokenSilently,
+    navigate,
+  ]);
+
+  // Auto-logout after showing Auth0 conflict error
+  useEffect(() => {
+    if (authConflictError) {
+      const timer = setTimeout(() => {
+        logout();
+      }, 10000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [authConflictError, logout]);
+
+  // Handle logout
+  const handleLogout = () => {
+    logout();
+  };
+
+  // Show Auth0 ID conflict error
+  if (authConflictError) {
+    return (
+      <div className="bg-background flex h-screen w-full items-center justify-center">
+        <div className="border-border bg-card mx-4 w-full max-w-md rounded-lg border p-6 shadow-lg">
+          <div className="mb-4 flex items-center space-x-3">
+            <AlertTriangle className="text-destructive h-8 w-8" />
+            <h1 className="text-foreground text-xl font-semibold">
+              Account Conflict
+            </h1>
+          </div>
+
+          <div className="space-y-4">
+            <p className="text-muted-foreground">
+              This email is already associated with a different Auth0 account.
+              Please try a different sign-in method or contact support.
+            </p>
+
+            <div className="bg-muted rounded-md p-4">
+              <h2 className="text-foreground mb-2 flex items-center font-medium">
+                <HelpCircle className="mr-2 h-4 w-4" />
+                What happened?
+              </h2>
+              <p className="text-muted-foreground text-sm">
+                You previously signed up using a different authentication method
+                (Google, GitHub, or email/password).
+              </p>
+            </div>
+
+            <div className="bg-muted rounded-md p-4">
+              <h2 className="text-foreground mb-2 flex items-center font-medium">
+                <Mail className="mr-2 h-4 w-4" />
+                Next steps
+              </h2>
+              <ul className="text-muted-foreground space-y-1 text-sm">
+                <li>• Try a different sign-in method</li>
+                <li>• Contact support to merge accounts</li>
+                <li>• Use a different email address</li>
+              </ul>
+            </div>
+
+            <div className="flex space-x-3">
+              <Button onClick={handleLogout} className="flex-1">
+                Try Different Login
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() =>
+                  window.open(
+                    "mailto:support@airweave.ai?subject=Auth0 Account Conflict",
+                    "_blank"
+                  )
+                }
+                className="flex-1"
+              >
+                Contact Support
+              </Button>
+            </div>
+
+            {import.meta.env.DEV && (
+              <details className="mt-4">
+                <summary className="text-muted-foreground cursor-pointer text-xs">
+                  Debug Information (Development Only)
+                </summary>
+                <pre className="bg-background text-muted-foreground mt-2 overflow-x-auto rounded border p-2 text-xs">
+                  {JSON.stringify(
+                    {
+                      existingAuth0Id: authConflictError.existing_auth0_id,
+                      incomingAuth0Id: authConflictError.incoming_auth0_id,
+                      userEmail: user?.email,
+                    },
+                    null,
+                    2
+                  )}
+                </pre>
+              </details>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Loading state
+  return (
+    <div className="bg-background flex h-screen w-full items-center justify-center">
+      <div className="flex flex-col items-center justify-center space-y-4">
+        <Loader2 className="text-primary h-10 w-10 animate-spin" />
+        {search.organizationName ? (
+          <p className="text-muted-foreground">
+            Finalizing your membership for {search.organizationName}...
+          </p>
+        ) : (
+          <p className="text-muted-foreground">Finalizing authentication...</p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
backend after Auth0 authentication. The callback page calls the
POST /users/create_or_update endpoint and gracefully handles Auth0 ID
conflicts (409 status) when a user attempts to sign in with a different
authentication method than their original registration.

Key changes:
- Create callback.tsx route with loading and error UI states
- Add createOrUpdateUser API function with Auth0ConflictError handling
- Update auth config to redirect to /callback after authentication
- Display friendly conflict error with explanation and next steps
- Include auto-logout after 10 seconds on conflict errors
- Show debug information in development mode

Update MIGRATION_SPEC.md and SHARED_TASK_NOTES.md to mark Phase 7 as
complete with all polish items finished.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated /callback route to sync Auth0 users with the backend and gracefully handle Auth0 ID conflicts. Redirects all Auth0 logins to /callback to finalize auth; completes Phase 7 polish.

- **New Features**
  - New /callback route with loading state and friendly conflict error UI.
  - Calls POST /users/create_or_update after Auth0 auth; handles 409 auth0_id_conflict.
  - Added createOrUpdateUser API helper with structured result for conflicts.
  - Updated auth redirect to always point to /callback.
  - Auto-logout after 10 seconds on conflict; dev-only debug details.

<sup>Written for commit 67740e6cb1823a8bbcdb5fc1fa3e62aa390bae48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

