### PR TITLE
feat: Add edit member role functionality

### DIFF
--- a/MIGRATION_SPEC.md
+++ b/MIGRATION_SPEC.md
@@ -75,7 +75,7 @@ These decisions were made during migration planning and should guide all impleme
 | Admin Dashboard | ✅ Complete | - | Superuser access with metrics |
 | Real-time Sync | ✅ Complete | - | Full SSE port with entity state |
 | Usage Dashboard | ✅ Complete | - | Part of settings |
-| Members Settings | ⚠️ Partial | **High** | Core CRUD done, role editing pending |
+| Members Settings | ✅ Complete | - | Full CRUD with role editing |
 | Validation System | ✅ Complete | - | Full validation integration |
 | QueryTool | ✅ Complete | - | Enhanced with MCP client tabs (Claude, Cursor, Windsurf) |
 | SemanticMcp Page | ✅ Complete | - | MCP auth alternative |
@@ -478,7 +478,7 @@ The frontend-v2 uses a new Orange/Amber primary color. This is intentional and s
   - [x] Create `/$orgSlug/settings/members.tsx`
   - [x] View members list
   - [x] Invite members (email + role)
-  - [ ] Edit member roles
+  - [x] Edit member roles
   - [x] Remove members
   - [x] View/cancel pending invitations
 
@@ -798,3 +798,12 @@ Phase 7 is now COMPLETE. Remaining items:
 - ValidatedInput component already exists at `src/components/validated-input.tsx` (integrated in 8 files)
 - Only remaining item is "Edit member roles" which requires backend `PATCH /organizations/{id}/members/{memberId}` endpoint (CRUD function `update_member_role` exists in backend but no API route)
 - **FRONTEND MIGRATION IS COMPLETE**
+
+**2026-01-08**: Implemented Edit Member Roles feature (the final remaining migration item):
+- Added `PATCH /organizations/{id}/members/{memberId}` backend API endpoint in `backend/airweave/api/v1/endpoints/organizations.py`
+- Added `MemberRoleUpdate` schema in `backend/airweave/schemas/invitation.py`
+- Added `updateMemberRole` API function in `frontend-v2/src/lib/api/organizations.ts`
+- Updated members settings page with role dropdown for non-owner members
+- Includes permission checks: only owners/admins can edit, cannot edit owner's role, cannot edit own role
+- Build passes, lint passes, all 25 tests pass
+- **ALL MIGRATION TASKS ARE NOW COMPLETE**

--- a/SHARED_TASK_NOTES.md
+++ b/SHARED_TASK_NOTES.md
@@ -4,10 +4,10 @@ Context for the next iteration.
 
 ## Project Status: COMPLETE
 
-The frontend migration from `frontend` to `frontend-v2` is **complete**.
+The frontend migration from `frontend` to `frontend-v2` is **fully complete**.
 
 ### Verification (2026-01-08)
-- Build: Passes (4.13s, no errors)
+- Build: Passes (4.18s, no errors)
 - Lint: Passes (0 warnings)
 - Tests: All 25 pass
 
@@ -20,18 +20,24 @@ The frontend migration from `frontend` to `frontend-v2` is **complete**.
 - Real-time sync infrastructure complete
 - Billing enforcement complete
 - S3 configuration complete (feature-flagged)
+- **Edit Member Roles**: Backend endpoint + frontend UI complete
 
-### Remaining (Blocked)
-The only incomplete item requires backend work:
-- **Edit Member Roles**: Needs `PATCH /organizations/{id}/members/{memberId}` API endpoint
-  - Backend CRUD function `update_member_role` exists in `crud_organization.py`
-  - No API route exposes this function yet
-  - Frontend UI placeholder exists in members settings page
+### Final Implementation (2026-01-08)
+The last remaining migration item "Edit Member Roles" has been implemented:
+- Backend: `PATCH /organizations/{id}/members/{memberId}` endpoint added
+- Schema: `MemberRoleUpdate` in `backend/airweave/schemas/invitation.py`
+- Frontend API: `updateMemberRole` in `frontend-v2/src/lib/api/organizations.ts`
+- Frontend UI: Role dropdown in members settings page for non-owner members
 
 ## Key Files Reference
 
 ### Migration Spec
-- `MIGRATION_SPEC.md` - Full migration specification with checklist
+- `MIGRATION_SPEC.md` - Full migration specification with checklist (all items now checked)
+
+### Backend Changes
+- `backend/airweave/api/v1/endpoints/organizations.py` - Added PATCH member role endpoint
+- `backend/airweave/schemas/invitation.py` - Added MemberRoleUpdate schema
+- `backend/airweave/schemas/__init__.py` - Exported MemberRoleUpdate
 
 ### Frontend-v2 Structure
 - Routes: `frontend-v2/src/routes/`
@@ -42,17 +48,9 @@ The only incomplete item requires backend work:
 
 ## Next Steps
 
-If backend support for member role editing is added:
-1. Create API function in `frontend-v2/src/lib/api/organizations.ts`:
-   ```typescript
-   export async function updateMemberRole(
-     token: string,
-     organizationId: string,
-     memberId: string,
-     role: 'admin' | 'member'
-   ): Promise<void>
-   ```
-2. Add mutation in `frontend-v2/src/routes/$orgSlug/settings/members.tsx`
-3. Add edit button/dropdown to member row UI
+The frontend migration project is **complete**. All tasks have been implemented and verified.
 
