### PR TITLE
fix: disable xlsx files

### DIFF
--- a/backend/airweave/platform/sync/file_types.py
+++ b/backend/airweave/platform/sync/file_types.py
@@ -14,8 +14,6 @@ SUPPORTED_FILE_EXTENSIONS = {
     ".jpg",
     ".jpeg",
     ".png",
-    # Spreadsheets (local extraction)
-    ".xlsx",
     # HTML
     ".html",
     ".htm",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disabled XLSX file handling in the sync pipeline to prevent unsupported spreadsheet extraction and avoid processing errors.

<sup>Written for commit d766fa7c17afa9b1dd1b220acc8bc69cc7661e50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

