### PR TITLE
fix: Add missing SVIX_JWT_SECRET env var to docker-compose configs

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -73,7 +73,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "svix-server healthcheck http://localhost:8071"]
+      test: [ "CMD-SHELL", "svix-server healthcheck http://localhost:8071" ]
       interval: 5s
       timeout: 5s
       retries: 30
@@ -112,6 +112,7 @@ services:
       - AUTH_ENABLED=false
       # Svix configuration
       - SVIX_URL=http://svix:8071
+      - SVIX_JWT_SECRET=test_signing_secret
       - SVIX_AUTH_TOKEN=
 
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       - AUTH_ENABLED=false
       # Svix configuration
       - SVIX_URL=http://svix:8071
+      - SVIX_JWT_SECRET=${SVIX_JWT_SECRET:-default_signing_secret}
       - SVIX_AUTH_TOKEN=${SVIX_AUTH_TOKEN:-}
     depends_on:
       postgres:
@@ -218,6 +219,7 @@ services:
       - TEMPORAL_ENABLED=true
       # Svix configuration
       - SVIX_URL=http://svix:8071
+      - SVIX_JWT_SECRET=${SVIX_JWT_SECRET:-default_signing_secret}
       - SVIX_AUTH_TOKEN=${SVIX_AUTH_TOKEN:-}
     volumes:
       - ../backend:/app
@@ -288,7 +290,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "svix-server healthcheck http://localhost:8071"]
+      test: [ "CMD-SHELL", "svix-server healthcheck http://localhost:8071" ]
       interval: 5s
       timeout: 5s
       retries: 30


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added SVIX_JWT_SECRET to docker-compose and docker-compose.test to enable Svix JWT signing and prevent auth errors in local and test runs, using default_signing_secret in dev and test_signing_secret in tests.

<sup>Written for commit c767f3a5032a862289edd476dbfe2ac3dc97ff32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

