### PR TITLE
feat(sync): add collection-level deduplication with per-sync entity rows

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -69,13 +69,13 @@ jobs:
           set +e
           diff-cover coverage.xml \
             --compare-branch=origin/${{ github.base_ref }} \
-            --markdown-report=diff-coverage.md \
+            --format markdown:diff-coverage.md \
             --fail-under=80
           EXIT_CODE=$?
           set -e
 
-          # Exit code 2 = coverage below threshold, others = error/no files
-          if [ $EXIT_CODE -eq 2 ]; then
+          # Exit code 1 = coverage below threshold, 0 = success
+          if [ $EXIT_CODE -ne 0 ]; then
             echo "coverage_failed=true" >> $GITHUB_OUTPUT
           else
             echo "coverage_failed=false" >> $GITHUB_OUTPUT

--- a/backend/airweave/crud/crud_entity.py
+++ b/backend/airweave/crud/crud_entity.py
@@ -186,6 +186,57 @@ class CRUDEntity(CRUDBaseOrganization[Entity, EntityCreate, EntityUpdate]):
 
         return result_map
 
+    async def bulk_get_by_entity_collection_and_definition(
+        self,
+        db: AsyncSession,
+        *,
+        collection_id: UUID,
+        entity_requests: list[tuple[str, UUID]],
+    ) -> dict[tuple[str, UUID], Entity]:
+        """Get entities by (entity_id, collection_id, entity_definition_id).
+
+        Used for collection-level deduplication to check if ANY sync in the
+        collection already has a given entity. Returns the first matching
+        entity for each (entity_id, entity_definition_id) pair.
+
+        Args:
+            db: Database session
+            collection_id: The collection ID to filter by
+            entity_requests: List of (entity_id, entity_definition_id) tuples
+
+        Returns:
+            Dict mapping (entity_id, entity_definition_id) -> Entity
+        """
+        if not entity_requests:
+            return {}
+
+        from sqlalchemy import and_, or_
+
+        CHUNK_SIZE = 1000
+        result_map: dict[tuple[str, UUID], Entity] = {}
+
+        for i in range(0, len(entity_requests), CHUNK_SIZE):
+            chunk = entity_requests[i : i + CHUNK_SIZE]
+
+            # Build OR conditions for this chunk
+            conditions = [
+                and_(Entity.entity_id == eid, Entity.entity_definition_id == def_id)
+                for eid, def_id in chunk
+            ]
+
+            stmt = select(Entity).where(Entity.collection_id == collection_id, or_(*conditions))
+
+            result = await db.execute(stmt)
+            rows = list(result.unique().scalars().all())
+
+            # Merge into result map - first match wins (any sync in collection)
+            for row in rows:
+                key = (row.entity_id, row.entity_definition_id)
+                if key not in result_map:
+                    result_map[key] = row
+
+        return result_map
+
     def _get_org_id_from_context(self, ctx: ApiContext) -> UUID | None:
         """Attempt to extract organization ID from the API context."""
         # 1) Direct attributes

--- a/backend/airweave/crud/crud_entity.py
+++ b/backend/airweave/crud/crud_entity.py
@@ -26,6 +26,31 @@ class CRUDEntity(CRUDBaseOrganization[Entity, EntityCreate, EntityUpdate]):
         """
         super().__init__(Entity, track_user=False)
 
+    def _prepare_entity_data(self, obj_in: EntityCreate | dict, org_id: UUID) -> dict:
+        """Prepare entity data with organization ID and timestamps.
+
+        Args:
+            obj_in: Entity data (Pydantic model or dict)
+            org_id: Organization ID to set
+
+        Returns:
+            Dict with organization_id and timestamps guaranteed
+        """
+        if not isinstance(obj_in, dict):
+            data = obj_in.model_dump(exclude_unset=True)
+        else:
+            data = obj_in.copy()
+
+        data["organization_id"] = org_id
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        if "created_at" not in data:
+            data["created_at"] = now
+        if "modified_at" not in data:
+            data["modified_at"] = now
+
+        return data
+
     async def create(
         self,
         db: AsyncSession,
@@ -51,21 +76,9 @@ class CRUDEntity(CRUDBaseOrganization[Entity, EntityCreate, EntityUpdate]):
             The created or updated entity
         """
         if not skip_validation:
-            # Validate auth context has org access
             await self._validate_organization_access(ctx, ctx.organization.id)
 
-        if not isinstance(obj_in, dict):
-            obj_in_dict = obj_in.model_dump(exclude_unset=True)
-        else:
-            obj_in_dict = obj_in
-
-        obj_in_dict["organization_id"] = ctx.organization.id
-
-        # Ensure we have timestamps
-        if "created_at" not in obj_in_dict:
-            obj_in_dict["created_at"] = datetime.now(timezone.utc).replace(tzinfo=None)
-        if "modified_at" not in obj_in_dict:
-            obj_in_dict["modified_at"] = datetime.now(timezone.utc).replace(tzinfo=None)
+        obj_in_dict = self._prepare_entity_data(obj_in, ctx.organization.id)
 
         # Use PostgreSQL's INSERT ... ON CONFLICT DO UPDATE
         stmt = insert(Entity).values(**obj_in_dict)
@@ -157,34 +170,12 @@ class CRUDEntity(CRUDBaseOrganization[Entity, EntityCreate, EntityUpdate]):
         Returns:
             Dict mapping (entity_id, entity_definition_id) -> Entity
         """
-        if not entity_requests:
-            return {}
-
-        from sqlalchemy import and_, or_
-
-        # Chunk requests to avoid timeouts with large datasets
-        CHUNK_SIZE = 1000
-        result_map: dict[tuple[str, UUID], Entity] = {}
-
-        for i in range(0, len(entity_requests), CHUNK_SIZE):
-            chunk = entity_requests[i : i + CHUNK_SIZE]
-
-            # Build OR conditions for this chunk
-            conditions = [
-                and_(Entity.entity_id == eid, Entity.entity_definition_id == def_id)
-                for eid, def_id in chunk
-            ]
-
-            stmt = select(Entity).where(Entity.sync_id == sync_id, or_(*conditions))
-
-            result = await db.execute(stmt)
-            rows = list(result.unique().scalars().all())
-
-            # Merge into result map with composite key to avoid collisions
-            for row in rows:
-                result_map[(row.entity_id, row.entity_definition_id)] = row
-
-        return result_map
+        return await self._bulk_get_by_entity_and_definition(
+            db,
+            scope_filter=Entity.sync_id == sync_id,
+            entity_requests=entity_requests,
+            first_match_wins=False,
+        )
 
     async def bulk_get_by_entity_collection_and_definition(
         self,
@@ -207,6 +198,35 @@ class CRUDEntity(CRUDBaseOrganization[Entity, EntityCreate, EntityUpdate]):
         Returns:
             Dict mapping (entity_id, entity_definition_id) -> Entity
         """
+        return await self._bulk_get_by_entity_and_definition(
+            db,
+            scope_filter=Entity.collection_id == collection_id,
+            entity_requests=entity_requests,
+            first_match_wins=True,
+        )
+
+    async def _bulk_get_by_entity_and_definition(
+        self,
+        db: AsyncSession,
+        *,
+        scope_filter,
+        entity_requests: list[tuple[str, UUID]],
+        first_match_wins: bool = False,
+    ) -> dict[tuple[str, UUID], Entity]:
+        """Internal helper for bulk entity lookups by (entity_id, entity_definition_id).
+
+        Chunks large requests to avoid database timeouts from massive OR conditions.
+
+        Args:
+            db: Database session
+            scope_filter: SQLAlchemy filter clause (e.g., Entity.sync_id == sync_id)
+            entity_requests: List of (entity_id, entity_definition_id) tuples
+            first_match_wins: If True, keep first match per key (for collection dedup).
+                              If False, last match overwrites (for sync-level lookup).
+
+        Returns:
+            Dict mapping (entity_id, entity_definition_id) -> Entity
+        """
         if not entity_requests:
             return {}
 
@@ -224,16 +244,17 @@ class CRUDEntity(CRUDBaseOrganization[Entity, EntityCreate, EntityUpdate]):
                 for eid, def_id in chunk
             ]
 
-            stmt = select(Entity).where(Entity.collection_id == collection_id, or_(*conditions))
+            stmt = select(Entity).where(scope_filter, or_(*conditions))
 
             result = await db.execute(stmt)
             rows = list(result.unique().scalars().all())
 
-            # Merge into result map - first match wins (any sync in collection)
+            # Merge into result map
             for row in rows:
                 key = (row.entity_id, row.entity_definition_id)
-                if key not in result_map:
-                    result_map[key] = row
+                if first_match_wins and key in result_map:
+                    continue  # Keep first match
+                result_map[key] = row
 
         return result_map
 
@@ -284,17 +305,8 @@ class CRUDEntity(CRUDBaseOrganization[Entity, EntityCreate, EntityUpdate]):
         if org_id is None:
             raise ValueError("ApiContext must contain valid organization information")
 
-        # Prepare data for bulk upsert
-        values_list = []
-        for o in objs:
-            data = o.model_dump()
-            data["organization_id"] = org_id
-            # Ensure we have timestamps
-            if "created_at" not in data:
-                data["created_at"] = datetime.now(timezone.utc).replace(tzinfo=None)
-            if "modified_at" not in data:
-                data["modified_at"] = datetime.now(timezone.utc).replace(tzinfo=None)
-            values_list.append(data)
+        # Prepare data for bulk upsert using shared helper
+        values_list = [self._prepare_entity_data(o, org_id) for o in objs]
 
         # Use PostgreSQL's INSERT ... ON CONFLICT DO UPDATE
         # This handles the unique constraint on (sync_id, entity_id, entity_definition_id)

--- a/backend/airweave/platform/sync/actions/entity/dispatcher.py
+++ b/backend/airweave/platform/sync/actions/entity/dispatcher.py
@@ -25,9 +25,14 @@ class EntityActionDispatcher:
     - PostgreSQL metadata handler runs ONLY AFTER all destination handlers succeed
     - This ensures consistency between vector stores and metadata
 
