### PR TITLE
fix: skip vespa shadowing architecture locally

### DIFF
--- a/backend/airweave/core/source_connection_service_helpers.py
+++ b/backend/airweave/core/source_connection_service_helpers.py
@@ -58,24 +58,22 @@ class SourceConnectionHelpers:
     ) -> list[UUID]:
         """Get destination connection IDs based on feature flags.
 
-        By default, writes to BOTH Qdrant and Vespa:
-        - Qdrant: Primary search destination (default for search queries)
-        - Vespa: Secondary destination (for future advanced search features)
+        By default, writes to Qdrant only. Vespa can be enabled via SyncConfig.
 
         Args:
             db: Database session
             ctx: API context with organization and feature flags
 
         Returns:
-            List of destination connection IDs (always includes Qdrant + Vespa, adds S3 if enabled)
+            List of destination connection IDs (Qdrant by default, adds S3 if enabled)
         """
         from sqlalchemy import and_, select
 
         from airweave.models.connection import Connection
 
-        # Write to both Qdrant and Vespa by default
-        # TODO: Remove Qdrant once we Vespa is fully supported
-        destination_ids = [NATIVE_QDRANT_UUID, NATIVE_VESPA_UUID]
+        # Write to Qdrant only by default (Vespa skipped for simpler local setup)
+        # To enable Vespa: set SYNC_CONFIG__DESTINATIONS__SKIP_VESPA=false
+        destination_ids = [NATIVE_QDRANT_UUID]
 
         # Add S3 if feature flag enabled
         if ctx.has_feature(FeatureFlag.S3_DESTINATION):

--- a/backend/airweave/platform/sync/config/base.py
+++ b/backend/airweave/platform/sync/config/base.py
@@ -16,7 +16,9 @@ class DestinationConfig(BaseModel):
     """Controls where entities are written."""
 
     skip_qdrant: bool = Field(False, description="Skip writing to native Qdrant")
-    skip_vespa: bool = Field(False, description="Skip writing to native Vespa")
+    skip_vespa: bool = Field(
+        True, description="Skip writing to native Vespa (default: true for local)"
+    )
     target_destinations: Optional[List[UUID]] = Field(
         None, description="If set, ONLY write to these destination UUIDs"
     )

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -232,10 +232,13 @@ services:
     restart: on-failure
 
   # Vespa single-node for development (config server + content + container combined)
+  # Enable with: --profile vespa
   vespa:
     container_name: airweave-vespa
     image: vespaengine/vespa:8
     hostname: vespa
+    profiles:
+      - vespa
     ports:
       - "8081:8081" # Query/Document API
       - "19071:19071" # Config server (for deployment)
@@ -255,6 +258,8 @@ services:
   vespa-init:
     container_name: airweave-vespa-init
     image: alpine:3.19
+    profiles:
+      - vespa
     volumes:
       - ../vespa/app:/app:ro
       - ../vespa/init-vespa.sh:/init-vespa.sh:ro

--- a/start.sh
+++ b/start.sh
@@ -238,60 +238,9 @@ echo ""
 echo "Waiting for services to initialize..."
 sleep 10
 
