### PR TITLE
Add soft-fail mode for destinations with Vespa migration monitoring

### DIFF
--- a/backend/airweave/platform/destinations/_base.py
+++ b/backend/airweave/platform/destinations/_base.py
@@ -23,11 +23,16 @@ class BaseDestination(ABC):
         ProcessingRequirement.CHUNKS_AND_EMBEDDINGS
     )
 
-    def __init__(self):
-        """Initialize the base destination."""
+    def __init__(self, soft_fail: bool = False):
+        """Initialize the base destination.
+
+        Args:
+            soft_fail: If True, errors won't fail the sync (for migrations)
+        """
         self._logger: Optional[ContextualLogger] = (
             None  # Store contextual logger as instance variable
         )
+        self.soft_fail = soft_fail
 
     @property
     def logger(self):

--- a/backend/airweave/platform/destinations/qdrant.py
+++ b/backend/airweave/platform/destinations/qdrant.py
@@ -87,9 +87,13 @@ class QdrantDestination(VectorDBDestination):
     # Default write concurrency (simple, code-local tuning)
     DEFAULT_WRITE_CONCURRENCY: int = 16
 
-    def __init__(self):
-        """Initialize defaults and placeholders for connection and collection state."""
-        super().__init__()
+    def __init__(self, soft_fail: bool = False):
+        """Initialize defaults and placeholders for connection and collection state.
+
+        Args:
+            soft_fail: If True, errors won't fail the sync (default False)
+        """
+        super().__init__(soft_fail=soft_fail)
         # Logical identifiers (from SQL)
         self.collection_id: UUID | None = None
         self.organization_id: UUID | None = None
@@ -123,6 +127,7 @@ class QdrantDestination(VectorDBDestination):
         credentials: Optional[QdrantAuthConfig] = None,
         config: Optional[dict] = None,
         logger: Optional[ContextualLogger] = None,
+        soft_fail: bool = False,
     ) -> "QdrantDestination":
         """Create and return a connected destination (matches source pattern).
 
@@ -135,6 +140,7 @@ class QdrantDestination(VectorDBDestination):
             credentials: Optional QdrantAuthConfig with url and api_key (None for native)
             config: Unused (kept for interface consistency with sources)
             logger: Logger instance
+            soft_fail: If True, errors won't fail the sync (default False)
 
         Returns:
             Configured QdrantDestination instance with multi-tenant shared collection
@@ -143,7 +149,7 @@ class QdrantDestination(VectorDBDestination):
             Tenant isolation is achieved via airweave_collection_id filtering in Qdrant.
             Each collection belongs to exactly one organization, so collection_id is sufficient.
         """
-        instance = cls()
+        instance = cls(soft_fail=soft_fail)
         instance.set_logger(logger or default_logger)
         instance.collection_id = collection_id
         instance.organization_id = organization_id

--- a/backend/airweave/platform/destinations/vespa.py
+++ b/backend/airweave/platform/destinations/vespa.py
@@ -114,9 +114,13 @@ class VespaDestination(VectorDBDestination):
 
     processing_requirement = ProcessingRequirement.VESPA_CHUNKS_AND_EMBEDDINGS
 
-    def __init__(self):
-        """Initialize the Vespa destination."""
-        super().__init__()
+    def __init__(self, soft_fail: bool = True):
+        """Initialize the Vespa destination.
+
+        Args:
+            soft_fail: If True, errors won't fail the sync (default True for migration)
+        """
+        super().__init__(soft_fail=soft_fail)
         self.collection_id: UUID | None = None
         self.sync_id: UUID | None = None
         self.organization_id: UUID | None = None
@@ -131,6 +135,7 @@ class VespaDestination(VectorDBDestination):
         organization_id: Optional[UUID] = None,
         vector_size: Optional[int] = None,
         logger: Optional[ContextualLogger] = None,
+        soft_fail: bool = True,
         **kwargs,
     ) -> "VespaDestination":
         """Create and return a connected Vespa destination.
@@ -142,6 +147,7 @@ class VespaDestination(VectorDBDestination):
             organization_id: Organization UUID
             vector_size: Vector dimensions (unused - Vespa handles embeddings)
             logger: Logger instance
+            soft_fail: If True, errors won't fail the sync (default True for migration)
             **kwargs: Additional keyword arguments (unused)
 
         Returns:
@@ -149,7 +155,7 @@ class VespaDestination(VectorDBDestination):
         """
         from vespa.application import Vespa
 