+    Collection-Level Deduplication:
+    - Inserts with skip_content_handlers=True are filtered out for destination handlers
+    - PostgreSQL handler receives ALL inserts (needs to record entity ownership)
+    - Filtering happens centrally in dispatcher, not in individual handlers
+
     Execution Order:
-    1. All destination handlers (non-Postgres) execute concurrently
-    2. If all succeed → PostgreSQL metadata handler executes
+    1. All destination handlers (non-Postgres) execute concurrently (filtered batch)
+    2. If all succeed → PostgreSQL metadata handler executes (full batch)
     3. If any fails → SyncFailureError, no Postgres writes
     """
 
@@ -61,8 +66,8 @@ class EntityActionDispatcher:
         """Dispatch action batch to all handlers.
 
         Execution order:
-        1. All destination handlers concurrently (Qdrant, RawData, etc.)
-        2. If all succeed → PostgreSQL metadata handler
+        1. All destination handlers concurrently (filtered batch - skip_content_handlers removed)
+        2. If all succeed → PostgreSQL metadata handler (full batch - all inserts)
         3. If any fails → SyncFailureError propagates
 
         Args:
@@ -81,10 +86,13 @@ class EntityActionDispatcher:
             f"[EntityDispatcher] Dispatching {batch.summary()} to handlers: {handler_names}"
         )
 
-        # Step 1: Execute destination handlers concurrently
-        await self._dispatch_to_destinations(batch, sync_context)
+        # Step 1: Create filtered batch for destination handlers (collection-level dedup)
+        destination_batch = self._filter_batch_for_destinations(batch, sync_context)
 
-        # Step 2: Execute postgres handler (only after destinations succeed)
+        # Step 2: Execute destination handlers concurrently with filtered batch
+        await self._dispatch_to_destinations(destination_batch, sync_context)
+
+        # Step 3: Execute postgres handler with FULL batch (needs all inserts for ownership)
         if self._postgres_handler:
             await self._dispatch_to_postgres(batch, sync_context)
 
@@ -154,6 +162,47 @@ class EntityActionDispatcher:
     # -------------------------------------------------------------------------
     # Internal Methods
     # -------------------------------------------------------------------------
+
+    def _filter_batch_for_destinations(
+        self,
+        batch: EntityActionBatch,
+        sync_context: "SyncContext",
+    ) -> EntityActionBatch:
+        """Filter batch for destination handlers (collection-level deduplication).
+
+        Removes inserts with skip_content_handlers=True. These entities already
+        exist in another sync within the collection with the same hash, so we
+        don't need to write them to vector DBs or ARF again.
+
+        Args:
+            batch: Original batch with all inserts
+            sync_context: Sync context for logging
+
+        Returns:
+            Filtered batch for destination handlers
+        """
+        # Filter out inserts where skip_content_handlers=True
+        filtered_inserts = [a for a in batch.inserts if not a.skip_content_handlers]
+        skipped_count = len(batch.inserts) - len(filtered_inserts)
+
+        if skipped_count > 0:
+            sync_context.logger.debug(
+                f"[EntityDispatcher] Filtering {skipped_count} inserts for destination handlers "
+                f"(collection-level dedup)"
+            )
+
+        # If no filtering needed, return original batch
+        if skipped_count == 0:
+            return batch
+
+        # Create new batch with filtered inserts
+        return EntityActionBatch(
+            inserts=filtered_inserts,
+            updates=batch.updates,
+            deletes=batch.deletes,
+            keeps=batch.keeps,
+            existing_map=batch.existing_map,
+        )
 
     async def _dispatch_to_destinations(
         self,

--- a/backend/airweave/platform/sync/actions/entity/types.py
+++ b/backend/airweave/platform/sync/actions/entity/types.py
@@ -20,11 +20,20 @@ if TYPE_CHECKING:
 
 @dataclass
 class EntityInsertAction:
-    """Entity should be inserted (new entity, not in database)."""
+    """Entity should be inserted (new entity, not in database).
+
+    For collection-level dedup: if another sync in the collection already has
+    this entity with the same hash, skip_content_handlers is set to True to
+    avoid redundant vector DB and ARF writes. Only postgres handler runs to
+    record this sync's ownership of the entity.
+    """
 
     entity: "BaseEntity"
     entity_definition_id: UUID
     chunk_entities: List["BaseEntity"] = field(default_factory=list)
+    # Skip destination + ARF handlers if another sync already has this entity (collection dedup)
+    # Only postgres handler should run to record this sync's ownership
+    skip_content_handlers: bool = False
 
     @property
     def entity_id(self) -> str:

--- a/backend/airweave/platform/sync/config/base.py
+++ b/backend/airweave/platform/sync/config/base.py
@@ -48,6 +48,15 @@ class BehaviorConfig(BaseModel):
         False, description="Replay from ARF storage instead of calling source"
     )
     skip_guardrails: bool = Field(False, description="Skip usage guardrails (entity count checks)")
+    dedupe_by_collection: bool = Field(
+        False,
+        description=(
+            "Enable collection-level deduplication. When True, entities are deduplicated "
+            "across all syncs in the collection. Each sync maintains its own entity rows "
+            "for proper CASCADE on delete, but content handlers (vector DB, ARF) skip "
+            "writes if another sync already has the entity with the same hash."
+        ),
+    )
 
 
 class SyncConfig(BaseSettings):