-Otherwise, the frontend migration project is complete.
+If starting a new project or enhancement:
+1. Review `MIGRATION_SPEC.md` for architecture decisions made during migration
+2. The `frontend-v2` codebase follows TanStack Router + React Query patterns
+3. API functions are modular in `src/lib/api/` directory

--- a/backend/airweave/schemas/__init__.py
+++ b/backend/airweave/schemas/__init__.py
@@ -63,6 +63,7 @@ from .invitation import (
     InvitationCreate,
     InvitationResponse,
     MemberResponse,
+    MemberRoleUpdate,
 )
 from .organization import (
     Organization,

--- a/backend/airweave/schemas/invitation.py
+++ b/backend/airweave/schemas/invitation.py
@@ -38,3 +38,9 @@ class MemberResponse(BaseModel):
     status: str = "active"
     is_primary: bool = False
     auth0_id: Optional[str] = None
+
+
+class MemberRoleUpdate(BaseModel):
+    """Schema for updating a member's role."""
+
+    role: str  # "admin" or "member" (not "owner" - ownership transfer is separate)

--- a/frontend-v2/src/lib/api/index.ts
+++ b/frontend-v2/src/lib/api/index.ts
@@ -35,6 +35,7 @@ export {
   inviteOrganizationMemberWithResponse,
   removeOrganizationMember,
   setPrimaryOrganization,
+  updateMemberRole,
   updateOrganization,
 } from "./organizations";
 export type {

--- a/frontend-v2/src/lib/api/organizations.ts
+++ b/frontend-v2/src/lib/api/organizations.ts
@@ -108,51 +108,6 @@ export async function createOrganization(
 }
 
 /**
- * Billing checkout session request
- */
-export interface CheckoutSessionRequest {
-  plan: string;
-  success_url: string;
-  cancel_url: string;
-}
-
-/**
- * Billing checkout session response
- */
-export interface CheckoutSessionResponse {
-  checkout_url: string;
-}
-
-/**
- * Create a billing checkout session
- */
-export async function createCheckoutSession(
-  token: string,
-  data: CheckoutSessionRequest,
-  yearly: boolean = false
-): Promise<CheckoutSessionResponse> {
-  const endpoint = yearly
-    ? `${API_BASE_URL}/billing/yearly/checkout-session`
-    : `${API_BASE_URL}/billing/checkout-session`;
-
-  const response = await fetch(endpoint, {
-    method: "POST",
-    headers: getAuthHeaders(token),
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const message = await parseErrorResponse(
-      response,
-      "Failed to create checkout session"
-    );
-    throw new Error(message);
-  }
-
-  return response.json();
-}
-
-/**
  * Invite a member to an organization
  */
 export async function inviteOrganizationMember(
@@ -426,4 +381,33 @@ export async function cancelOrganizationInvitation(
     );
     throw new Error(message);
   }
+}
+
+/**
+ * Update a member's role in an organization
+ */
+export async function updateMemberRole(
+  token: string,
+  organizationId: string,
+  memberId: string,
+  role: "admin" | "member"
+): Promise<OrganizationMember> {
+  const response = await fetch(
+    `${API_BASE_URL}/organizations/${organizationId}/members/${memberId}`,
+    {
+      method: "PATCH",
+      headers: getAuthHeaders(token),
+      body: JSON.stringify({ role }),
+    }
+  );
+
+  if (!response.ok) {
+    const message = await parseErrorResponse(
+      response,
+      "Failed to update member role"
+    );
+    throw new Error(message);
+  }
+
+  return response.json();
 }


### PR DESCRIPTION
roles. This completes the frontend-v2 migration project.

Backend changes:
- Add PATCH /organizations/{id}/members/{memberId} endpoint to update
  member roles
- Add MemberRoleUpdate schema for role update requests
- Include permission checks: only owners/admins can edit roles, cannot
  edit owner's role, cannot edit own role

Frontend changes:
- Add updateMemberRole API function in organizations.ts
- Add role dropdown UI in members settings page for non-owner members
- Integrate mutation with React Query for optimistic updates
- Refactor billing checkout imports to use dedicated billing module

Documentation updates:
- Update MIGRATION_SPEC.md to mark Members Settings as complete
- Update SHARED_TASK_NOTES.md to reflect project completion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the ability to edit organization member roles from Members Settings, with a new backend endpoint and a simple role dropdown UI. This completes the frontend-v2 migration.

- **New Features**
  - Backend: Added PATCH /organizations/{id}/members/{memberId} with MemberRoleUpdate schema and permission checks (owners/admins only; cannot change owner’s role; cannot change your own role).
  - Frontend: Added updateMemberRole API, integrated a role dropdown for non-owner members, and wired up a React Query mutation with success/error toasts.

- **Refactors**
  - Moved billing checkout logic to a dedicated billing module and updated onboarding hook.
  - Updated MIGRATION_SPEC.md and SHARED_TASK_NOTES.md to mark Members Settings as complete.

<sup>Written for commit c3cef3d55807b1e949d4c7fa97e9e12c0c2cb112. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

