### PR TITLE
fix(sync): correct source_instance check for orphan cleanup

### DIFF
--- a/backend/airweave/platform/sync/orchestrator.py
+++ b/backend/airweave/platform/sync/orchestrator.py
@@ -413,9 +413,14 @@ class SyncOrchestrator:
             and self.sync_context.cursor.cursor_data
         )
 
-        # Check if source supports continuous/incremental sync
-        source_supports_continuous = getattr(
-            self.sync_context.source, "_supports_continuous", False
+        # Check if source supports continuous/incremental sync (class attribute)
+        source_class = type(self.sync_context.source_instance)
+        source_supports_continuous = source_class._supports_continuous
+
+        self.sync_context.logger.debug(
+            f"Orphan cleanup check: has_cursor_data={has_cursor_data}, "
+            f"supports_continuous={source_supports_continuous}, "
+            f"force_full_sync={self.sync_context.force_full_sync}"
         )
 
         # Cleanup should run if:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix orphan cleanup by reading the source_instance class attribute _supports_continuous, so cleanup only runs when the source supports continuous sync. Adds a debug log for has_cursor_data, supports_continuous, and force_full_sync.

<sup>Written for commit beec6c8d1c47dde0e0bcb8f8cbc76992b53c1b36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

