### PR TITLE
fix: rename encrypted data field for S3 credentials

### DIFF
--- a/backend/airweave/api/v1/endpoints/s3.py
+++ b/backend/airweave/api/v1/endpoints/s3.py
@@ -113,7 +113,7 @@ async def configure_s3_destination(
                 db, existing_connection.integration_credential_id, ctx=ctx
             )
             if cred:
-                cred.encrypted_data = encrypt(auth_config.model_dump())
+                cred.encrypted_credentials = encrypt(auth_config.model_dump())
                 await db.commit()
                 await db.refresh(cred)
 
@@ -299,7 +299,7 @@ async def get_s3_status(
             from airweave.core.credentials import decrypt
 
             try:
-                decrypted = decrypt(cred.encrypted_data)
+                decrypted = decrypt(cred.encrypted_credentials)
                 bucket_name = decrypted.get("bucket_name")
                 role_arn = decrypted.get("role_arn")
             except Exception:

--- a/backend/tests/unit/api/test_s3_endpoints.py
+++ b/backend/tests/unit/api/test_s3_endpoints.py
@@ -275,7 +275,7 @@ class TestGetS3Status:
 
         # Mock credential with decrypted data
         mock_cred = MagicMock()
-        mock_cred.encrypted_data = b"encrypted"
+        mock_cred.encrypted_credentials = b"encrypted"
 
         with patch("airweave.api.v1.endpoints.s3.crud") as mock_crud:
             mock_crud.integration_credential.get = AsyncMock(return_value=mock_cred)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the S3 credential field from encrypted_data to encrypted_credentials to align with the schema and fix decrypting during status checks. Updated the unit test to mock the correct field, preventing misreads and potential config overwrite.

<sup>Written for commit f43bd8cb6850e84379f3b7f10a02dee168e52c84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

