### PR TITLE
Feat: Make Vespa default search destination

### DIFF
--- a/backend/airweave/api/v1/endpoints/search.py
+++ b/backend/airweave/api/v1/endpoints/search.py
@@ -160,7 +160,7 @@ async def search(
             "temporal_relevance is under construction and was ignored"
         )
 
-    # Execute search with new service
+    # Execute search with new service (always use Vespa for public endpoints)
     search_response = await service.search(
         request_id=ctx.request_id,
         readable_collection_id=readable_id,
@@ -168,6 +168,7 @@ async def search(
         stream=False,
         db=db,
         ctx=ctx,
+        destination_override="vespa",
     )
 
     ctx.logger.info(f"Search completed for collection '{readable_id}'")
@@ -224,6 +225,7 @@ async def stream_search_collection_advanced(  # noqa: C901 - streaming orchestra
     async def _run_search() -> None:
         try:
             async with AsyncSessionLocal() as search_db:
+                # Always use Vespa for public endpoints
                 await service.search(
                     request_id=request_id,
                     readable_collection_id=readable_id,
@@ -231,6 +233,7 @@ async def stream_search_collection_advanced(  # noqa: C901 - streaming orchestra
                     stream=True,
                     db=search_db,
                     ctx=ctx,
+                    destination_override="vespa",
                 )
         except ValueError as e:
             await _publish_stream_error(message=str(e), transient=False)

--- a/backend/airweave/search/service.py
+++ b/backend/airweave/search/service.py
@@ -35,8 +35,23 @@ class SearchService:
         stream: bool,
         db: AsyncSession,
         ctx: ApiContext,
+        destination_override: SearchDestination | None = None,
     ) -> SearchResponse:
-        """Search a collection."""
+        """Search a collection.
+
+        Args:
+            request_id: Unique request identifier
+            readable_collection_id: Collection readable ID to search
+            search_request: Search parameters
+            stream: Whether to enable SSE streaming
+            db: Database session
+            ctx: API context
+            destination_override: If provided, override the default destination
+                ('qdrant' or 'vespa'). If None, uses SyncConfig default.
+
+        Returns:
+            SearchResponse with results
+        """
         start_time = time.monotonic()
 
         collection = await crud.collection.get_by_readable_id(
@@ -47,7 +62,14 @@ class SearchService:
 
         ctx.logger.debug("Building search context")
         search_context = await factory.build(
-            request_id, collection.id, readable_collection_id, search_request, stream, ctx, db
+            request_id,
+            collection.id,
+            readable_collection_id,
+            search_request,
+            stream,
+            ctx,
+            db,
+            destination_override=destination_override,
         )
 
         ctx.logger.debug("Executing search")


### PR DESCRIPTION
Make Vespa the default search destination for both the normal and the streaming endpoint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Vespa as the default search backend for both the normal and streaming search endpoints. The API now forces destination_override="vespa", and the search service supports this override while keeping config defaults for other calls.

<sup>Written for commit 6940a497f648a17570d41f48d4233978150c3d65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