--- a/backend/tests/unit/platform/sync/actions/entity/test_dispatcher.py
+++ b/backend/tests/unit/platform/sync/actions/entity/test_dispatcher.py
@@ -1,0 +1,400 @@
+"""Tests for EntityActionDispatcher.
+
+Tests the dispatcher's batch filtering and handler coordination,
+including skip_content_handlers filtering for collection-level deduplication.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from airweave.platform.sync.actions.entity.dispatcher import EntityActionDispatcher
+from airweave.platform.sync.actions.entity.types import (
+    EntityActionBatch,
+    EntityDeleteAction,
+    EntityInsertAction,
+    EntityUpdateAction,
+)
+from airweave.platform.sync.handlers.entity_postgres import EntityPostgresHandler
+from airweave.platform.sync.handlers.protocol import EntityActionHandler
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+class MockEntity:
+    """Mock entity for testing."""
+
+    def __init__(self, entity_id: str):
+        self.entity_id = entity_id
+
+
+class MockLogger:
+    """Mock logger for testing."""
+
+    def debug(self, msg: str) -> None:
+        pass
+
+    def info(self, msg: str) -> None:
+        pass
+
+    def warning(self, msg: str) -> None:
+        pass
+
+    def error(self, msg: str, exc_info: bool = False) -> None:
+        pass
+
+
+class MockSync:
+    """Mock sync object."""
+
+    def __init__(self):
+        self.id = uuid4()
+
+
+class MockSyncContext:
+    """Mock sync context for testing."""
+
+    def __init__(self):
+        self.sync = MockSync()
+        self.logger = MockLogger()
+
+
+class MockDestinationHandler(EntityActionHandler):
+    """Mock destination handler for testing."""
+
+    def __init__(self, name: str = "mock_destination"):
+        self._name = name
+        self.handle_batch = AsyncMock()
+        self.handle_orphan_cleanup = AsyncMock()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+
+class MockPostgresHandler(EntityPostgresHandler):
+    """Mock postgres handler for testing."""
+
+    def __init__(self):
+        # Don't call super().__init__() to avoid dependency injection
+        pass
+
+    @property
+    def name(self) -> str:
+        return "postgres"
+
+    async def handle_batch(self, batch, sync_context):
+        pass
+
+    async def handle_orphan_cleanup(self, orphan_entity_ids, sync_context):
+        pass
+
+
+def create_insert_action(entity_id: str, skip: bool = False) -> EntityInsertAction:
+    """Create an insert action for testing."""
+    entity = MockEntity(entity_id)
+    return EntityInsertAction(
+        entity=entity,
+        entity_definition_id=uuid4(),
+        skip_content_handlers=skip,
+    )
+
+
+def create_update_action(entity_id: str) -> EntityUpdateAction:
+    """Create an update action for testing."""
+    entity = MockEntity(entity_id)
+    return EntityUpdateAction(
+        entity=entity,
+        entity_definition_id=uuid4(),
+        db_id=uuid4(),
+    )
+
+
+def create_delete_action(entity_id: str) -> EntityDeleteAction:
+    """Create a delete action for testing."""
+    entity = MockEntity(entity_id)
+    return EntityDeleteAction(
+        entity=entity,
+        entity_definition_id=uuid4(),
+        db_id=uuid4(),
+    )
+
+
+# =============================================================================
+# Test Classes
+# =============================================================================
+
+
+class TestDispatcherInit:
+    """Test EntityActionDispatcher initialization."""
+
+    def test_separates_postgres_from_destination_handlers(self):
+        """Test that postgres handler is separated from destination handlers."""
+        dest_handler = MockDestinationHandler("destination")
+        postgres_handler = MockPostgresHandler()
+
+        dispatcher = EntityActionDispatcher([dest_handler, postgres_handler])
+
+        assert len(dispatcher._destination_handlers) == 1
+        assert dispatcher._destination_handlers[0] == dest_handler
+        assert dispatcher._postgres_handler == postgres_handler
+
+    def test_handles_no_postgres_handler(self):
+        """Test dispatcher works without postgres handler."""
+        dest_handler = MockDestinationHandler("destination")
+
+        dispatcher = EntityActionDispatcher([dest_handler])
+
+        assert len(dispatcher._destination_handlers) == 1
+        assert dispatcher._postgres_handler is None
+
+    def test_handles_multiple_destination_handlers(self):
+        """Test dispatcher with multiple destination handlers."""
+        dest1 = MockDestinationHandler("dest1")
+        dest2 = MockDestinationHandler("dest2")
+
+        dispatcher = EntityActionDispatcher([dest1, dest2])
+
+        assert len(dispatcher._destination_handlers) == 2
+
+
+class TestFilterBatchForDestinations:
+    """Test _filter_batch_for_destinations method."""
+
+    def test_filters_inserts_with_skip_content_handlers(self):
+        """Test filtering removes inserts with skip_content_handlers=True."""
+        dispatcher = EntityActionDispatcher([])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[
+                create_insert_action("entity-1", skip=False),  # Keep
+                create_insert_action("entity-2", skip=True),   # Filter out
+                create_insert_action("entity-3", skip=False),  # Keep
+            ],
+            updates=[create_update_action("entity-4")],
+            deletes=[create_delete_action("entity-5")],
+            keeps=[],
+        )
+
+        filtered = dispatcher._filter_batch_for_destinations(batch, ctx)
+
+        assert len(filtered.inserts) == 2
+        assert all(not a.skip_content_handlers for a in filtered.inserts)
+        # Updates and deletes are preserved
+        assert len(filtered.updates) == 1
+        assert len(filtered.deletes) == 1
+
+    def test_returns_original_when_no_filtering_needed(self):
+        """Test returns original batch when no skip_content_handlers flags."""
+        dispatcher = EntityActionDispatcher([])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[
+                create_insert_action("entity-1", skip=False),
+                create_insert_action("entity-2", skip=False),
+            ],
+            updates=[],
+            deletes=[],
+            keeps=[],
+        )
+
+        filtered = dispatcher._filter_batch_for_destinations(batch, ctx)
+
+        # Should be the same object (no copy needed)
+        assert filtered is batch
+
+    def test_filters_all_inserts_when_all_skipped(self):
+        """Test all inserts filtered when all have skip_content_handlers=True."""
+        dispatcher = EntityActionDispatcher([])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[
+                create_insert_action("entity-1", skip=True),
+                create_insert_action("entity-2", skip=True),
+            ],
+            updates=[],
+            deletes=[],
+            keeps=[],
+        )
+
+        filtered = dispatcher._filter_batch_for_destinations(batch, ctx)
+
+        assert len(filtered.inserts) == 0
+
+    def test_preserves_existing_map(self):
+        """Test filtered batch preserves existing_map."""
+        dispatcher = EntityActionDispatcher([])
+        ctx = MockSyncContext()
+
+        existing_map = {("entity-1", uuid4()): MagicMock()}
+        batch = EntityActionBatch(
+            inserts=[create_insert_action("entity-1", skip=True)],
+            updates=[],
+            deletes=[],
+            keeps=[],
+            existing_map=existing_map,
+        )
+
+        filtered = dispatcher._filter_batch_for_destinations(batch, ctx)
+
+        assert filtered.existing_map == existing_map
+
+
+class TestDispatch:
+    """Test dispatch method."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_sends_filtered_batch_to_destinations(self):
+        """Test destinations receive filtered batch."""
+        dest_handler = MockDestinationHandler("destination")
+        dispatcher = EntityActionDispatcher([dest_handler])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[
+                create_insert_action("entity-1", skip=False),  # Keep
+                create_insert_action("entity-2", skip=True),   # Filter
+            ],
+            updates=[],
+            deletes=[],
+            keeps=[],
+        )
+
+        await dispatcher.dispatch(batch, ctx)
+
+        dest_handler.handle_batch.assert_called_once()
+        received_batch = dest_handler.handle_batch.call_args[0][0]
+        # Destination should receive filtered batch (1 insert)
+        assert len(received_batch.inserts) == 1
+        assert received_batch.inserts[0].entity.entity_id == "entity-1"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_sends_full_batch_to_postgres(self):
+        """Test postgres receives full batch (all inserts)."""
+        postgres_handler = MockPostgresHandler()
+        postgres_handler.handle_batch = AsyncMock()
+        dispatcher = EntityActionDispatcher([postgres_handler])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[
+                create_insert_action("entity-1", skip=False),
+                create_insert_action("entity-2", skip=True),  # Still sent to postgres
+            ],
+            updates=[],
+            deletes=[],
+            keeps=[],
+        )
+
+        await dispatcher.dispatch(batch, ctx)
+
+        postgres_handler.handle_batch.assert_called_once()
+        received_batch = postgres_handler.handle_batch.call_args[0][0]
+        # Postgres should receive full batch (both inserts)
+        assert len(received_batch.inserts) == 2
+
+    @pytest.mark.asyncio
+    async def test_dispatch_order_destinations_then_postgres(self):
+        """Test destinations are processed before postgres."""
+        dest_handler = MockDestinationHandler("destination")
+        postgres_handler = MockPostgresHandler()
+        postgres_handler.handle_batch = AsyncMock()
+        call_order = []
+
+        async def track_dest(*args, **kwargs):
+            call_order.append("destination")
+
+        async def track_postgres(*args, **kwargs):
+            call_order.append("postgres")
+
+        dest_handler.handle_batch = AsyncMock(side_effect=track_dest)
+        postgres_handler.handle_batch = AsyncMock(side_effect=track_postgres)
+
+        dispatcher = EntityActionDispatcher([dest_handler, postgres_handler])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[create_insert_action("entity-1")],
+            updates=[],
+            deletes=[],
+            keeps=[],
+        )
+
+        await dispatcher.dispatch(batch, ctx)
+
+        assert call_order == ["destination", "postgres"]
+
+    @pytest.mark.asyncio
+    async def test_dispatch_skips_when_no_mutations(self):
+        """Test dispatch returns early with no mutations."""
+        dest_handler = MockDestinationHandler("destination")
+        dispatcher = EntityActionDispatcher([dest_handler])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[],
+            updates=[],
+            deletes=[],
+            keeps=[MagicMock()],  # Only keeps
+        )
+
+        await dispatcher.dispatch(batch, ctx)
+
+        dest_handler.handle_batch.assert_not_called()
+
+
+class TestDispatchWithMixedActions:
+    """Test dispatch with various action combinations."""
+
+    @pytest.mark.asyncio
+    async def test_updates_not_filtered(self):
+        """Test updates are never filtered (skip_content_handlers is for inserts)."""
+        dest_handler = MockDestinationHandler("destination")
+        dispatcher = EntityActionDispatcher([dest_handler])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[],
+            updates=[
+                create_update_action("entity-1"),
+                create_update_action("entity-2"),
+            ],
+            deletes=[],
+            keeps=[],
+        )
+
+        await dispatcher.dispatch(batch, ctx)
+
+        dest_handler.handle_batch.assert_called_once()
+        received_batch = dest_handler.handle_batch.call_args[0][0]
+        assert len(received_batch.updates) == 2
+
+    @pytest.mark.asyncio
+    async def test_deletes_not_filtered(self):
+        """Test deletes are never filtered."""
+        dest_handler = MockDestinationHandler("destination")
+        dispatcher = EntityActionDispatcher([dest_handler])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[],
+            updates=[],
+            deletes=[
+                create_delete_action("entity-1"),
+                create_delete_action("entity-2"),
+            ],
+            keeps=[],
+        )
+
+        await dispatcher.dispatch(batch, ctx)
+
+        dest_handler.handle_batch.assert_called_once()
+        received_batch = dest_handler.handle_batch.call_args[0][0]
+        assert len(received_batch.deletes) == 2

