### PR TITLE
fix: correct mock settings attribute in rate limiter tests

### DIFF
--- a/backend/tests/unit/core/test_rate_limiter_service.py
+++ b/backend/tests/unit/core/test_rate_limiter_service.py
@@ -40,9 +40,8 @@ def mock_ctx(organization_id):
 @pytest.fixture
 def mock_settings():
     """Mock settings to enable rate limiting."""
-    with patch("airweave.core.config.settings") as mock:
-        mock.LOCAL_DEVELOPMENT = False
-        mock.RATE_LIMIT_ENABLED = True
+    with patch("airweave.core.rate_limiter_service.settings") as mock:
+        mock.DISABLE_RATE_LIMIT = False
         yield mock
 
 


### PR DESCRIPTION
## Summary
- Fixed failing rate limiter unit tests caused by incorrect mock settings attribute
- The mock_settings fixture was setting RATE_LIMIT_ENABLED=True, but the actual code checks DISABLE_RATE_LIMIT
- Changed patch target to airweave.core.rate_limiter_service.settings (where it is used) and set DISABLE_RATE_LIMIT=False

## Test plan
- [x] All 7 rate limiter tests now pass
- [x] Pre-commit hooks pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing rate limiter unit tests by patching the correct settings module and mocking DISABLE_RATE_LIMIT=False so tests exercise the limiter logic.

- **Bug Fixes**
  - Patch target updated to airweave.core.rate_limiter_service.settings.
  - Mock uses DISABLE_RATE_LIMIT=False instead of RATE_LIMIT_ENABLED.

<sup>Written for commit 43c4629c14d0b3a3110c394d3520c5cd3b461a39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

