### PR TITLE
chore: move local_storage to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,9 +75,6 @@ backend/coverage.xml
 
 coverage.xml
 
-# Local storage folder
-local_storage/
-
 monke/venv/
 logs/
 monke/.runs/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,14 +9,14 @@
             "args": [
                 "--reload",
                 "--reload-dir",
-                "airweave",
+                "backend/airweave",
                 "--host",
                 "127.0.0.1",
                 "--port",
                 "8001",
                 "airweave.main:app"
             ],
-            "cwd": "${workspaceFolder}/backend",
+            "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
             "consoleName": "⚡ FastAPI Backend",
             "jinja": true,
@@ -39,7 +39,7 @@
                 "8001",
                 "airweave.main:app"
             ],
-            "cwd": "${workspaceFolder}/backend",
+            "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
             "consoleName": "⚡ FastAPI Backend (Stable)",
             "jinja": true,
@@ -59,7 +59,7 @@
             ],
             "console": "integratedTerminal",
             "justMyCode": false,
-            "cwd": "${workspaceFolder}/backend",
+            "cwd": "${workspaceFolder}",
             "env": {
                 "PYTHONPATH": "${workspaceFolder}/backend",
                 "TESTING": "true"
@@ -76,7 +76,7 @@
             "console": "integratedTerminal",
             "consoleName": "🧪 Pytest",
             "justMyCode": false,
-            "cwd": "${workspaceFolder}/backend",
+            "cwd": "${workspaceFolder}",
             "env": {
                 "PYTHONPATH": "${workspaceFolder}/backend",
                 "TESTING": "true"
@@ -90,7 +90,7 @@
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal",
-            "cwd": "${workspaceFolder}/backend",
+            "cwd": "${workspaceFolder}",
             "justMyCode": true
         },
         {
@@ -101,9 +101,9 @@
             "python": "${command:python.interpreterPath}",
             "console": "integratedTerminal",
             "consoleName": "✨ Temporal Worker",
-            "cwd": "${workspaceFolder}/backend",
+            "cwd": "${workspaceFolder}",
             "env": {
-                "PYTHONPATH": "${workspaceFolder}/backend",
+                "PYTHONPATH": "${workspaceFolder}/backend"
                 // "LOG_LEVEL": "DEBUG"
             },
             "justMyCode": false,
@@ -116,7 +116,7 @@
             "program": "${workspaceFolder}/.vscode/run_worker_reload.py",
             "console": "integratedTerminal",
             "consoleName": "✨ Temporal Worker (Hot Reload)",
-            "cwd": "${workspaceFolder}/backend",
+            "cwd": "${workspaceFolder}",
             "env": {
                 "PYTHONPATH": "${workspaceFolder}/backend",
                 "AIRWEAVE_DEBUGPY_WORKER_PORT": "7233"

--- a/backend/airweave/platform/sources/snapshot.py
+++ b/backend/airweave/platform/sources/snapshot.py
@@ -15,7 +15,7 @@ Usage:
     - credentials: {"placeholder": "snapshot"} (required for API)
 
 The path can be:
-- A local filesystem path (for evals): "/path/to/airweave/backend/local_storage/raw/{sync_id}"
+- A local filesystem path (for evals): "/path/to/airweave/local_storage/raw/{sync_id}"
 - A storage-relative path (for blob): "raw/{sync_id}"
 - A full Azure blob URL: "https://{account}.blob.core.windows.net/{container}/{path}"
 

--- a/backend/airweave/platform/storage/README.md
+++ b/backend/airweave/platform/storage/README.md
@@ -65,5 +65,5 @@ Each entity JSON contains original fields plus reconstruction metadata:
 
 ### Location
 
-- **Local**: `backend/local_storage/raw/`
+- **Local**: `local_storage/raw/` (at repo root)
 - **Kubernetes**: PVC-mounted at configured `STORAGE_PATH`

--- a/backend/airweave/platform/storage/backend.py
+++ b/backend/airweave/platform/storage/backend.py
@@ -140,7 +140,7 @@ class FilesystemBackend(StorageBackend):
     """Filesystem-based storage backend.
 
     Works with:
-    - Local development: ./local_storage
+    - Local development: local_storage/ (at repo root, mounted to /app/local_storage)
     - Kubernetes: PVC-mounted path (e.g., /data/airweave-storage)
 
     Thread-safe for basic operations (relies on OS-level file locking).

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -119,6 +119,7 @@ services:
       - "9001:8001"
     volumes:
       - ../backend:/app
+      - ../local_storage:/app/local_storage
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8001/health" ]
       interval: 5s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - "8001:8001"
     volumes:
       - ../backend:/app
+      - ../local_storage:/app/local_storage
     # Enable host.docker.internal on Linux (needed for webhook e2e tests)
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/monke/core/steps.py
+++ b/monke/core/steps.py
@@ -971,10 +971,9 @@ class VerifyRawDataStep(TestStep):
         if storage_path:
             base_path = Path(storage_path)
         else:
-            # Try common local development paths
+            # Try common local development paths (local_storage lives at repo root)
             candidates = [
                 Path("local_storage"),
-                Path("backend/local_storage"),
                 Path("/app/local_storage"),
             ]
             base_path = None


### PR DESCRIPTION
Relocates the local_storage directory to the repository root to align with the intended project structure and improve consistency across environments.

Updates related paths in VS Code launch configurations, Docker Compose files, snapshot source handling, and storage backend configurations to reflect the new location of local_storage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved local_storage to the repository root and updated references across VS Code, Docker Compose, snapshot handling, and the storage backend for consistent local and container usage. Containers now mount it at /app/local_storage.

- **Migration**
  - Move any existing data from backend/local_storage to local_storage/ at the repo root.
  - Ensure local_storage/ exists before running Docker; it’s mounted to /app/local_storage.

<sup>Written for commit 9d4410b79362319de929f6ecdd50c709e1aaedac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