--- a/backend/tests/unit/platform/sync/actions/entity/test_resolver.py
+++ b/backend/tests/unit/platform/sync/actions/entity/test_resolver.py
@@ -1,0 +1,856 @@
+"""Tests for EntityActionResolver.
+
+Tests the entity action resolution logic including:
+- INSERT/UPDATE/DELETE/KEEP action resolution
+- Sync-level vs collection-level deduplication
+- Deletion entity handling
+- Polymorphic entity handling
+- skip_hash_comparison mode
+"""
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional, Type
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from airweave.platform.entities._airweave_field import AirweaveField
+from airweave.platform.entities._base import (
+    AirweaveSystemMetadata,
+    BaseEntity,
+    DeletionEntity,
+    PolymorphicEntity,
+)
+from airweave.platform.sync.actions.entity.resolver import EntityActionResolver
+from airweave.platform.sync.actions.entity.types import (
+    EntityActionBatch,
+    EntityDeleteAction,
+    EntityInsertAction,
+    EntityKeepAction,
+    EntityUpdateAction,
+)
+from airweave.platform.sync.config import BehaviorConfig, SyncConfig
+from airweave.platform.sync.exceptions import SyncFailureError
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+class MockEntity(BaseEntity):
+    """Simple mock entity for resolver tests."""
+
+    mock_id: str = AirweaveField(..., description="Entity ID", is_entity_id=True)
+    mock_name: str = AirweaveField(..., description="Entity name", is_name=True)
+
+
+class MockEntity2(BaseEntity):
+    """Another mock entity type for multi-type tests."""
+
+    mock_id: str = AirweaveField(..., description="Entity ID", is_entity_id=True)
+    mock_name: str = AirweaveField(..., description="Entity name", is_name=True)
+
+
+class MockDeletionEntity(DeletionEntity):
+    """Mock deletion entity."""
+
+    deletes_entity_class: ClassVar[Optional[Type[BaseEntity]]] = MockEntity
+    deletion_id: str = AirweaveField(..., description="Deletion ID", is_entity_id=True)
+    deletion_name: str = AirweaveField(..., description="Deletion name", is_name=True)
+
+
+class MockPolymorphicEntity(PolymorphicEntity):
+    """Mock polymorphic entity for table-based entities."""
+
+    table_name: str = "test_table"
+
+
+@dataclass
+class MockDbEntity:
+    """Mock database entity for testing."""
+
+    id: UUID
+    entity_id: str
+    entity_definition_id: UUID
+    hash: str
+
+
+class MockLogger:
+    """Mock logger for testing."""
+
+    def debug(self, msg: str) -> None:
+        pass
+
+    def info(self, msg: str) -> None:
+        pass
+
+    def warning(self, msg: str) -> None:
+        pass
+
+    def error(self, msg: str) -> None:
+        pass
+
+
+class MockSync:
+    """Mock sync object."""
+
+    def __init__(self, sync_id: Optional[UUID] = None):
+        self.id = sync_id or uuid4()
+
+
+class MockSyncContext:
+    """Mock sync context for testing."""
+
+    def __init__(
+        self,
+        sync_id: Optional[UUID] = None,
+        collection_id: Optional[UUID] = None,
+        execution_config: Optional[SyncConfig] = None,
+    ):
+        self.sync = MockSync(sync_id)
+        self.collection_id = collection_id or uuid4()
+        self.execution_config = execution_config
+        self.logger = MockLogger()
+
+
+def create_mock_entity(ent_id: str, hash_value: str) -> MockEntity:
+    """Create a MockEntity with system metadata and hash set."""
+    entity = MockEntity(
+        mock_id=ent_id,
+        mock_name=f"Entity {ent_id}",
+        breadcrumbs=[],
+    )
+    # Manually set entity_id since the validator copies from flagged field
+    entity.entity_id = ent_id
+    entity.airweave_system_metadata = AirweaveSystemMetadata(hash=hash_value)
+    return entity
+
+
+def create_mock_entity2(ent_id: str, hash_value: str) -> MockEntity2:
+    """Create a MockEntity2 with system metadata and hash set."""
+    entity = MockEntity2(
+        mock_id=ent_id,
+        mock_name=f"Entity {ent_id}",
+        breadcrumbs=[],
+    )
+    # Manually set entity_id since the validator copies from flagged field
+    entity.entity_id = ent_id
+    entity.airweave_system_metadata = AirweaveSystemMetadata(hash=hash_value)
+    return entity
+
+
+def create_deletion_entity(
+    ent_id: str,
+    deletion_status: str = "removed",
+) -> MockDeletionEntity:
+    """Create a deletion entity for testing."""
+    entity = MockDeletionEntity(
+        deletion_id=ent_id,
+        deletion_name=f"Deleted {ent_id}",
+        deletion_status=deletion_status,
+        breadcrumbs=[],
+    )
+    # Manually set entity_id since the validator copies from flagged field
+    entity.entity_id = ent_id
+    entity.airweave_system_metadata = AirweaveSystemMetadata()
+    return entity
+
+
+def create_polymorphic_entity(ent_id: str, hash_value: str) -> MockPolymorphicEntity:
+    """Create a polymorphic entity for testing."""
+    entity = MockPolymorphicEntity(
+        table_name="test_table",
+        entity_id=ent_id,
+        name=f"PolyEntity {ent_id}",
+        breadcrumbs=[],
+    )
+    entity.airweave_system_metadata = AirweaveSystemMetadata(hash=hash_value)
+    return entity
+
+
+# =============================================================================
+# Test Classes
+# =============================================================================
+
+
+class TestEntityActionResolverInit:
+    """Test EntityActionResolver initialization."""
+
+    def test_init_with_entity_map(self):
+        """Test resolver initializes with entity map."""
+        entity_map = {MockEntity: uuid4(), MockEntity2: uuid4()}
+        resolver = EntityActionResolver(entity_map)
+        assert resolver.entity_map == entity_map
+
+    def test_init_with_empty_map(self):
+        """Test resolver can initialize with empty map."""
+        resolver = EntityActionResolver({})
+        assert resolver.entity_map == {}
+
+
+class TestResolveEntityDefinitionId:
+    """Test resolve_entity_definition_id method."""
+
+    def test_resolves_regular_entity(self):
+        """Test resolution of a regular entity."""
+        entity_def_id = uuid4()
+        entity_map = {MockEntity: entity_def_id}
+        resolver = EntityActionResolver(entity_map)
+
+        entity = create_mock_entity("test-1", "hash1")
+        result = resolver.resolve_entity_definition_id(entity)
+
+        assert result == entity_def_id
+
+    def test_resolves_deletion_entity_to_target_class(self):
+        """Test deletion entity resolves to its target class definition."""
+        target_def_id = uuid4()
+        entity_map = {MockEntity: target_def_id}
+        resolver = EntityActionResolver(entity_map)
+
+        deletion = create_deletion_entity("del-1", "removed")
+        result = resolver.resolve_entity_definition_id(deletion)
+
+        assert result == target_def_id
+
+    def test_resolves_polymorphic_entity_to_reserved_id(self):
+        """Test polymorphic entity resolves to reserved table entity ID."""
+        from airweave.core.constants.reserved_ids import RESERVED_TABLE_ENTITY_ID
+
+        resolver = EntityActionResolver({})
+
+        entity = create_polymorphic_entity("poly-1", "hash1")
+        result = resolver.resolve_entity_definition_id(entity)
+
+        assert result == RESERVED_TABLE_ENTITY_ID
+
+    def test_returns_none_for_unknown_entity(self):
+        """Test returns None for entity not in map."""
+        resolver = EntityActionResolver({MockEntity2: uuid4()})
+
+        entity = create_mock_entity("test-1", "hash1")
+        result = resolver.resolve_entity_definition_id(entity)
+
+        assert result is None
+
+
+class TestSeparateDeletions:
+    """Test _separate_deletions method."""
+
+    def test_separates_deletions_from_non_deletions(self):
+        """Test separation of deletion entities."""
+        entity_map = {MockEntity: uuid4()}
+        resolver = EntityActionResolver(entity_map)
+
+        regular = create_mock_entity("reg-1", "hash1")
+        deletion = create_deletion_entity("del-1", "removed")
+
+        delete_entities, non_delete_entities = resolver._separate_deletions(
+            [regular, deletion]
+        )
+
+        assert len(delete_entities) == 1
+        assert len(non_delete_entities) == 1
+        assert deletion in delete_entities
+        assert regular in non_delete_entities
+
+    def test_active_deletion_entity_goes_to_non_delete(self):
+        """Test deletion entity with active status goes to non-delete."""
+        entity_map = {MockEntity: uuid4()}
+        resolver = EntityActionResolver(entity_map)
+
+        # Active deletion entity (not removed)
+        active_deletion = create_deletion_entity("active-1", "active")
+        active_deletion.airweave_system_metadata = AirweaveSystemMetadata(hash="hash1")
+
+        delete_entities, non_delete_entities = resolver._separate_deletions(
+            [active_deletion]
+        )
+
+        assert len(delete_entities) == 0
+        assert len(non_delete_entities) == 1
+
+    def test_empty_list_returns_empty(self):
+        """Test empty input returns empty lists."""
+        resolver = EntityActionResolver({})
+        delete_entities, non_delete_entities = resolver._separate_deletions([])
+
+        assert delete_entities == []
+        assert non_delete_entities == []
+
+
+class TestBuildEntityRequests:
+    """Test _build_entity_requests method."""
+
+    def test_builds_requests_for_entities(self):
+        """Test building entity requests."""
+        def_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        entity = create_mock_entity("test-1", "hash1")
+        requests = resolver._build_entity_requests([entity], ctx)
+
+        assert len(requests) == 1
+        assert requests[0] == ("test-1", def_id)
+
+    def test_raises_for_unknown_entity_type(self):
+        """Test raises SyncFailureError for unknown entity type."""
+        resolver = EntityActionResolver({})
+        ctx = MockSyncContext()
+
+        entity = create_mock_entity("test-1", "hash1")
+
+        with pytest.raises(SyncFailureError, match="not in entity_map"):
+            resolver._build_entity_requests([entity], ctx)
+
+
+class TestResolveNonDeleteAction:
+    """Test _resolve_non_delete_action method."""
+
+    def test_returns_insert_for_new_entity(self):
+        """Test INSERT action for entity not in database."""
+        def_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        entity = create_mock_entity("test-1", "hash1")
+        existing_map = {}  # Empty - entity doesn't exist
+
+        action = resolver._resolve_non_delete_action(entity, existing_map, ctx)
+
+        assert isinstance(action, EntityInsertAction)
+        assert action.entity == entity
+        assert action.entity_definition_id == def_id
+        assert action.skip_content_handlers is False
+
+    def test_returns_insert_with_skip_content_handlers_for_collection_dedup(self):
+        """Test INSERT with skip_content_handlers when entity exists in collection."""
+        def_id = uuid4()
+        db_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        entity = create_mock_entity("test-1", "hash1")
+        existing_map = {}  # Not in THIS sync
+        collection_map = {
+            ("test-1", def_id): MockDbEntity(
+                id=db_id,
+                entity_id="test-1",
+                entity_definition_id=def_id,
+                hash="hash1",  # Same hash - skip content handlers
+            )
+        }
+
+        action = resolver._resolve_non_delete_action(
+            entity, existing_map, ctx, collection_map=collection_map
+        )
+
+        assert isinstance(action, EntityInsertAction)
+        assert action.entity == entity
+        assert action.skip_content_handlers is True
+
+    def test_returns_insert_without_skip_when_collection_hash_differs(self):
+        """Test INSERT without skip when collection entity has different hash."""
+        def_id = uuid4()
+        db_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        entity = create_mock_entity("test-1", "new_hash")
+        existing_map = {}  # Not in THIS sync
+        collection_map = {
+            ("test-1", def_id): MockDbEntity(
+                id=db_id,
+                entity_id="test-1",
+                entity_definition_id=def_id,
+                hash="old_hash",  # Different hash - don't skip
+            )
+        }
+
+        action = resolver._resolve_non_delete_action(
+            entity, existing_map, ctx, collection_map=collection_map
+        )
+
+        assert isinstance(action, EntityInsertAction)
+        assert action.skip_content_handlers is False
+
+    def test_returns_update_for_changed_hash(self):
+        """Test UPDATE action when hash has changed."""
+        def_id = uuid4()
+        db_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        entity = create_mock_entity("test-1", "new_hash")
+        existing_map = {
+            ("test-1", def_id): MockDbEntity(
+                id=db_id,
+                entity_id="test-1",
+                entity_definition_id=def_id,
+                hash="old_hash",
+            )
+        }
+
+        action = resolver._resolve_non_delete_action(entity, existing_map, ctx)
+
+        assert isinstance(action, EntityUpdateAction)
+        assert action.entity == entity
+        assert action.db_id == db_id
+
+    def test_returns_keep_for_unchanged_hash(self):
+        """Test KEEP action when hash is unchanged."""
+        def_id = uuid4()
+        db_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        entity = create_mock_entity("test-1", "same_hash")
+        existing_map = {
+            ("test-1", def_id): MockDbEntity(
+                id=db_id,
+                entity_id="test-1",
+                entity_definition_id=def_id,
+                hash="same_hash",
+            )
+        }
+
+        action = resolver._resolve_non_delete_action(entity, existing_map, ctx)
+
+        assert isinstance(action, EntityKeepAction)
+        assert action.entity == entity
+
+    def test_raises_for_missing_hash(self):
+        """Test raises SyncFailureError when entity has no hash."""
+        def_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        entity = MockEntity(mock_id="test-1", mock_name="Test", breadcrumbs=[])
+        entity.entity_id = "test-1"
+        entity.airweave_system_metadata = None  # No metadata
+
+        with pytest.raises(SyncFailureError, match="has no hash"):
+            resolver._resolve_non_delete_action(entity, {}, ctx)
+
+
+class TestCreateDeleteAction:
+    """Test _create_delete_action method."""
+
+    def test_creates_delete_with_db_id_when_exists(self):
+        """Test delete action includes db_id when entity exists."""
+        def_id = uuid4()
+        db_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        deletion = create_deletion_entity("test-1", "removed")
+        existing_map = {
+            ("test-1", def_id): MockDbEntity(
+                id=db_id,
+                entity_id="test-1",
+                entity_definition_id=def_id,
+                hash="hash1",
+            )
+        }
+
+        action = resolver._create_delete_action(deletion, existing_map, ctx)
+
+        assert isinstance(action, EntityDeleteAction)
+        assert action.entity == deletion
+        assert action.db_id == db_id
+
+    def test_creates_delete_without_db_id_when_not_exists(self):
+        """Test delete action has None db_id when entity never synced."""
+        def_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        deletion = create_deletion_entity("test-1", "removed")
+        existing_map = {}  # Entity never existed
+
+        action = resolver._create_delete_action(deletion, existing_map, ctx)
+
+        assert isinstance(action, EntityDeleteAction)
+        assert action.db_id is None
+
+
+class TestForceAllInserts:
+    """Test _force_all_inserts method."""
+
+    def test_forces_all_as_inserts(self):
+        """Test all non-deletion entities become inserts."""
+        def_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        entity1 = create_mock_entity("test-1", "hash1")
+        entity2 = create_mock_entity("test-2", "hash2")
+
+        batch = resolver._force_all_inserts([entity1, entity2], ctx)
+
+        assert len(batch.inserts) == 2
+        assert len(batch.updates) == 0
+        assert len(batch.keeps) == 0
+        assert len(batch.deletes) == 0
+
+    def test_keeps_deletions_as_deletes(self):
+        """Test deletion entities remain as deletes."""
+        def_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        entity = create_mock_entity("test-1", "hash1")
+        deletion = create_deletion_entity("del-1", "removed")
+
+        batch = resolver._force_all_inserts([entity, deletion], ctx)
+
+        assert len(batch.inserts) == 1
+        assert len(batch.deletes) == 1
+
+
+class TestCreateActions:
+    """Test _create_actions method."""
+
+    def test_creates_batch_with_all_action_types(self):
+        """Test creating a batch with inserts, updates, keeps, and deletes."""
+        def_id = uuid4()
+        db_id_update = uuid4()
+        db_id_keep = uuid4()
+        db_id_delete = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        # New entity -> INSERT
+        new_entity = create_mock_entity("new-1", "hash_new")
+        # Updated entity -> UPDATE
+        updated_entity = create_mock_entity("updated-1", "hash_updated")
+        # Unchanged entity -> KEEP
+        unchanged_entity = create_mock_entity("unchanged-1", "hash_same")
+        # Deleted entity -> DELETE
+        deleted_entity = create_deletion_entity("deleted-1", "removed")
+
+        existing_map = {
+            ("updated-1", def_id): MockDbEntity(
+                id=db_id_update,
+                entity_id="updated-1",
+                entity_definition_id=def_id,
+                hash="hash_old",
+            ),
+            ("unchanged-1", def_id): MockDbEntity(
+                id=db_id_keep,
+                entity_id="unchanged-1",
+                entity_definition_id=def_id,
+                hash="hash_same",
+            ),
+            ("deleted-1", def_id): MockDbEntity(
+                id=db_id_delete,
+                entity_id="deleted-1",
+                entity_definition_id=def_id,
+                hash="hash_deleted",
+            ),
+        }
+        collection_map = {}  # No collection-level dedup
+
+        batch = resolver._create_actions(
+            non_delete_entities=[new_entity, updated_entity, unchanged_entity],
+            delete_entities=[deleted_entity],
+            existing_map=existing_map,
+            collection_map=collection_map,
+            sync_context=ctx,
+        )
+
+        assert len(batch.inserts) == 1
+        assert len(batch.updates) == 1
+        assert len(batch.keeps) == 1
+        assert len(batch.deletes) == 1
+
+    def test_creates_batch_with_collection_dedup_skip_content_handlers(self):
+        """Test INSERT actions get skip_content_handlers=True when entity exists in collection."""
+        def_id = uuid4()
+        db_id_collection = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext()
+
+        # New entity for this sync, but exists in collection with same hash
+        entity = create_mock_entity("shared-1", "hash_shared")
+
+        existing_map = {}  # Not in this sync
+        collection_map = {
+            ("shared-1", def_id): MockDbEntity(
+                id=db_id_collection,
+                entity_id="shared-1",
+                entity_definition_id=def_id,
+                hash="hash_shared",  # Same hash
+            )
+        }
+
+        batch = resolver._create_actions(
+            non_delete_entities=[entity],
+            delete_entities=[],
+            existing_map=existing_map,
+            collection_map=collection_map,
+            sync_context=ctx,
+        )
+
+        assert len(batch.inserts) == 1
+        assert batch.inserts[0].skip_content_handlers is True
+
+
+class TestFetchExistingEntitiesForSync:
+    """Test _fetch_existing_entities_for_sync method."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_entities_for_sync(self):
+        """Test fetches entities scoped to the current sync."""
+        def_id = uuid4()
+        sync_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext(sync_id=sync_id, execution_config=None)
+
+        mock_result = {}
+
+        with patch("airweave.platform.sync.actions.entity.resolver.get_db_context") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.return_value.__aenter__.return_value = mock_session
+
+            with patch("airweave.platform.sync.actions.entity.resolver.crud") as mock_crud:
+                mock_crud.entity.bulk_get_by_entity_sync_and_definition = AsyncMock(
+                    return_value=mock_result
+                )
+
+                result = await resolver._fetch_existing_entities_for_sync(
+                    [("test-1", def_id)], ctx
+                )
+
+                mock_crud.entity.bulk_get_by_entity_sync_and_definition.assert_called_once()
+                assert result == mock_result
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_empty_requests(self):
+        """Test returns empty dict for empty entity requests."""
+        resolver = EntityActionResolver({})
+        ctx = MockSyncContext()
+
+        result = await resolver._fetch_existing_entities_for_sync([], ctx)
+
+        assert result == {}
+
+
+class TestFetchExistingEntitiesForCollection:
+    """Test _fetch_existing_entities_for_collection method."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_entities_for_collection(self):
+        """Test fetches entities across all syncs in collection."""
+        def_id = uuid4()
+        collection_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+
+        ctx = MockSyncContext(collection_id=collection_id, execution_config=None)
+
+        mock_result = {}
+
+        with patch("airweave.platform.sync.actions.entity.resolver.get_db_context") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.return_value.__aenter__.return_value = mock_session
+
+            with patch("airweave.platform.sync.actions.entity.resolver.crud") as mock_crud:
+                mock_crud.entity.bulk_get_by_entity_collection_and_definition = AsyncMock(
+                    return_value=mock_result
+                )
+
+                result = await resolver._fetch_existing_entities_for_collection(
+                    [("test-1", def_id)], ctx
+                )
+
+                mock_crud.entity.bulk_get_by_entity_collection_and_definition.assert_called_once()
+                assert result == mock_result
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_empty_requests(self):
+        """Test returns empty dict for empty entity requests."""
+        resolver = EntityActionResolver({})
+        ctx = MockSyncContext()
+
+        result = await resolver._fetch_existing_entities_for_collection([], ctx)
+
+        assert result == {}
+
+
+class TestResolve:
+    """Test the main resolve method."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_with_skip_hash_comparison(self):
+        """Test resolve forces all inserts when skip_hash_comparison is enabled."""
+        def_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+
+        config = SyncConfig(behavior=BehaviorConfig(skip_hash_comparison=True))
+        ctx = MockSyncContext(execution_config=config)
+
+        entity = create_mock_entity("test-1", "hash1")
+
+        batch = await resolver.resolve([entity], ctx)
+
+        assert len(batch.inserts) == 1
+        assert len(batch.updates) == 0
+        assert len(batch.keeps) == 0
+
+    @pytest.mark.asyncio
+    async def test_resolve_full_flow(self):
+        """Test full resolve flow with database lookup."""
+        def_id = uuid4()
+        db_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+        ctx = MockSyncContext(execution_config=None)
+
+        # Create entities
+        new_entity = create_mock_entity("new-1", "hash_new")
+        existing_entity = create_mock_entity("existing-1", "same_hash")
+
+        # Mock database lookup
+        mock_existing_map = {
+            ("existing-1", def_id): MockDbEntity(
+                id=db_id,
+                entity_id="existing-1",
+                entity_definition_id=def_id,
+                hash="same_hash",  # Same hash = KEEP
+            )
+        }
+
+        with patch.object(
+            resolver,
+            "_fetch_existing_entities_for_sync",
+            new=AsyncMock(return_value=mock_existing_map),
+        ):
+            batch = await resolver.resolve([new_entity, existing_entity], ctx)
+
+        assert len(batch.inserts) == 1  # new_entity
+        assert len(batch.keeps) == 1  # existing_entity (same hash)
+        assert len(batch.updates) == 0
+        assert len(batch.deletes) == 0
+
+    @pytest.mark.asyncio
+    async def test_resolve_with_collection_dedup(self):
+        """Test resolve with collection-level dedup sets skip_content_handlers."""
+        def_id = uuid4()
+        db_id = uuid4()
+        entity_map = {MockEntity: def_id}
+        resolver = EntityActionResolver(entity_map)
+
+        config = SyncConfig(behavior=BehaviorConfig(dedupe_by_collection=True))
+        ctx = MockSyncContext(execution_config=config)
+
+        # Entity exists in collection (different sync) with same hash
+        entity = create_mock_entity("shared-1", "hash_shared")
+
+        # Not in this sync
+        mock_sync_map = {}
+        # But exists in collection
+        mock_collection_map = {
+            ("shared-1", def_id): MockDbEntity(
+                id=db_id,
+                entity_id="shared-1",
+                entity_definition_id=def_id,
+                hash="hash_shared",
+            )
+        }
+
+        with patch.object(
+            resolver,
+            "_fetch_existing_entities_for_sync",
+            new=AsyncMock(return_value=mock_sync_map),
+        ):
+            with patch.object(
+                resolver,
+                "_fetch_existing_entities_for_collection",
+                new=AsyncMock(return_value=mock_collection_map),
+            ):
+                batch = await resolver.resolve([entity], ctx)
+
+        assert len(batch.inserts) == 1
+        assert batch.inserts[0].skip_content_handlers is True
+
+
+class TestEntityActionBatch:
+    """Test EntityActionBatch helper methods."""
+
+    def test_has_mutations_true(self):
+        """Test has_mutations returns True when mutations exist."""
+        batch = EntityActionBatch(
+            inserts=[MagicMock()],
+            updates=[],
+            deletes=[],
+            keeps=[],
+        )
+        assert batch.has_mutations is True
+
+    def test_has_mutations_false(self):
+        """Test has_mutations returns False for keeps only."""
+        batch = EntityActionBatch(
+            inserts=[],
+            updates=[],
+            deletes=[],
+            keeps=[MagicMock()],
+        )
+        assert batch.has_mutations is False
+
+    def test_mutation_count(self):
+        """Test mutation_count calculation."""
+        batch = EntityActionBatch(
+            inserts=[MagicMock(), MagicMock()],
+            updates=[MagicMock()],
+            deletes=[MagicMock()],
+            keeps=[MagicMock(), MagicMock(), MagicMock()],
+        )
+        assert batch.mutation_count == 4
+
+    def test_total_count(self):
+        """Test total_count includes keeps."""
+        batch = EntityActionBatch(
+            inserts=[MagicMock()],
+            updates=[MagicMock()],
+            deletes=[MagicMock()],
+            keeps=[MagicMock(), MagicMock()],
+        )
+        assert batch.total_count == 5
+
+    def test_summary(self):
+        """Test summary string generation."""
+        batch = EntityActionBatch(
+            inserts=[MagicMock(), MagicMock()],
+            updates=[MagicMock()],
+            deletes=[],
+            keeps=[MagicMock()],
+        )
+        summary = batch.summary()
+        assert "2 inserts" in summary
+        assert "1 updates" in summary
+        assert "1 keeps" in summary
+        assert "deletes" not in summary
+
+    def test_summary_empty(self):
+        """Test summary for empty batch."""
+        batch = EntityActionBatch()
+        assert batch.summary() == "empty"

--- a/backend/tests/unit/platform/sync/actions/entity/test_types.py
+++ b/backend/tests/unit/platform/sync/actions/entity/test_types.py
@@ -1,0 +1,278 @@
+"""Tests for entity action types.
+
+Tests the action type dataclasses and EntityActionBatch.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from airweave.platform.sync.actions.entity.types import (
+    EntityActionBatch,
+    EntityDeleteAction,
+    EntityInsertAction,
+    EntityKeepAction,
+    EntityUpdateAction,
+)
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+class MockEntity:
+    """Mock entity for testing."""
+
+    def __init__(self, entity_id: str = "test-entity"):
+        self.entity_id = entity_id
+
+    @property
+    def __class__(self):
+        """Return a mock class with __name__."""
+        return type("MockEntity", (), {"__name__": "MockEntity"})
+
+
+# =============================================================================
+# Test Classes
+# =============================================================================
+
+
+class TestEntityInsertAction:
+    """Test EntityInsertAction dataclass."""
+
+    def test_defaults(self):
+        """Test default values for EntityInsertAction."""
+        entity = MockEntity("test-1")
+        action = EntityInsertAction(
+            entity=entity,
+            entity_definition_id=uuid4(),
+        )
+
+        assert action.entity == entity
+        assert action.chunk_entities == []
+        assert action.skip_content_handlers is False
+
+    def test_skip_content_handlers_true(self):
+        """Test skip_content_handlers can be set to True."""
+        entity = MockEntity("test-1")
+        action = EntityInsertAction(
+            entity=entity,
+            entity_definition_id=uuid4(),
+            skip_content_handlers=True,
+        )
+
+        assert action.skip_content_handlers is True
+
+    def test_entity_id_property(self):
+        """Test entity_id property returns entity's id."""
+        entity = MockEntity("my-entity-id")
+        action = EntityInsertAction(
+            entity=entity,
+            entity_definition_id=uuid4(),
+        )
+
+        assert action.entity_id == "my-entity-id"
+
+    def test_entity_type_property(self):
+        """Test entity_type property returns class name."""
+        entity = MockEntity("test-1")
+        action = EntityInsertAction(
+            entity=entity,
+            entity_definition_id=uuid4(),
+        )
+
+        assert action.entity_type == "MockEntity"
+
+    def test_with_chunk_entities(self):
+        """Test EntityInsertAction with chunk entities."""
+        entity = MockEntity("parent")
+        chunks = [MockEntity("chunk-1"), MockEntity("chunk-2")]
+        action = EntityInsertAction(
+            entity=entity,
+            entity_definition_id=uuid4(),
+            chunk_entities=chunks,
+        )
+
+        assert len(action.chunk_entities) == 2
+
+
+class TestEntityUpdateAction:
+    """Test EntityUpdateAction dataclass."""
+
+    def test_requires_db_id(self):
+        """Test EntityUpdateAction requires db_id."""
+        entity = MockEntity("test-1")
+        db_id = uuid4()
+        action = EntityUpdateAction(
+            entity=entity,
+            entity_definition_id=uuid4(),
+            db_id=db_id,
+        )
+
+        assert action.db_id == db_id
+
+    def test_entity_id_property(self):
+        """Test entity_id property."""
+        entity = MockEntity("update-entity")
+        action = EntityUpdateAction(
+            entity=entity,
+            entity_definition_id=uuid4(),
+            db_id=uuid4(),
+        )
+
+        assert action.entity_id == "update-entity"
+
+
+class TestEntityDeleteAction:
+    """Test EntityDeleteAction dataclass."""
+
+    def test_db_id_optional(self):
+        """Test EntityDeleteAction db_id is optional."""
+        entity = MockEntity("test-1")
+        action = EntityDeleteAction(
+            entity=entity,
+            entity_definition_id=uuid4(),
+        )
+
+        assert action.db_id is None
+
+    def test_with_db_id(self):
+        """Test EntityDeleteAction with db_id."""
+        entity = MockEntity("test-1")
+        db_id = uuid4()
+        action = EntityDeleteAction(
+            entity=entity,
+            entity_definition_id=uuid4(),
+            db_id=db_id,
+        )
+
+        assert action.db_id == db_id
+
+
+class TestEntityKeepAction:
+    """Test EntityKeepAction dataclass."""
+
+    def test_basic_creation(self):
+        """Test basic EntityKeepAction creation."""
+        entity = MockEntity("keep-entity")
+        def_id = uuid4()
+        action = EntityKeepAction(
+            entity=entity,
+            entity_definition_id=def_id,
+        )
+
+        assert action.entity == entity
+        assert action.entity_definition_id == def_id
+
+
+class TestEntityActionBatch:
+    """Test EntityActionBatch container."""
+
+    def test_empty_batch(self):
+        """Test empty batch defaults."""
+        batch = EntityActionBatch()
+
+        assert batch.inserts == []
+        assert batch.updates == []
+        assert batch.deletes == []
+        assert batch.keeps == []
+        assert batch.existing_map == {}
+
+    def test_has_mutations_with_inserts(self):
+        """Test has_mutations returns True with inserts."""
+        batch = EntityActionBatch(
+            inserts=[MagicMock()],
+        )
+        assert batch.has_mutations is True
+
+    def test_has_mutations_with_updates(self):
+        """Test has_mutations returns True with updates."""
+        batch = EntityActionBatch(
+            updates=[MagicMock()],
+        )
+        assert batch.has_mutations is True
+
+    def test_has_mutations_with_deletes(self):
+        """Test has_mutations returns True with deletes."""
+        batch = EntityActionBatch(
+            deletes=[MagicMock()],
+        )
+        assert batch.has_mutations is True
+
+    def test_has_mutations_false_with_keeps_only(self):
+        """Test has_mutations returns False with only keeps."""
+        batch = EntityActionBatch(
+            keeps=[MagicMock()],
+        )
+        assert batch.has_mutations is False
+
+    def test_mutation_count(self):
+        """Test mutation_count calculation."""
+        batch = EntityActionBatch(
+            inserts=[MagicMock(), MagicMock()],  # 2
+            updates=[MagicMock()],  # 1
+            deletes=[MagicMock(), MagicMock(), MagicMock()],  # 3
+            keeps=[MagicMock()],  # not counted
+        )
+        assert batch.mutation_count == 6
+
+    def test_total_count(self):
+        """Test total_count includes keeps."""
+        batch = EntityActionBatch(
+            inserts=[MagicMock()],  # 1
+            updates=[MagicMock()],  # 1
+            deletes=[MagicMock()],  # 1
+            keeps=[MagicMock(), MagicMock()],  # 2
+        )
+        assert batch.total_count == 5
+
+    def test_summary_with_all_types(self):
+        """Test summary includes all action types."""
+        batch = EntityActionBatch(
+            inserts=[MagicMock(), MagicMock()],
+            updates=[MagicMock()],
+            deletes=[MagicMock()],
+            keeps=[MagicMock()],
+        )
+        summary = batch.summary()
+
+        assert "2 inserts" in summary
+        assert "1 updates" in summary
+        assert "1 deletes" in summary
+        assert "1 keeps" in summary
+
+    def test_summary_empty(self):
+        """Test summary for empty batch."""
+        batch = EntityActionBatch()
+        assert batch.summary() == "empty"
+
+    def test_summary_excludes_zero_counts(self):
+        """Test summary excludes action types with zero count."""
+        batch = EntityActionBatch(
+            inserts=[MagicMock()],
+        )
+        summary = batch.summary()
+
+        assert "1 inserts" in summary
+        assert "updates" not in summary
+        assert "deletes" not in summary
+        assert "keeps" not in summary
+
+    def test_get_entities_to_process(self):
+        """Test get_entities_to_process returns INSERT and UPDATE entities."""
+        entity1 = MockEntity("insert-1")
+        entity2 = MockEntity("update-1")
+        entity3 = MockEntity("keep-1")
+
+        batch = EntityActionBatch(
+            inserts=[EntityInsertAction(entity=entity1, entity_definition_id=uuid4())],
+            updates=[EntityUpdateAction(entity=entity2, entity_definition_id=uuid4(), db_id=uuid4())],
+            keeps=[EntityKeepAction(entity=entity3, entity_definition_id=uuid4())],
+        )
+
+        entities = batch.get_entities_to_process()
+
+        assert len(entities) == 2
+        assert entity1 in entities
+        assert entity2 in entities
+        assert entity3 not in entities

