### PR TITLE
fix: remove PR coverage comments to reduce noise

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   test:
@@ -61,45 +60,12 @@ jobs:
         if: github.event_name == 'pull_request'
         run: pip install diff-cover
 
-      - name: Generate diff coverage report
+      - name: Check diff coverage
         if: github.event_name == 'pull_request'
-        id: diff-cover
         run: |
-          # Run diff-cover and capture exit code
-          set +e
           diff-cover coverage.xml \
             --compare-branch=origin/${{ github.base_ref }} \
-            --markdown-report=diff-coverage.md \
             --fail-under=80
-          EXIT_CODE=$?
-          set -e
-
-          # Exit code 2 = coverage below threshold, others = error/no files
-          if [ $EXIT_CODE -eq 2 ]; then
-            echo "coverage_failed=true" >> $GITHUB_OUTPUT
-          else
-            echo "coverage_failed=false" >> $GITHUB_OUTPUT
-          fi
-
-          # Create report if it doesn't exist (no Python files changed)
-          if [ ! -f diff-coverage.md ]; then
-            echo "## ✅ Diff Coverage Report" > diff-coverage.md
-            echo "" >> diff-coverage.md
-            echo "No Python source files were changed in this PR." >> diff-coverage.md
-          fi
-
-      - name: Post coverage comment
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: coverage
-          path: backend/diff-coverage.md
-
-      - name: Fail if coverage too low
-        if: github.event_name == 'pull_request' && steps.diff-cover.outputs.coverage_failed == 'true'
-        run: |
-          echo "::error::Diff coverage is below 80% threshold. Please add tests for your changes."
-          exit 1
 
       - name: Upload coverage to Codecov
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- Removes the sticky coverage comment from PRs to stop polluting discussions
- Keeps diff-cover functionality: still fails if coverage is below 80%
- Removes unused `pull-requests: write` permission
- Simplifies the workflow by removing markdown report generation

## Test plan
- [ ] Open a PR with backend changes and verify no coverage comment is posted
- [ ] Verify the workflow still fails if coverage is below threshold

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove sticky diff coverage comments on PRs to reduce noise, while still failing the check when diff coverage is below 80%. Dropped the unused pull-requests: write permission and removed markdown report generation to simplify the workflow.

<sup>Written for commit c99716b13599dcfe7f7dd5ef92a5b86ba45e14cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

