### PR TITLE
feat(tracking): integrate Reddit Pixel for tracking new signups 

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,6 +21,12 @@
       }
     })();
   </script>
+  <!-- Reddit Pixel -->
+  <script>
+  !function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);
+  rdt('init','a2_ib2d0jv3vre5');
+  </script>
+  <!-- End Reddit Pixel -->
 </head>
 
 <body>

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -27,6 +27,13 @@ import { useAuth } from '@/lib/auth-context';
 import authConfig from '@/config/auth';
 import { posthog } from '@/lib/posthog-provider';
 
+// Reddit Pixel type declaration
+declare global {
+  interface Window {
+    rdt?: (...args: unknown[]) => void;
+  }
+}
+
 interface OnboardingData {
   organizationName: string;
   organizationSize: string;
@@ -332,6 +339,15 @@ export const Onboarding = () => {
         user_role: formData.userRole,
         org_type: formData.organizationType,
       });
+
+      // Fire Reddit Lead event for new signups only (first organization)
+      if (!hasOrganizations) {
+        const redditLeadFired = localStorage.getItem('reddit_lead_fired');
+        if (!redditLeadFired && window.rdt) {
+          window.rdt('track', 'Lead');
+          localStorage.setItem('reddit_lead_fired', 'true');
+        }
+      }
 
       // Step 2: Update organization context
       setCurrentOrganization(organization);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Integrates Reddit Pixel to track new signups. Adds the pixel script and fires a one-time Lead event during onboarding for first-time organizations.

- **New Features**
  - Added Reddit Pixel to index.html and initialized with ID a2_ib2d0jv3vre5.
  - Fired 'Lead' event only on first organization creation, once per browser via localStorage, and only if window.rdt is available.

<sup>Written for commit 317ccb06ce85da740e8c9b3161478c1521be6c9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