--- a/backend/tests/unit/platform/sync/config/test_base.py
+++ b/backend/tests/unit/platform/sync/config/test_base.py
@@ -83,11 +83,18 @@ class TestBehaviorConfig:
         config = BehaviorConfig()
         assert config.skip_hash_comparison is False
         assert config.replay_from_arf is False
+        assert config.skip_guardrails is False
+        assert config.dedupe_by_collection is False
 
     def test_with_custom_values(self):
         """Test behavior config with custom values."""
         config = BehaviorConfig(replay_from_arf=True)
         assert config.replay_from_arf is True
+
+    def test_dedupe_by_collection(self):
+        """Test dedupe_by_collection flag."""
+        config = BehaviorConfig(dedupe_by_collection=True)
+        assert config.dedupe_by_collection is True
 
 
 class TestSyncConfig:

--- a/backend/tests/unit/platform/sync/handlers/__init__.py
+++ b/backend/tests/unit/platform/sync/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for sync handler modules."""

--- a/backend/tests/unit/platform/sync/handlers/test_arf.py
+++ b/backend/tests/unit/platform/sync/handlers/test_arf.py
@@ -1,0 +1,284 @@
+"""Tests for ArfHandler.
+
+Tests the ARF handler's behavior. Note that skip_content_handlers filtering
+is done by EntityActionDispatcher, not by individual handlers.
+"""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from airweave.platform.sync.actions.entity.types import (
+    EntityActionBatch,
+    EntityDeleteAction,
+    EntityInsertAction,
+    EntityUpdateAction,
+)
+from airweave.platform.sync.handlers.arf import ArfHandler
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+class MockEntity:
+    """Mock entity for testing."""
+
+    def __init__(self, entity_id: str):
+        self.entity_id = entity_id
+
+
+class MockLogger:
+    """Mock logger for testing."""
+
+    def debug(self, msg: str) -> None:
+        pass
+
+    def info(self, msg: str) -> None:
+        pass
+
+    def warning(self, msg: str) -> None:
+        pass
+
+
+class MockSync:
+    """Mock sync object."""
+
+    def __init__(self):
+        self.id = uuid4()
+
+
+class MockSyncContext:
+    """Mock sync context for testing."""
+
+    def __init__(self):
+        self.sync = MockSync()
+        self.logger = MockLogger()
+
+
+def create_insert_action(entity_id: str, skip: bool = False) -> EntityInsertAction:
+    """Create an insert action for testing."""
+    entity = MockEntity(entity_id)
+    return EntityInsertAction(
+        entity=entity,
+        entity_definition_id=uuid4(),
+        skip_content_handlers=skip,
+    )
+
+
+def create_update_action(entity_id: str) -> EntityUpdateAction:
+    """Create an update action for testing."""
+    entity = MockEntity(entity_id)
+    return EntityUpdateAction(
+        entity=entity,
+        entity_definition_id=uuid4(),
+        db_id=uuid4(),
+    )
+
+
+def create_delete_action(entity_id: str) -> EntityDeleteAction:
+    """Create a delete action for testing."""
+    entity = MockEntity(entity_id)
+    return EntityDeleteAction(
+        entity=entity,
+        entity_definition_id=uuid4(),
+        db_id=uuid4(),
+    )
+
+
+# =============================================================================
+# Test Classes
+# =============================================================================
+
+
+class TestArfHandlerBatch:
+    """Test ArfHandler batch processing."""
+
+    @pytest.mark.asyncio
+    async def test_handle_batch_processes_all_inserts(self):
+        """Test handle_batch processes all inserts (no filtering at handler level)."""
+        handler = ArfHandler()
+        ctx = MockSyncContext()
+
+        # Create batch with inserts
+        batch = EntityActionBatch(
+            inserts=[
+                create_insert_action("entity-1"),
+                create_insert_action("entity-2"),
+                create_insert_action("entity-3"),
+            ],
+            updates=[],
+            deletes=[],
+            keeps=[],
+        )
+
+        with patch.object(handler, "handle_inserts", new=AsyncMock()) as mock_handle:
+            await handler.handle_batch(batch, ctx)
+
+            mock_handle.assert_called_once()
+            actions = mock_handle.call_args[0][0]
+            assert len(actions) == 3
+
+    @pytest.mark.asyncio
+    async def test_handle_batch_does_not_call_handle_inserts_when_empty(self):
+        """Test handle_batch doesn't call handle_inserts when no inserts."""
+        handler = ArfHandler()
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[],
+            updates=[create_update_action("entity-1")],
+            deletes=[],
+            keeps=[],
+        )
+
+        with patch.object(handler, "handle_inserts", new=AsyncMock()) as mock_inserts:
+            with patch.object(handler, "handle_updates", new=AsyncMock()):
+                await handler.handle_batch(batch, ctx)
+                mock_inserts.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_batch_processes_updates(self):
+        """Test handle_batch processes updates."""
+        handler = ArfHandler()
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[],
+            updates=[
+                create_update_action("entity-1"),
+                create_update_action("entity-2"),
+            ],
+            deletes=[],
+            keeps=[],
+        )
+
+        with patch.object(handler, "handle_updates", new=AsyncMock()) as mock_updates:
+            await handler.handle_batch(batch, ctx)
+
+            mock_updates.assert_called_once()
+            actions = mock_updates.call_args[0][0]
+            assert len(actions) == 2
+
+    @pytest.mark.asyncio
+    async def test_handle_batch_processes_deletes_first(self):
+        """Test handle_batch processes deletes before updates and inserts."""
+        handler = ArfHandler()
+        ctx = MockSyncContext()
+        call_order = []
+
+        async def track_deletes(*args, **kwargs):
+            call_order.append("deletes")
+
+        async def track_updates(*args, **kwargs):
+            call_order.append("updates")
+
+        async def track_inserts(*args, **kwargs):
+            call_order.append("inserts")
+
+        batch = EntityActionBatch(
+            inserts=[create_insert_action("entity-3")],
+            updates=[create_update_action("entity-2")],
+            deletes=[create_delete_action("entity-1")],
+            keeps=[],
+        )
+
+        with patch.object(handler, "handle_deletes", side_effect=track_deletes):
+            with patch.object(handler, "handle_updates", side_effect=track_updates):
+                with patch.object(handler, "handle_inserts", side_effect=track_inserts):
+                    await handler.handle_batch(batch, ctx)
+
+        assert call_order == ["deletes", "updates", "inserts"]
+
+
+class TestArfHandlerInserts:
+    """Test ArfHandler insert operations."""
+
+    @pytest.mark.asyncio
+    async def test_handle_inserts_processes_all(self):
+        """Test handle_inserts processes all actions."""
+        handler = ArfHandler()
+        ctx = MockSyncContext()
+
+        actions = [
+            create_insert_action("entity-1"),
+            create_insert_action("entity-2"),
+            create_insert_action("entity-3"),
+        ]
+
+        with patch.object(handler, "_ensure_manifest", new=AsyncMock()):
+            with patch.object(handler, "_do_upsert", new=AsyncMock()) as mock_upsert:
+                await handler.handle_inserts(actions, ctx)
+
+                mock_upsert.assert_called_once()
+                entities = mock_upsert.call_args[0][0]
+                assert len(entities) == 3
+
+    @pytest.mark.asyncio
+    async def test_handle_inserts_empty_list(self):
+        """Test handle_inserts with empty list."""
+        handler = ArfHandler()
+        ctx = MockSyncContext()
+
+        with patch.object(handler, "_ensure_manifest", new=AsyncMock()) as mock_manifest:
+            with patch.object(handler, "_do_upsert", new=AsyncMock()) as mock_upsert:
+                await handler.handle_inserts([], ctx)
+
+                # Should not call anything
+                mock_manifest.assert_not_called()
+                mock_upsert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_inserts_ensures_manifest(self):
+        """Test handle_inserts ensures manifest exists before upsert."""
+        handler = ArfHandler()
+        ctx = MockSyncContext()
+        call_order = []
+
+        async def track_manifest(*args, **kwargs):
+            call_order.append("manifest")
+
+        async def track_upsert(*args, **kwargs):
+            call_order.append("upsert")
+
+        actions = [create_insert_action("entity-1")]
+
+        with patch.object(handler, "_ensure_manifest", side_effect=track_manifest):
+            with patch.object(handler, "_do_upsert", side_effect=track_upsert):
+                await handler.handle_inserts(actions, ctx)
+
+        assert call_order == ["manifest", "upsert"]
+
+
+class TestArfHandlerDeletes:
+    """Test ArfHandler delete operations."""
+
+    @pytest.mark.asyncio
+    async def test_handle_deletes_processes_all(self):
+        """Test handle_deletes processes all delete actions."""
+        handler = ArfHandler()
+        ctx = MockSyncContext()
+
+        actions = [
+            create_delete_action("entity-1"),
+            create_delete_action("entity-2"),
+        ]
+
+        with patch.object(handler, "_do_delete", new=AsyncMock()) as mock_delete:
+            await handler.handle_deletes(actions, ctx)
+
+            mock_delete.assert_called_once()
+            entity_ids = mock_delete.call_args[0][0]
+            assert len(entity_ids) == 2
+
+    @pytest.mark.asyncio
+    async def test_handle_deletes_empty_list(self):
+        """Test handle_deletes with empty list."""
+        handler = ArfHandler()
+        ctx = MockSyncContext()
+
+        with patch.object(handler, "_do_delete", new=AsyncMock()) as mock_delete:
+            await handler.handle_deletes([], ctx)
+            mock_delete.assert_not_called()

