### PR TITLE
perf: optimize ARF entity counting to fix admin sync list timeouts

### DIFF
--- a/backend/airweave/platform/storage/arf_reader.py
+++ b/backend/airweave/platform/storage/arf_reader.py
@@ -124,13 +124,16 @@ class ArfReader:
             return []
 
     async def get_entity_count(self) -> int:
-        """Get count of entities in ARF storage.
+        """Get count of entities in ARF storage (optimized).
 
         Returns:
             Number of entity files
         """
-        files = await self.list_entity_files()
-        return len(files)
+        entities_dir = self._entities_dir()
+        try:
+            return await self.storage.count_files(entities_dir, pattern="*.json")
+        except Exception:
+            return 0
 
     async def iter_entity_dicts(self, batch_size: int = 50) -> AsyncGenerator[Dict[str, Any], None]:
         """Iterate over raw entity dicts from storage with batched concurrent reads.

--- a/backend/airweave/platform/sync/arf/service.py
+++ b/backend/airweave/platform/sync/arf/service.py
@@ -536,12 +536,10 @@ class ArfService:
         return await self.storage.delete(self._sync_path(sync_id))
 
     async def get_entity_count(self, sync_id: str) -> int:
-        """Get count of entities in store (fast - just counts files without reading)."""
+        """Get count of entities in store (fast - counts without listing all files)."""
         entities_dir = f"{self._sync_path(sync_id)}/entities"
         try:
-            files = await self.storage.list_files(entities_dir)
-            # Just count .json files, don't read them
-            return len([f for f in files if f.endswith(".json")])
+            return await self.storage.count_files(entities_dir, pattern="*.json")
         except Exception:
             return 0
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Optimized ARF entity counting by adding fast file-counting in storage backends, avoiding full listings. This prevents admin sync list timeouts on large datasets.

- **Performance**
  - Added count_files to StorageBackend (filesystem and Azure) for efficient counts.
  - Updated ARFReader.get_entity_count and SyncService.get_entity_count to use "*.json" counts.
  - Reduces I/O and memory usage when counting entities.

<sup>Written for commit 124fe8bbbc630d5b7204db085d4ba794b3e54183. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

