### PR TITLE
fix(sync): check source_instance for file_downloader to enable temp cleanup

### DIFF
--- a/backend/airweave/platform/sync/pipeline/cleanup_service.py
+++ b/backend/airweave/platform/sync/pipeline/cleanup_service.py
@@ -91,7 +91,7 @@ class CleanupService:
             For these sources, file_downloader won't be set, which is expected.
         """
         try:
-            if not hasattr(sync_context.source, "file_downloader"):
+            if not hasattr(sync_context.source_instance, "file_downloader"):
                 sync_context.logger.debug(
                     "Source has no file downloader (API-only source), skipping temp cleanup"
                 )


### PR DESCRIPTION
tested locally

<img width="207" height="73" alt="Screenshot 2026-01-12 at 10 10 20" src="https://github.com/user-attachments/assets/32d45fd0-fc21-42f3-b119-d1849e519719" />


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix temp file cleanup by checking file_downloader on sync_context.source_instance instead of sync_context.source, so cleanup runs for file-based sources and still skips API-only sources, preventing leftover temp files.

<sup>Written for commit 1e3b8387c43c83ea5f2387f25613ce8738570748. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

