### PR TITLE
Fix AttributeError for undecorated sources missing _supports_continuous

### DIFF
--- a/backend/airweave/platform/sync/orchestrator.py
+++ b/backend/airweave/platform/sync/orchestrator.py
@@ -415,7 +415,7 @@ class SyncOrchestrator:
 
         # Check if source supports continuous/incremental sync (class attribute)
         source_class = type(self.sync_context.source_instance)
-        source_supports_continuous = source_class._supports_continuous
+        source_supports_continuous = getattr(source_class, "_supports_continuous", False)
 
         self.sync_context.logger.debug(
             f"Orphan cleanup check: has_cursor_data={has_cursor_data}, "


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a crash when a source class doesn't define _supports_continuous by safely reading the attribute with a default of False in the orphan cleanup check. This restores compatibility with undecorated sources and treats them as not supporting continuous sync.

<sup>Written for commit e0b7f355f782c71e5aef9d884c93cdf3b8e709f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