-# Check if Vespa document API is ready (wait for vespa-init to complete)
-echo "Checking Vespa readiness..."
-MAX_VESPA_RETRIES=60
-VESPA_RETRY_COUNT=0
-VESPA_READY=false
-
-while [ $VESPA_RETRY_COUNT -lt $MAX_VESPA_RETRIES ]; do
-  # Check if vespa-init has completed (exited with status 0)
-  INIT_STATUS=$(${CONTAINER_CMD} inspect airweave-vespa-init --format='{{.State.Status}}' 2>/dev/null || echo "not_found")
-  INIT_EXIT_CODE=$(${CONTAINER_CMD} inspect airweave-vespa-init --format='{{.State.ExitCode}}' 2>/dev/null || echo "1")
-
-  if [ "$INIT_STATUS" = "exited" ] && [ "$INIT_EXIT_CODE" = "0" ]; then
-    # Init completed, now verify document API is actually ready for requests
-    # Use timeout and write to temp file to avoid concatenation issues
-    if timeout 5 curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/document/v1/ > /tmp/vespa_status_$$ 2>&1; then
-      DOC_STATUS=$(cat /tmp/vespa_status_$$ 2>/dev/null | tr -cd '0-9' || echo "000")
-      rm -f /tmp/vespa_status_$$
-      
-      # Any HTTP response code (400, 404, 200, etc.) means API is responding
-      # Only "000" or empty means connection failed
-      if [ -n "$DOC_STATUS" ] && [ "$DOC_STATUS" != "000" ] && [ "$DOC_STATUS" -ge 100 ] 2>/dev/null; then
-        echo "✅ Vespa is ready! (init completed, document API verified: HTTP $DOC_STATUS)"
-        VESPA_READY=true
-        break
-      else
-        echo "⏳ Vespa init done but document API not responding (attempt $((VESPA_RETRY_COUNT + 1))/$MAX_VESPA_RETRIES)"
-      fi
-    else
-      rm -f /tmp/vespa_status_$$
-      echo "⏳ Vespa document API not reachable (attempt $((VESPA_RETRY_COUNT + 1))/$MAX_VESPA_RETRIES)"
-    fi
-  elif [ "$INIT_STATUS" = "exited" ] && [ "$INIT_EXIT_CODE" != "0" ]; then
-    echo "❌ Vespa init container failed with exit code $INIT_EXIT_CODE"
-    echo "Check vespa-init logs with: ${CONTAINER_CMD} logs airweave-vespa-init"
-    break
-  else
-    echo "⏳ Waiting for Vespa init... (attempt $((VESPA_RETRY_COUNT + 1))/$MAX_VESPA_RETRIES, init_status=$INIT_STATUS)"
-  fi
-
-  VESPA_RETRY_COUNT=$((VESPA_RETRY_COUNT + 1))
-  sleep 5
-done
-
-if [ "$VESPA_READY" = false ]; then
-  echo "❌ Vespa not ready after $((MAX_VESPA_RETRIES * 5)) seconds"
-  echo "Check vespa logs: ${CONTAINER_CMD} logs airweave-vespa"
-  echo "Check vespa-init logs: ${CONTAINER_CMD} logs airweave-vespa-init"
-  echo ""
-  echo "Vespa troubleshooting:"
-  echo "  1. Check if Vespa container is running: ${CONTAINER_CMD} ps | grep vespa"
-  echo "  2. Check Vespa health: curl http://localhost:8081/state/v1/health"
-  echo "  3. Check document API: curl http://localhost:8081/document/v1/"
-  exit 1
-fi
+# Vespa is disabled by default (uses Qdrant only for simpler local setup)
+# To enable Vespa, run with --profile vespa
+echo "⏭️  Vespa skipped (not needed for local development, uses Qdrant only)"
 
 # Check if backend is healthy (with retries)
 echo "Checking backend health..."
@@ -362,11 +311,7 @@ echo "Other services:"
 echo "📊 Temporal UI:    http://localhost:8088"
 echo "🗄️  PostgreSQL:    localhost:5432"
 echo "🔍 Qdrant:         http://localhost:6333"
-if curl -sf http://localhost:8081/state/v1/health | grep -q '"up"' 2>/dev/null; then
-  echo "🔎 Vespa:          http://localhost:8081"
-else
-  echo "⚠️  Vespa:          Not responding (check logs with: docker logs airweave-vespa)"
-fi
+echo "⏭️  Vespa:          Skipped (enable with --profile vespa)"
 
 if [ "$USE_LOCAL_EMBEDDINGS" = true ]; then
   echo "🤖 Embeddings:    http://localhost:9878 (local text2vec)"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Default local setup now skips Vespa and writes to Qdrant only. Vespa is optional and can be enabled when needed to simplify development.

- **Refactors**
  - Destination selection now returns Qdrant-only by default; set SYNC_CONFIG__DESTINATIONS__SKIP_VESPA=false to include Vespa.
  - DestinationConfig sets skip_vespa=true by default (local).
  - Docker adds a vespa profile; start.sh removes Vespa readiness checks and shows Vespa as “skipped”.

- **Migration**
  - To run Vespa locally: use the docker profile (e.g., docker compose --profile vespa up -d).
  - To write to Vespa: set SYNC_CONFIG__DESTINATIONS__SKIP_VESPA=false.

<sup>Written for commit 3dd0cacacd5619914ad5297a4a5c7a9842fda05c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

