### PR TITLE
feat: Add skip_guardrails flag to bypass entity limits for backfills

### DIFF
--- a/backend/airweave/platform/sync/config.py
+++ b/backend/airweave/platform/sync/config.py
@@ -43,6 +43,12 @@ class SyncExecutionConfig(BaseModel):
         "Uses the sync's existing ARF data.",
     )
 
+    # Guardrail bypass (admin-only)
+    skip_guardrails: bool = Field(
+        False,
+        description="Skip guardrail checks (entity limits, payment status). Admin-only for backfills.",
+    )
+
     @model_validator(mode="after")
     def validate_config_logic(self):
         """Validate that config combinations make sense."""

--- a/backend/airweave/platform/sync/orchestrator.py
+++ b/backend/airweave/platform/sync/orchestrator.py
@@ -192,21 +192,33 @@ class SyncOrchestrator:
         try:
             # Use the pre-created stream (already started in _start_sync)
             async for entity in self.stream.get_entities():
-                try:
-                    await self.sync_context.guard_rail.is_allowed(ActionType.ENTITIES)
-                except (UsageLimitExceededException, PaymentRequiredException) as guard_error:
-                    self.sync_context.logger.error(
-                        f"Guard rail check failed: {type(guard_error).__name__}: {str(guard_error)}"
-                    )
-                    stream_error = guard_error
-                    # Flush any buffered work so we don't drop it
-                    if batch_buffer:
-                        pending_tasks = await self._submit_batch_and_trim(
-                            batch_buffer, pending_tasks
+                # Check guardrails unless explicitly skipped via execution config
+                if (
+                    not self.sync_context.execution_config
+                    or not self.sync_context.execution_config.skip_guardrails
+                ):
+                    try:
+                        await self.sync_context.guard_rail.is_allowed(ActionType.ENTITIES)
+                    except (UsageLimitExceededException, PaymentRequiredException) as guard_error:
+                        self.sync_context.logger.error(
+                            f"Guard rail check failed: {type(guard_error).__name__}: {str(guard_error)}"
                         )
-                        batch_buffer = []
-                        flush_deadline = None
-                    break
+                        stream_error = guard_error
+                        # Flush any buffered work so we don't drop it
+                        if batch_buffer:
+                            pending_tasks = await self._submit_batch_and_trim(
+                                batch_buffer, pending_tasks
+                            )
+                            batch_buffer = []
+                            flush_deadline = None
+                        break
+                else:
+                    # Log once at the start that guardrails are skipped
+                    if not hasattr(self, "_guardrails_skip_logged"):
+                        self.sync_context.logger.warning(
+                            "⚠️ Guardrails skipped via execution config (skip_guardrails=True)"
+                        )
+                        self._guardrails_skip_logged = True
 
                 # Accumulate into batch
                 batch_buffer.append(entity)

--- a/frontend/src/pages/admin/SyncsTab.tsx
+++ b/frontend/src/pages/admin/SyncsTab.tsx
@@ -120,6 +120,7 @@ export function SyncsTab() {
         enableVectorHandlers: true,
         enableRawDataHandler: true,
         enablePostgresHandler: true,
+        skipGuardrails: false,
     });
 
     const loadSyncs = async () => {
@@ -257,6 +258,7 @@ export function SyncsTab() {
             enable_vector_handlers: resyncConfig.enableVectorHandlers,
             enable_raw_data_handler: resyncConfig.enableRawDataHandler,
             enable_postgres_handler: resyncConfig.enablePostgresHandler,
+            skip_guardrails: resyncConfig.skipGuardrails,
         };
 
         for (const sync of selected) {
@@ -445,6 +447,7 @@ export function SyncsTab() {
             enableVectorHandlers: true,
             enableRawDataHandler: true,
             enablePostgresHandler: true,
+            skipGuardrails: false,
         });
         setResyncDialogOpen(true);
     };
@@ -1109,6 +1112,16 @@ export function SyncsTab() {
                                         Skip Vespa
                                     </Label>
                                 </div>
+                                <div className="flex items-center space-x-2">
+                                    <Checkbox
+                                        id="skip-guardrails"
+                                        checked={resyncConfig.skipGuardrails}
+                                        onCheckedChange={(checked) => setResyncConfig({ ...resyncConfig, skipGuardrails: checked as boolean })}
+                                    />
+                                    <Label htmlFor="skip-guardrails" className="text-sm cursor-pointer">
+                                        Skip Guardrails (Entity Limits)
+                                    </Label>
+                                </div>
                             </div>
                         </div>
 
@@ -1250,6 +1263,16 @@ export function SyncsTab() {
                                     />
                                     <Label htmlFor="bulk-skip-vespa" className="text-sm cursor-pointer">
                                         Skip Vespa
+                                    </Label>
+                                </div>
+                                <div className="flex items-center space-x-2">
+                                    <Checkbox
+                                        id="bulk-skip-guardrails"
+                                        checked={resyncConfig.skipGuardrails}
+                                        onCheckedChange={(checked) => setResyncConfig({ ...resyncConfig, skipGuardrails: checked as boolean })}
+                                    />
+                                    <Label htmlFor="bulk-skip-guardrails" className="text-sm cursor-pointer">
+                                        Skip Guardrails (Entity Limits)
                                     </Label>
                                 </div>
                             </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an admin-only skip_guardrails flag to bypass entity limit and payment checks during backfills. When enabled, entity processing skips guardrail checks and logs a one-time warning.

- **New Features**
  - Added skip_guardrails (default false) to SyncExecutionConfig and Admin Syncs UI; flag is sent in resync payloads.
  - Orchestrator respects the flag: skips guardrail checks and logs once; otherwise, on guardrail failure, flushes buffered work and stops processing.

<sup>Written for commit 1ad3eb974c679d741022511d70eb00ac556f0123. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

