### PR TITLE
fix: avoid SQLAlchemy lazy-load issues

### DIFF
--- a/backend/airweave/api/v1/endpoints/s3.py
+++ b/backend/airweave/api/v1/endpoints/s3.py
@@ -104,6 +104,9 @@ async def configure_s3_destination(
     existing_connection = result.scalar_one_or_none()
 
     if existing_connection:
+        # Store connection ID before any commit (avoids SQLAlchemy lazy-load issues)
+        existing_connection_id = existing_connection.id
+
         # Update existing connection credentials
         if existing_connection.integration_credential_id:
             cred = await crud.integration_credential.get(
@@ -115,7 +118,7 @@ async def configure_s3_destination(
                 await db.refresh(cred)
 
         return S3ConfigResponse(
-            connection_id=str(existing_connection.id),
+            connection_id=str(existing_connection_id),
             status="updated",
             message="S3 connection updated successfully",
         )


### PR DESCRIPTION
Stores the connection ID before committing changes to prevent potential issues related to SQLAlchemy's lazy loading behavior. This ensures that the connection ID is readily available when needed, preventing errors or unexpected behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture the S3 connection_id before any commit to avoid SQLAlchemy lazy-load/detached-instance issues. This prevents intermittent errors and ensures the correct connection_id is returned after updating credentials.

<sup>Written for commit fc3a82f02ec5f432c5216bc01cc947cb93e4d5a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