--- a/backend/tests/unit/platform/sync/handlers/test_destination.py
+++ b/backend/tests/unit/platform/sync/handlers/test_destination.py
@@ -1,0 +1,270 @@
+"""Tests for DestinationHandler.
+
+Tests the destination handler's behavior. Note that skip_content_handlers filtering
+is done by EntityActionDispatcher, not by individual handlers.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from airweave.platform.sync.actions.entity.types import (
+    EntityActionBatch,
+    EntityDeleteAction,
+    EntityInsertAction,
+    EntityUpdateAction,
+)
+from airweave.platform.sync.handlers.destination import DestinationHandler
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+class MockDestination:
+    """Mock destination for testing."""
+
+    processing_requirement = MagicMock()
+
+    def __init__(self):
+        self.bulk_insert = AsyncMock()
+        self.bulk_delete_by_parent_ids = AsyncMock()
+
+
+class MockEntity:
+    """Mock entity for testing."""
+
+    def __init__(self, entity_id: str):
+        self.entity_id = entity_id
+
+    def model_copy(self, deep: bool = False):
+        """Mock model_copy for entity copying."""
+        return MockEntity(self.entity_id)
+
+
+class MockLogger:
+    """Mock logger for testing."""
+
+    def debug(self, msg: str) -> None:
+        pass
+
+    def info(self, msg: str) -> None:
+        pass
+
+    def warning(self, msg: str) -> None:
+        pass
+
+
+class MockSync:
+    """Mock sync object."""
+
+    def __init__(self):
+        self.id = uuid4()
+
+
+class MockSyncContext:
+    """Mock sync context for testing."""
+
+    def __init__(self):
+        self.sync = MockSync()
+        self.logger = MockLogger()
+
+
+def create_insert_action(entity_id: str, skip: bool = False) -> EntityInsertAction:
+    """Create an insert action for testing."""
+    entity = MockEntity(entity_id)
+    return EntityInsertAction(
+        entity=entity,
+        entity_definition_id=uuid4(),
+        skip_content_handlers=skip,
+    )
+
+
+def create_update_action(entity_id: str) -> EntityUpdateAction:
+    """Create an update action for testing."""
+    entity = MockEntity(entity_id)
+    return EntityUpdateAction(
+        entity=entity,
+        entity_definition_id=uuid4(),
+        db_id=uuid4(),
+    )
+
+
+def create_delete_action(entity_id: str) -> EntityDeleteAction:
+    """Create a delete action for testing."""
+    entity = MockEntity(entity_id)
+    return EntityDeleteAction(
+        entity=entity,
+        entity_definition_id=uuid4(),
+        db_id=uuid4(),
+    )
+
+
+# =============================================================================
+# Test Classes
+# =============================================================================
+
+
+class TestDestinationHandlerBatch:
+    """Test DestinationHandler batch processing."""
+
+    @pytest.mark.asyncio
+    async def test_handle_batch_processes_inserts_and_updates(self):
+        """Test handle_batch processes both inserts and updates."""
+        dest = MockDestination()
+        handler = DestinationHandler([dest])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[
+                create_insert_action("entity-1"),
+                create_insert_action("entity-2"),
+            ],
+            updates=[
+                create_update_action("entity-3"),
+            ],
+            deletes=[],
+            keeps=[],
+        )
+
+        with patch.object(handler, "_do_process_and_insert", new=AsyncMock()) as mock_process:
+            with patch.object(handler, "_do_delete_by_ids", new=AsyncMock()):
+                await handler.handle_batch(batch, ctx)
+
+                mock_process.assert_called_once()
+                entities = mock_process.call_args[0][0]
+                # Should have 3 entities: 2 inserts + 1 update
+                assert len(entities) == 3
+
+    @pytest.mark.asyncio
+    async def test_handle_batch_skips_when_no_mutations(self):
+        """Test handle_batch returns early with no mutations."""
+        dest = MockDestination()
+        handler = DestinationHandler([dest])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[],
+            updates=[],
+            deletes=[],
+            keeps=[MagicMock()],  # Only keeps
+        )
+
+        with patch.object(handler, "_do_process_and_insert", new=AsyncMock()) as mock_process:
+            await handler.handle_batch(batch, ctx)
+            mock_process.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_batch_deletes_before_insert_for_updates(self):
+        """Test handle_batch deletes old data before inserting new for updates."""
+        dest = MockDestination()
+        handler = DestinationHandler([dest])
+        ctx = MockSyncContext()
+        call_order = []
+
+        async def track_delete(*args, **kwargs):
+            call_order.append("delete")
+
+        async def track_process(*args, **kwargs):
+            call_order.append("process")
+
+        batch = EntityActionBatch(
+            inserts=[],
+            updates=[create_update_action("entity-1")],
+            deletes=[],
+            keeps=[],
+        )
+
+        with patch.object(handler, "_do_delete_by_ids", side_effect=track_delete):
+            with patch.object(handler, "_do_process_and_insert", side_effect=track_process):
+                await handler.handle_batch(batch, ctx)
+
+        assert call_order == ["delete", "process"]
+
+
+class TestDestinationHandlerInserts:
+    """Test DestinationHandler insert operations."""
+
+    @pytest.mark.asyncio
+    async def test_handle_inserts_processes_all(self):
+        """Test handle_inserts processes all actions."""
+        dest = MockDestination()
+        handler = DestinationHandler([dest])
+        ctx = MockSyncContext()
+
+        actions = [
+            create_insert_action("entity-1"),
+            create_insert_action("entity-2"),
+        ]
+
+        with patch.object(handler, "_do_process_and_insert", new=AsyncMock()) as mock_process:
+            await handler.handle_inserts(actions, ctx)
+
+            mock_process.assert_called_once()
+            entities = mock_process.call_args[0][0]
+            assert len(entities) == 2
+
+    @pytest.mark.asyncio
+    async def test_handle_inserts_empty_list(self):
+        """Test handle_inserts with empty list."""
+        dest = MockDestination()
+        handler = DestinationHandler([dest])
+        ctx = MockSyncContext()
+
+        with patch.object(handler, "_do_process_and_insert", new=AsyncMock()) as mock_process:
+            await handler.handle_inserts([], ctx)
+            mock_process.assert_not_called()
+
+
+class TestDestinationHandlerNoDestinations:
+    """Test DestinationHandler with no destinations configured."""
+
+    @pytest.mark.asyncio
+    async def test_handle_batch_with_no_destinations(self):
+        """Test handle_batch returns early with no destinations."""
+        handler = DestinationHandler([])
+        ctx = MockSyncContext()
+
+        batch = EntityActionBatch(
+            inserts=[create_insert_action("entity-1")],
+            updates=[],
+            deletes=[],
+            keeps=[],
+        )
+
+        # Should not raise, just return early
+        await handler.handle_batch(batch, ctx)
+
+    @pytest.mark.asyncio
+    async def test_handle_inserts_with_no_destinations(self):
+        """Test handle_inserts returns early with no destinations."""
+        handler = DestinationHandler([])
+        ctx = MockSyncContext()
+
+        # Should not raise
+        await handler.handle_inserts([create_insert_action("entity-1")], ctx)
+
+
+class TestDestinationHandlerDeletes:
+    """Test DestinationHandler delete operations."""
+
+    @pytest.mark.asyncio
+    async def test_handle_deletes_processes_all(self):
+        """Test handle_deletes processes all delete actions."""
+        dest = MockDestination()
+        handler = DestinationHandler([dest])
+        ctx = MockSyncContext()
+
+        actions = [
+            create_delete_action("entity-1"),
+            create_delete_action("entity-2"),
+        ]
+
+        with patch.object(handler, "_do_delete_by_ids", new=AsyncMock()) as mock_delete:
+            await handler.handle_deletes(actions, ctx)
+
+            mock_delete.assert_called_once()
+            entity_ids = mock_delete.call_args[0][0]
+            assert len(entity_ids) == 2


### PR DESCRIPTION
Implements collection-level dedup that maintains separate entity rows per sync for proper CASCADE deletion, while skipping redundant vector DB and ARF writes.

Changes:
- Add skip_content_handlers flag to EntityInsertAction
- Add dedupe_by_collection flag to BehaviorConfig (default: false)
- Update EntityActionResolver with dual lookup (sync + collection)
- Add bulk_get_by_entity_collection_and_definition to crud_entity
- Update DestinationHandler and ArfHandler to respect skip flag
- Add tests for dedupe_by_collection config

When dedupe_by_collection=true:
- Each sync maintains its own entity rows (CASCADE works correctly)
- Content handlers skip writes if another sync has same entity+hash
- Postgres handler always runs to record sync ownership

Default behavior unchanged (dedupe_by_collection=false).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds collection-level deduplication so each sync keeps its own entity rows (CASCADE deletes work), while vector DB and ARF writes are skipped if another sync in the collection already stored the same entity/hash. Opt-in via BehaviorConfig.dedupe_by_collection; default behavior is unchanged.

- **New Features**
  - BehaviorConfig.dedupe_by_collection flag (default: false).
  - EntityInsertAction.skip_content_handlers to skip destination/ARF writes on collection duplicates; Postgres still records sync ownership.
  - Resolver adds dual lookup: per-sync and per-collection; CRUD adds bulk_get_by_entity_collection_and_definition.
  - Destination and ARF handlers respect skip_content_handlers.
  - Unit tests for dedupe_by_collection.

- **Bug Fixes**
  - Fix CI diff-cover step to use the correct format flag and exit code, failing when coverage is below threshold.

<sup>Written for commit f61dac4895d24236db71b716beb374520a8eae1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

