### PR TITLE
Fix Vespa document count to query all schemas instead of only base_entity

### DIFF
--- a/backend/airweave/api/v1/endpoints/admin.py
+++ b/backend/airweave/api/v1/endpoints/admin.py
@@ -2102,8 +2102,10 @@ async def _fetch_destination_counts(
                 async def count_vespa_sync(sync):
                     async with semaphore:
                         try:
+                            # Query all Vespa schemas (not just base_entity)
+                            all_schemas = ", ".join(VespaDestination._get_all_vespa_schemas())
                             yql = (
-                                f"select * from base_entity "
+                                f"select * from sources {all_schemas} "
                                 f"where airweave_system_metadata_sync_id contains '{sync.id}' "
                                 f"and airweave_system_metadata_collection_id contains '{collection_id}' "
                                 f"limit 0"


### PR DESCRIPTION
…tity

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Vespa document counting to query all schemas instead of only base_entity, ensuring accurate totals per sync and collection. Prevents undercounts when documents live outside base_entity.

- **Bug Fixes**
  - Builds YQL using sources from all schemas via VespaDestination._get_all_vespa_schemas(), while keeping existing sync and collection filters.

<sup>Written for commit 030b7cc706f179070636019e629b68beed0181be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

