### PR TITLE
Add stable FastAPI debug configuration without auto-reload

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,19 +8,40 @@
             "module": "uvicorn",
             "args": [
                 "--reload",
-                "--reload-exclude",
-                "local_storage",
+                "--reload-dir",
+                "airweave",
                 "--host",
                 "127.0.0.1",
                 "--port",
                 "8001",
-                "--workers",
-                "4",
                 "airweave.main:app"
             ],
             "cwd": "${workspaceFolder}/backend",
             "console": "integratedTerminal",
             "consoleName": "⚡ FastAPI Backend",
+            "jinja": true,
+            "justMyCode": true,
+            "envFile": "${workspaceFolder}/.env",
+            "env": {
+                "LOCAL_DEVELOPMENT": "true",
+                "PYTHONPATH": "${workspaceFolder}/backend"
+            }
+        },
+        {
+            "name": "FastAPI (no reload)",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8001",
+                "airweave.main:app"
+            ],
+            "cwd": "${workspaceFolder}/backend",
+            "console": "integratedTerminal",
+            "consoleName": "⚡ FastAPI Backend (Stable)",
             "jinja": true,
             "justMyCode": true,
             "envFile": "${workspaceFolder}/.env",
@@ -151,6 +172,15 @@
                 "FastAPI",
                 "Temporal Worker (hot reload)",
                 "Attach to Worker"
+            ],
+            "stopAll": true,
+            "preLaunchTask": "start-dev-stack"
+        },
+        {
+            "name": "Stable Stack (no reload)",
+            "configurations": [
+                "FastAPI (no reload)",
+                "Temporal Worker"
             ],
             "stopAll": true,
             "preLaunchTask": "start-dev-stack"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a VS Code debug profile to run FastAPI without auto-reload for stable debugging. Also narrows hot-reload to the airweave folder and removes the workers flag for local dev.

- New Features
  - Added "FastAPI (no reload)" profile and a "Stable Stack (no reload)" compound with the Temporal Worker.
  - Updated hot-reload profile to use --reload-dir airweave and dropped --workers.

<sup>Written for commit 68b19cf838178825fe48199ab072e325fb5ee0f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

