### PR TITLE
fix: token injection tests with composio

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -24,3 +24,4 @@ markers =
     integration: marks tests as integration tests (deselect with '-m "not integration"')
     rate_limit: marks tests that test rate limiting (run sequentially for proper isolation)
     api_rate_limit: marks tests for API-level rate limiting (excluded from CI)
+    svix: marks tests that require Svix webhook delivery (excluded from CI due to network routing)

--- a/backend/tests/e2e/smoke/test_source_connections_token_injection.py
+++ b/backend/tests/e2e/smoke/test_source_connections_token_injection.py
@@ -1,0 +1,437 @@
+"""
+Test module for OAuth token injection (direct token injection) source connections.
+
+Tests the OAuthTokenAuthentication flow where users provide access tokens directly
+without going through the OAuth browser flow.
+"""
+
+import pytest
+import pytest_asyncio
+import httpx
+import asyncio
+from typing import Dict
+
+
+async def fetch_fresh_token_from_composio(
+    api_key: str,
+    auth_config_id: str,
+    account_id: str,
+    source_slug: str = "notion",
+) -> str:
+    """Fetch a fresh access token directly from Composio API."""
+    async with httpx.AsyncClient() as client:
+        headers = {"x-api-key": api_key}
+
+        page = 1
+        while True:
+            response = await client.get(
+                "https://backend.composio.dev/api/v3/connected_accounts",
+                headers=headers,
+                params={"limit": 100, "page": page},
+            )
+            response.raise_for_status()
+            data = response.json()
+            items = data.get("items", [])
+
+            if not items:
+                break
+
+            for account in items:
+                toolkit_slug = account.get("toolkit", {}).get("slug")
+                acc_auth_config_id = account.get("auth_config", {}).get("id")
+                acc_id = account.get("id")
+
+                if (toolkit_slug == source_slug and
+                    acc_auth_config_id == auth_config_id and
+                    acc_id == account_id):
+                    creds = account.get("state", {}).get("val", {})
+                    token = creds.get("access_token")
+                    if token:
+                        return token
+
+            if len(items) < 100:
+                break
+            page += 1
+
+    raise ValueError(f"Could not find access_token for {source_slug}")
+
+
+@pytest_asyncio.fixture
+async def fresh_notion_token(config) -> str:
+    """Fetch a fresh Notion access token from Composio. Fails if not configured."""
+    if not config.TEST_COMPOSIO_API_KEY:
+        pytest.fail("TEST_COMPOSIO_API_KEY not configured")
+    if not config.TEST_COMPOSIO_NOTION_AUTH_CONFIG_ID_1:
+        pytest.fail("TEST_COMPOSIO_NOTION_AUTH_CONFIG_ID_1 not configured")
+    if not config.TEST_COMPOSIO_NOTION_ACCOUNT_ID_1:
+        pytest.fail("TEST_COMPOSIO_NOTION_ACCOUNT_ID_1 not configured")
+
+    return await fetch_fresh_token_from_composio(
+        api_key=config.TEST_COMPOSIO_API_KEY,
+        auth_config_id=config.TEST_COMPOSIO_NOTION_AUTH_CONFIG_ID_1,
+        account_id=config.TEST_COMPOSIO_NOTION_ACCOUNT_ID_1,
+        source_slug="notion",
+    )
+
+
+class TestDirectTokenInjectionValidation:
+    """Test suite for token injection API validation (no valid tokens needed)."""
+
+    @pytest.mark.asyncio
+    async def test_token_injection_invalid_token_rejected(
+        self, api_client: httpx.AsyncClient, collection: Dict
+    ):
+        """Test that invalid tokens are rejected during connection creation."""
+        payload = {
+            "name": "Test Invalid Token",
+            "short_name": "notion",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": "invalid_token_12345",
+            },
+            "sync_immediately": False,
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+
+        assert response.status_code == 400
+        error = response.json()
+        detail = error.get("detail", "").lower()
+        assert "invalid" in detail or "token" in detail
+
+    @pytest.mark.asyncio
+    async def test_token_injection_empty_token_rejected(
+        self, api_client: httpx.AsyncClient, collection: Dict
+    ):
+        """Test that empty access_token is rejected."""
+        payload = {
+            "name": "Test Empty Token",
+            "short_name": "notion",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": "",
+            },
+            "sync_immediately": False,
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+        assert response.status_code in [400, 422]
+
+    @pytest.mark.asyncio
+    async def test_token_injection_unsupported_source_rejected(
+        self, api_client: httpx.AsyncClient, collection: Dict
+    ):
+        """Test that token injection on non-OAuth sources is rejected."""
+        payload = {
+            "name": "Test Token on Non-OAuth Source",
+            "short_name": "stripe",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": "some_access_token",
+            },
+            "sync_immediately": False,
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+
+        assert response.status_code == 400
+        error = response.json()
+        detail = error.get("detail", "").lower()
+        assert "not support" in detail or "unsupported" in detail
+
+    @pytest.mark.asyncio
+    async def test_token_injection_whitespace_token_rejected(
+        self, api_client: httpx.AsyncClient, collection: Dict
+    ):
+        """Test that whitespace-only access_token is rejected."""
+        payload = {
+            "name": "Test Whitespace Token",
+            "short_name": "notion",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": "   ",
+            },
+            "sync_immediately": False,
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+        assert response.status_code in [400, 422]
+
+
+class TestDirectTokenInjectionWithValidToken:
+    """Test suite for token injection with valid tokens."""
+
+    @pytest.mark.asyncio
+    async def test_token_injection_creates_authenticated_connection(
+        self, api_client: httpx.AsyncClient, collection: Dict, fresh_notion_token: str
+    ):
+        """Test that token injection creates an immediately authenticated connection."""
+        payload = {
+            "name": "Test Token Injection",
+            "short_name": "notion",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": fresh_notion_token,
+            },
+            "sync_immediately": False,
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+        response.raise_for_status()
+        connection = response.json()
+
+        assert connection["auth"]["method"] == "oauth_token"
+        assert connection["auth"]["authenticated"] is True
+        assert connection["status"] in ["active", "syncing"]
+        assert connection["auth"]["auth_url"] is None
+
+        await api_client.delete(f"/source-connections/{connection['id']}")
+
+    @pytest.mark.asyncio
+    async def test_token_injection_defaults_sync_immediately_true(
+        self, api_client: httpx.AsyncClient, collection: Dict, fresh_notion_token: str
+    ):
+        """Test that token injection defaults to sync_immediately=True."""
+        payload = {
+            "name": "Test Token Injection Default Sync",
+            "short_name": "notion",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": fresh_notion_token,
+            },
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+        response.raise_for_status()
+        connection = response.json()
+
+        assert connection["auth"]["method"] == "oauth_token"
+        assert connection["status"] in ["active", "syncing"]
+
+        await api_client.delete(f"/source-connections/{connection['id']}")
+
+    @pytest.mark.asyncio
+    async def test_token_injection_with_optional_refresh_token(
+        self, api_client: httpx.AsyncClient, collection: Dict, fresh_notion_token: str
+    ):
+        """Test token injection with both access_token and refresh_token."""
+        payload = {
+            "name": "Test Token Injection With Refresh",
+            "short_name": "notion",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": fresh_notion_token,
+                "refresh_token": "optional_refresh_token_for_test",
+            },
+            "sync_immediately": False,
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+        response.raise_for_status()
+        connection = response.json()
+
+        assert connection["auth"]["method"] == "oauth_token"
+        assert connection["auth"]["authenticated"] is True
+
+        await api_client.delete(f"/source-connections/{connection['id']}")
+
+
+class TestTokenInjectionSync:
+    """Test sync behavior for token-injected connections."""
+
+    @pytest.mark.asyncio
+    async def test_token_injection_sync_completes_without_refresh(
+        self, api_client: httpx.AsyncClient, collection: Dict, fresh_notion_token: str
+    ):
+        """Test that sync completes successfully without token refresh."""
+        payload = {
+            "name": "Test Token Sync No Refresh",
+            "short_name": "notion",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": fresh_notion_token,
+            },
+            "sync_immediately": True,
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+        response.raise_for_status()
+        connection = response.json()
+        connection_id = connection["id"]
+
+        max_wait = 60
+        poll_interval = 2
+        elapsed = 0
+        sync_completed = False
+        final_status = None
+
+        while elapsed < max_wait:
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+
+            status_response = await api_client.get(f"/source-connections/{connection_id}")
+            if status_response.status_code == 200:
+                conn_details = status_response.json()
+                final_status = conn_details.get("status")
+
+                if final_status in ["active", "error"]:
+                    sync_completed = True
+                    break
+
+                sync_info = conn_details.get("sync")
+                if sync_info and sync_info.get("last_job"):
+                    job_status = sync_info["last_job"].get("status")
+                    if job_status in ["completed", "failed"]:
+                        sync_completed = True
+                        final_status = "active" if job_status == "completed" else "error"
+                        break
+
+        assert sync_completed, f"Sync did not complete within {max_wait} seconds"
+        assert final_status == "active", f"Expected 'active' status, got '{final_status}'"
+
+        await api_client.delete(f"/source-connections/{connection_id}")
+
+    @pytest.mark.asyncio
+    async def test_token_injection_manual_sync_trigger(
+        self, api_client: httpx.AsyncClient, collection: Dict, fresh_notion_token: str
+    ):
+        """Test manually triggering a sync on a token-injected connection."""
+        payload = {
+            "name": "Test Token Manual Sync",
+            "short_name": "notion",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": fresh_notion_token,
+            },
+            "sync_immediately": False,
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+        response.raise_for_status()
+        connection = response.json()
+        connection_id = connection["id"]
+
+        assert connection["sync"] is None or connection["sync"]["total_runs"] == 0
+
+        run_response = await api_client.post(f"/source-connections/{connection_id}/run")
+        assert run_response.status_code == 200
+        sync_job = run_response.json()
+        assert sync_job["status"] in ["pending", "running"]
+
+        max_wait = 60
+        poll_interval = 2
+        elapsed = 0
+
+        while elapsed < max_wait:
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+
+            status_response = await api_client.get(f"/source-connections/{connection_id}")
+            if status_response.status_code == 200:
+                conn_details = status_response.json()
+                sync_info = conn_details.get("sync")
+                if sync_info and sync_info.get("last_job"):
+                    job_status = sync_info["last_job"].get("status")
+                    if job_status in ["completed", "failed"]:
+                        assert job_status == "completed", \
+                            f"Sync failed: {sync_info['last_job'].get('error')}"
+                        break
+
+        await api_client.delete(f"/source-connections/{connection_id}")
+
+
+class TestTokenInjectionEdgeCases:
+    """Edge case tests for token injection."""
+
+    @pytest.mark.asyncio
+    async def test_token_injection_with_schedule(
+        self, api_client: httpx.AsyncClient, collection: Dict, fresh_notion_token: str
+    ):
+        """Test token injection with a sync schedule."""
+        payload = {
+            "name": "Test Token With Schedule",
+            "short_name": "notion",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": fresh_notion_token,
+            },
+            "schedule": {
+                "cron": "0 * * * *",
+            },
+            "sync_immediately": False,
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+        response.raise_for_status()
+        connection = response.json()
+
+        assert connection["auth"]["method"] == "oauth_token"
+        assert connection["schedule"]["cron"] == "0 * * * *"
+
+        await api_client.delete(f"/source-connections/{connection['id']}")
+
+    @pytest.mark.asyncio
+    async def test_token_injection_connection_get_details(
+        self, api_client: httpx.AsyncClient, collection: Dict, fresh_notion_token: str
+    ):
+        """Test retrieving details of a token-injected connection."""
+        payload = {
+            "name": "Test Token Get Details",
+            "short_name": "notion",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": fresh_notion_token,
+            },
+            "sync_immediately": False,
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+        response.raise_for_status()
+        connection = response.json()
+        connection_id = connection["id"]
+
+        get_response = await api_client.get(f"/source-connections/{connection_id}")
+        get_response.raise_for_status()
+        details = get_response.json()
+
+        assert details["auth"]["method"] == "oauth_token"
+        assert details["auth"]["authenticated"] is True
+        assert "access_token" not in str(details["auth"])
+
+        await api_client.delete(f"/source-connections/{connection_id}")
+
+    @pytest.mark.asyncio
+    async def test_token_injection_list_connections(
+        self, api_client: httpx.AsyncClient, collection: Dict, fresh_notion_token: str
+    ):
+        """Test that token-injected connections appear in list endpoints."""
+        payload = {
+            "name": "Test Token List",
+            "short_name": "notion",
+            "readable_collection_id": collection["readable_id"],
+            "authentication": {
+                "access_token": fresh_notion_token,
+            },
+            "sync_immediately": False,
+        }
+
+        response = await api_client.post("/source-connections", json=payload)
+        response.raise_for_status()
+        connection = response.json()
+        connection_id = connection["id"]
+
+        list_response = await api_client.get("/source-connections")
+        list_response.raise_for_status()
+        connections = list_response.json()
+
+        found = False
+        for conn in connections:
+            if conn["id"] == connection_id:
+                found = True
+                assert conn["auth_method"] == "oauth_token"
+                assert conn["is_authenticated"] is True
+                break
+
+        assert found, f"Connection {connection_id} not found in list"
+
+        await api_client.delete(f"/source-connections/{connection_id}")

