### PR TITLE
Fix: Complete migration to AirweaveSearchResult format for search results

### DIFF
--- a/frontend/src/search/SearchResponse.tsx
+++ b/frontend/src/search/SearchResponse.tsx
@@ -146,9 +146,8 @@ export const SearchResponse: React.FC<SearchResponseProps> = ({
         };
 
         results.forEach((result: any, idx: number) => {
-            const payload = result.payload || result;
-            const entityId = payload.entity_id || payload.id || payload._id;
-            const rawSourceName = payload.airweave_system_metadata?.source_name || payload.source_name || 'Unknown';
+            const entityId = result.entity_id;
+            const rawSourceName = result.system_metadata?.source_name || 'Unknown';
             const sourceName = formatSourceName(rawSourceName);
 
             if (entityId) {
@@ -305,12 +304,7 @@ export const SearchResponse: React.FC<SearchResponseProps> = ({
         setTimeout(() => {
             // Find the entity in the results array
             const entityIndex = results.findIndex((result: any) => {
-                const payload = result.payload || result;
-                const found = payload.entity_id === entityId ||
-                    payload.id === entityId ||
-                    payload._id === entityId;
-
-                return found;
+                return result.entity_id === entityId;
             });
 
             if (entityIndex === -1) {
@@ -2067,7 +2061,7 @@ export const SearchResponse: React.FC<SearchResponseProps> = ({
                                         >
                                             {results.slice(0, visibleResultsCount).map((result: any, index: number) => (
                                                 <EntityResultCard
-                                                    key={result.payload?.entity_id || result.id || index}
+                                                    key={result.entity_id || result.id || index}
                                                     result={result}
                                                     index={index}
                                                     isDark={isDark}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrated all search results to the unified AirweaveSearchResult format, removing payload-based structures and fixing entity ID handling across backend and frontend. This unifies data across sources and prevents UI mismatches.

- **Refactors**
  - Backend: Federated search now returns AirweaveSearchResult with top-level id, entity_id, name, textual_representation, created_at, updated_at, breadcrumbs, system_metadata, access, and source_fields; score preserved; _get_result_id now uses id or entity_id.
  - Frontend: EntityResultCard and SearchResponse read flat result fields; URLs and source-specific metadata pulled from source_fields; removed all payload references; list keys and lookups use result.entity_id; raw JSON copy shows the flat result.

<sup>Written for commit 568498b1ba70102bd853b378b4789ce8957011c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

