### PR TITLE
fix(ci): add coverage flags to pytest command

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,7 +55,7 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Run unit tests with coverage
-        run: poetry run pytest tests/unit/ -m "not slow"
+        run: poetry run pytest tests/unit/ -m "not slow" --cov=airweave --cov-report=xml:coverage.xml
 
       - name: Install diff-cover
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Problem

The unit tests workflow runs pytest without coverage flags:
```yaml
poetry run pytest tests/unit/ -m "not slow"
```

This means `coverage.xml` is never generated, causing `diff-cover` to always fall back to:
> No Python source files were changed in this PR.

...even when Python files are clearly changed (e.g., PR #1253).

## Fix

Add the missing `--cov` flags:
```yaml
poetry run pytest tests/unit/ -m "not slow" --cov=airweave --cov-report=xml:coverage.xml
```

This ensures coverage data is collected and diff-cover can properly analyze changed Python files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add coverage flags to the unit tests workflow so pytest generates coverage.xml. This lets diff-cover analyze changed Python files instead of reporting no changes.

<sup>Written for commit 6a54b7d9b14cd12efd0222d61d55805d76d720c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

