### PR TITLE
Fix OutlookMessageEntity validation error for null recipient addresses

### DIFF
--- a/backend/airweave/platform/sources/outlook_mail.py
+++ b/backend/airweave/platform/sources/outlook_mail.py
@@ -511,12 +511,12 @@ class OutlookMailSource(BaseSource):
         to_recipients = [
             r.get("emailAddress", {}).get("address")
             for r in message_data.get("toRecipients", [])
-            if r.get("emailAddress")
+            if r.get("emailAddress") and r.get("emailAddress", {}).get("address")
         ]
         cc_recipients = [
             r.get("emailAddress", {}).get("address")
             for r in message_data.get("ccRecipients", [])
-            if r.get("emailAddress")
+            if r.get("emailAddress") and r.get("emailAddress", {}).get("address")
         ]
 
         # Parse dates


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip to/cc recipients with null email addresses to prevent OutlookMessageEntity validation errors. We now require emailAddress.address to be present before collecting recipient addresses.

<sup>Written for commit 49c7274c60244ab2895388c51cbd48ea6b4576be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

