### PR TITLE
Fix empty error messages from Qdrant ResponseHandlingException

### DIFF
--- a/backend/airweave/api/v1/endpoints/s3.py
+++ b/backend/airweave/api/v1/endpoints/s3.py
@@ -14,7 +14,8 @@ from airweave.api import deps
 from airweave.api.context import ApiContext
 from airweave.api.router import TrailingSlashRouter
 from airweave.core.credentials import encrypt
-from airweave.core.shared_models import AuthenticationMethod, ConnectionStatus, FeatureFlag
+from airweave.core.shared_models import ConnectionStatus, FeatureFlag
+from airweave.schemas.source_connection import AuthenticationMethod
 from airweave.models.connection import Connection
 from airweave.models.integration_credential import IntegrationCredential
 from airweave.platform.configs.auth import S3AuthConfig

--- a/backend/airweave/platform/sources/google_drive.py
+++ b/backend/airweave/platform/sources/google_drive.py
@@ -1606,7 +1606,7 @@ class GoogleDriveSource(BaseSource):
                     except Exception as e:
                         self.logger.error(f"Include mode error for My Drive: {str(e)}")
 
-                # Store the next start page token for future incremental syncs
+                # Store the next start page token for future syncs (both incremental and full)
                 await self._store_next_start_page_token(client)
 
         except Exception as e:


### PR DESCRIPTION
- Handle None/empty source errors in ResponseHandlingException gracefully
- Add fallback error messages when exception strings are empty
- Include exc_info=True for full tracebacks in destination handler
- Add response_handling_exception_str to error context for debugging

Resolves issue where ResponseHandlingException failures showed as: 'Destination failed: ResponseHandlingException: ' (empty message)

Now provides actionable error context even when Qdrant client provides insufficient error details.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty Qdrant ResponseHandlingException messages by adding safe fallbacks and richer context, so failures show actionable details instead of blank errors. Also logs full tracebacks in the destination handler.

- **Bug Fixes**
  - Add defaults when source_error is None/empty and include response_handling_exception_str in error context.
  - Guard HTTP fields; only attach status/method/url when present.
  - Use "(empty error message)" fallbacks in logs and SyncFailureError; include exc_info=True for full tracebacks.

<sup>Written for commit fb5d29205ba098b1adf605b170b3f2279883847c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