--- a/backend/tests/unit/platform/sync/test_token_manager.py
+++ b/backend/tests/unit/platform/sync/test_token_manager.py
@@ -1,0 +1,306 @@
+"""
+Unit tests for TokenManager.
+
+Tests the token manager's ability to:
+- Detect refresh token presence in credentials
+- Determine refresh capability based on credentials
+- Handle direct token injection (access_token only, no refresh_token)
+"""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from uuid import uuid4
+
+from airweave.platform.sync.token_manager import TokenManager
+
+
+class TestCheckHasRefreshToken:
+    """Tests for TokenManager._check_has_refresh_token method."""
+
+    def _create_minimal_token_manager(self, credentials):
+        """Create a TokenManager instance for testing _check_has_refresh_token."""
+        # Create mock dependencies
+        mock_db = MagicMock()
+        mock_source_connection = MagicMock()
+        mock_source_connection.id = uuid4()
+        mock_source_connection.integration_credential_id = uuid4()
+        mock_source_connection.config_fields = None
+        mock_ctx = MagicMock()
+        mock_ctx.logger = MagicMock()
+
+        # TokenManager constructor will call _check_has_refresh_token
+        # We need to ensure credentials has access_token
+        if isinstance(credentials, dict) and "access_token" not in credentials:
+            credentials["access_token"] = "test_access_token"
+        elif not isinstance(credentials, dict):
+            # For non-dict credentials, we'll test the method directly
+            pass
+
+        manager = TokenManager(
+            db=mock_db,
+            source_short_name="test_source",
+            source_connection=mock_source_connection,
+            ctx=mock_ctx,
+            initial_credentials=credentials if isinstance(credentials, dict) else {"access_token": "test"},
+            is_direct_injection=False,
+            logger_instance=MagicMock(),
+        )
+
+        return manager
+
+    def test_dict_with_refresh_token(self):
+        """Test detection of refresh token in dict credentials."""
+        credentials = {
+            "access_token": "test_access_token",
+            "refresh_token": "test_refresh_token",
+        }
+        manager = self._create_minimal_token_manager(credentials)
+        assert manager._has_refresh_token is True
+
+    def test_dict_without_refresh_token(self):
+        """Test no refresh token in dict credentials (direct token injection)."""
+        credentials = {
+            "access_token": "test_access_token",
+        }
+        manager = self._create_minimal_token_manager(credentials)
+        assert manager._has_refresh_token is False
+
+    def test_dict_with_empty_refresh_token(self):
+        """Test empty refresh token is treated as no refresh token."""
+        credentials = {
+            "access_token": "test_access_token",
+            "refresh_token": "",
+        }
+        manager = self._create_minimal_token_manager(credentials)
+        assert manager._has_refresh_token is False
+
+    def test_dict_with_whitespace_refresh_token(self):
+        """Test whitespace-only refresh token is treated as no refresh token."""
+        credentials = {
+            "access_token": "test_access_token",
+            "refresh_token": "   ",
+        }
+        manager = self._create_minimal_token_manager(credentials)
+        assert manager._has_refresh_token is False
+
+    def test_dict_with_none_refresh_token(self):
+        """Test None refresh token is treated as no refresh token."""
+        credentials = {
+            "access_token": "test_access_token",
+            "refresh_token": None,
+        }
+        manager = self._create_minimal_token_manager(credentials)
+        assert manager._has_refresh_token is False
+
+
+class TestDetermineRefreshCapability:
+    """Tests for TokenManager._determine_refresh_capability method."""
+
+    def _create_token_manager(
+        self,
+        credentials,
+        is_direct_injection=False,
+        auth_provider_instance=None,
+    ):
+        """Create a TokenManager instance for testing _determine_refresh_capability."""
+        mock_db = MagicMock()
+        mock_source_connection = MagicMock()
+        mock_source_connection.id = uuid4()
+        mock_source_connection.integration_credential_id = uuid4()
+        mock_source_connection.config_fields = None
+        mock_ctx = MagicMock()
+        mock_ctx.logger = MagicMock()
+
+        manager = TokenManager(
+            db=mock_db,
+            source_short_name="test_source",
+            source_connection=mock_source_connection,
+            ctx=mock_ctx,
+            initial_credentials=credentials,
+            is_direct_injection=is_direct_injection,
+            logger_instance=MagicMock(),
+            auth_provider_instance=auth_provider_instance,
+        )
+
+        return manager
+
+    def test_direct_injection_disables_refresh(self):
+        """Test that direct injection flag disables refresh capability."""
+        credentials = {
+            "access_token": "test_access_token",
+            "refresh_token": "test_refresh_token",  # Even with refresh token
+        }
+        manager = self._create_token_manager(
+            credentials=credentials,
+            is_direct_injection=True,  # Direct injection
+        )
+        assert manager._can_refresh is False
+
+    def test_auth_provider_enables_refresh(self):
+        """Test that auth provider instance enables refresh capability."""
+        credentials = {
+            "access_token": "test_access_token",
+            # No refresh token
+        }
+        mock_auth_provider = MagicMock()
+        manager = self._create_token_manager(
+            credentials=credentials,
+            auth_provider_instance=mock_auth_provider,
+        )
+        assert manager._can_refresh is True
+
+    def test_no_refresh_token_disables_refresh(self):
+        """Test that missing refresh token disables refresh capability.
+
+        This is the key fix for direct token injection via OAuthTokenAuthentication.
+        """
+        credentials = {
+            "access_token": "test_access_token",
+            # No refresh token - simulates OAuthTokenAuthentication
+        }
+        manager = self._create_token_manager(
+            credentials=credentials,
+            is_direct_injection=False,  # Not flagged as direct injection
+            auth_provider_instance=None,  # No auth provider
+        )
+        # Should detect missing refresh token and disable refresh
+        assert manager._can_refresh is False
+
+    def test_refresh_token_present_enables_refresh(self):
+        """Test that present refresh token enables refresh capability."""
+        credentials = {
+            "access_token": "test_access_token",
+            "refresh_token": "test_refresh_token",
+        }
+        manager = self._create_token_manager(
+            credentials=credentials,
+            is_direct_injection=False,
+            auth_provider_instance=None,
+        )
+        # Should detect refresh token and enable refresh
+        assert manager._can_refresh is True
+
+
+class TestGetValidToken:
+    """Tests for TokenManager.get_valid_token method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_current_token_when_refresh_disabled(self):
+        """Test that get_valid_token returns current token when refresh is disabled."""
+        credentials = {
+            "access_token": "test_access_token",
+            # No refresh token - refresh should be disabled
+        }
+
+        mock_db = MagicMock()
+        mock_source_connection = MagicMock()
+        mock_source_connection.id = uuid4()
+        mock_source_connection.integration_credential_id = uuid4()
+        mock_source_connection.config_fields = None
+        mock_ctx = MagicMock()
+        mock_ctx.logger = MagicMock()
+
+        manager = TokenManager(
+            db=mock_db,
+            source_short_name="test_source",
+            source_connection=mock_source_connection,
+            ctx=mock_ctx,
+            initial_credentials=credentials,
+            is_direct_injection=False,
+            logger_instance=MagicMock(),
+        )
+
+        # Refresh should be disabled
+        assert manager._can_refresh is False
+
+        # get_valid_token should return current token without attempting refresh
+        token = await manager.get_valid_token()
+        assert token == "test_access_token"
+
+    @pytest.mark.asyncio
+    async def test_direct_injection_returns_token_without_refresh(self):
+        """Test direct injection mode returns token without refresh attempt."""
+        credentials = {
+            "access_token": "direct_injected_token",
+            "refresh_token": "should_not_be_used",
+        }
+
+        mock_db = MagicMock()
+        mock_source_connection = MagicMock()
+        mock_source_connection.id = uuid4()
+        mock_source_connection.integration_credential_id = uuid4()
+        mock_source_connection.config_fields = None
+        mock_ctx = MagicMock()
+        mock_ctx.logger = MagicMock()
+
+        manager = TokenManager(
+            db=mock_db,
+            source_short_name="test_source",
+            source_connection=mock_source_connection,
+            ctx=mock_ctx,
+            initial_credentials=credentials,
+            is_direct_injection=True,  # Explicit direct injection
+            logger_instance=MagicMock(),
+        )
+
+        # Should be disabled due to direct_injection flag
+        assert manager._can_refresh is False
+
+        token = await manager.get_valid_token()
+        assert token == "direct_injected_token"
+
+
+class TestCredentialFormats:
+    """Tests for different credential formats."""
+
+    def _create_manager_with_credentials(self, credentials):
+        """Helper to create manager with various credential formats."""
+        mock_db = MagicMock()
+        mock_source_connection = MagicMock()
+        mock_source_connection.id = uuid4()
+        mock_source_connection.integration_credential_id = uuid4()
+        mock_source_connection.config_fields = None
+        mock_ctx = MagicMock()
+        mock_ctx.logger = MagicMock()
+
+        return TokenManager(
+            db=mock_db,
+            source_short_name="test_source",
+            source_connection=mock_source_connection,
+            ctx=mock_ctx,
+            initial_credentials=credentials,
+            is_direct_injection=False,
+            logger_instance=MagicMock(),
+        )
+
+    def test_string_credentials_no_refresh(self):
+        """Test that string credentials (just token) have no refresh capability."""
+        # String credentials are just the access token
+        manager = self._create_manager_with_credentials("string_access_token")
+
+        # String credentials don't have refresh token
+        assert manager._has_refresh_token is False
+        assert manager._can_refresh is False
+
+    def test_object_credentials_with_refresh_token(self):
+        """Test object credentials with refresh_token attribute."""
+        # Create an object with access_token and refresh_token attributes
+        class CredentialsObj:
+            access_token = "obj_access_token"
+            refresh_token = "obj_refresh_token"
+
+        manager = self._create_manager_with_credentials(CredentialsObj())
+
+        assert manager._has_refresh_token is True
+        assert manager._can_refresh is True
+
+    def test_object_credentials_without_refresh_token(self):
+        """Test object credentials without refresh_token attribute."""
+        class CredentialsObj:
+            access_token = "obj_access_token"
+            # No refresh_token attribute
+
+        manager = self._create_manager_with_credentials(CredentialsObj())
+
+        assert manager._has_refresh_token is False
+        assert manager._can_refresh is False


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix failing OAuth token injection by disabling refresh when credentials have no refresh_token and adding Composio-backed tests to verify correct behavior.

- **Bug Fixes**
  - TokenManager now checks for refresh_token and disables refresh for direct injection or missing refresh_token.
  - Added debug logs to explain why refresh is disabled.

- **Tests**
  - Added E2E suite for direct token injection using fresh Notion tokens from Composio.
  - Updated existing OAuth tests to use a Composio fixture for fresh tokens.
  - Added unit tests for refresh-token detection and get_valid_token behavior.
  - Added pytest “svix” marker (excluded from CI).

<sup>Written for commit 090b209f25662843adfda4b007c98ae67540d8ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

