### PR TITLE
Fix webhook edit modal crash from undefined urlError variable

### DIFF
--- a/frontend/src/components/webhooks/WebhooksTab.tsx
+++ b/frontend/src/components/webhooks/WebhooksTab.tsx
@@ -401,11 +401,8 @@ export function EditWebhookModal({
                   type="url"
                   value={url}
                   onChange={(e) => setUrl(e.target.value)}
-                  className={cn("h-9", urlError && "border-destructive")}
+                  className="h-9"
                 />
-                {urlError && (
-                  <p className="text-xs text-destructive">{urlError}</p>
-                )}
               </div>
               <div className="space-y-1.5">
                 <Label className="text-xs">Event Types</Label>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a crash in the Edit Webhook modal caused by referencing an undefined urlError. Removes conditional error styling and the error message for the URL input so the modal opens and edits reliably.

<sup>Written for commit 474b87fc43e9f8396a655ec84a057f482acb986c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