-        instance = cls()
+        instance = cls(soft_fail=soft_fail)
         instance.set_logger(logger or default_logger)
         instance.collection_id = collection_id
         instance.organization_id = organization_id
@@ -158,7 +164,8 @@ class VespaDestination(VectorDBDestination):
         instance.app = Vespa(url=settings.VESPA_URL, port=settings.VESPA_PORT)
 
         instance.logger.info(
-            f"Connected to Vespa at {settings.vespa_url} for collection {collection_id}"
+            f"Connected to Vespa at {settings.vespa_url} for collection {collection_id} "
+            f"(soft_fail={'enabled' if soft_fail else 'disabled'})"
         )
 
         return instance

--- a/backend/airweave/platform/sync/handlers/destination.py
+++ b/backend/airweave/platform/sync/handlers/destination.py
@@ -187,6 +187,7 @@ class DestinationHandler(EntityActionHandler):
             await self._execute_with_retry(
                 operation=lambda d=dest, p=processed: d.bulk_insert(p),
                 operation_name=f"insert_{dest.__class__.__name__}",
+                destination=dest,
                 sync_context=sync_context,
             )
 
@@ -203,6 +204,7 @@ class DestinationHandler(EntityActionHandler):
                     ids, sync_context.sync.id
                 ),
                 operation_name=f"{operation}_{dest.__class__.__name__}",
+                destination=dest,
                 sync_context=sync_context,
             )
 
@@ -224,10 +226,19 @@ class DestinationHandler(EntityActionHandler):
         self,
         operation: Callable[[], Awaitable],
         operation_name: str,
+        destination: BaseDestination,
         sync_context: "SyncContext",
         max_retries: int = 4,
     ) -> None:
-        """Execute operation with exponential backoff retry for network issues."""
+        """Execute operation with exponential backoff retry for network issues.
+
+        Args:
+            operation: The operation to execute
+            operation_name: Name for logging
+            destination: The destination instance (for soft_fail check)
+            sync_context: Sync context
+            max_retries: Max retry attempts for network errors
+        """
         for attempt in range(max_retries + 1):
             try:
                 return await operation()
@@ -240,10 +251,27 @@ class DestinationHandler(EntityActionHandler):
                     )
                     await asyncio.sleep(wait)
                 else:
+                    # Soft-fail: log error but don't crash sync
+                    if destination.soft_fail:
+                        sync_context.logger.error(
+                            f"🔴 [{self.name}] {operation_name} SOFT-FAIL after {max_retries + 1} attempts: "
+                            f"{type(e).__name__}: {e}. Sync continues (soft_fail=True)",
+                            exc_info=True,
+                        )
+                        return  # Continue sync
                     raise SyncFailureError(
                         f"Destination unavailable: {type(e).__name__}: {e}"
                     ) from e
             except Exception as e:
+                # Soft-fail: log error but don't crash sync
+                if destination.soft_fail:
+                    sync_context.logger.error(
+                        f"🔴 [{self.name}] {operation_name} SOFT-FAIL: "
+                        f"{type(e).__name__}: {e}. Sync continues (soft_fail=True)",
+                        exc_info=True,
+                    )
+                    return  # Continue sync
+
                 sync_context.logger.error(
                     f"[{self.name}] {operation_name} failed: {type(e).__name__}: {e}"
                 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduce soft-fail mode for destination operations to keep syncs running during the Vespa migration. When enabled, destination errors are logged and the sync continues instead of failing.

- **New Features**
  - Added soft_fail flag to BaseDestination; propagated to Qdrant and Vespa constructors and create methods (default True for Vespa, False for Qdrant).
  - Updated sync retry logic to check destination.soft_fail and continue on errors with clear SOFT-FAIL logs instead of raising.
  - Vespa connection logs now include soft_fail status for migration monitoring.

<sup>Written for commit 6bdcfc776510110cddb3491554c086098298963e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

