### PR TITLE
Fix: PostHog search operations timing events after Vespa integration

### DIFF
--- a/backend/airweave/analytics/search_analytics.py
+++ b/backend/airweave/analytics/search_analytics.py
@@ -104,7 +104,7 @@ def _flatten_operation_metrics(properties: Dict[str, Any], state: Dict[str, Any]
         state: State dict containing operation metrics
     """
     # Extract operation metrics
-    operation_metrics = state.get("_operation_metrics", {})
+    operation_metrics = state.get("operation_metrics", {})
     if not operation_metrics:
         return
 
@@ -145,7 +145,7 @@ def _flatten_operation_metrics(properties: Dict[str, Any], state: Dict[str, Any]
             properties[prop_name] = value
 
     # Extract provider usage (captured by fallback method)
-    provider_usage = state.get("_provider_usage", {})
+    provider_usage = state.get("provider_usage", {})
     if provider_usage:
         # Keep nested structure for full context
         properties["providers_used"] = provider_usage

--- a/backend/airweave/search/service.py
+++ b/backend/airweave/search/service.py
@@ -299,7 +299,7 @@ class SearchService:
         ctx: ApiContext,
     ) -> None:
         """Mark source connections as unauthenticated on federated auth errors."""
-        failed_conn_ids: List[str] = state.get("_failed_federated_auth", [])
+        failed_conn_ids: List[str] = state.get("failed_federated_auth", [])
         if not failed_conn_ids:
             return
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes PostHog search timing events after the Vespa integration. Aligns analytics with updated state keys to restore operation metrics, provider usage, and failed federated auth handling.

- **Bug Fixes**
  - Use state.operation_metrics instead of _operation_metrics.
  - Use state.provider_usage instead of _provider_usage.
  - Use state.failed_federated_auth instead of _failed_federated_auth.

<sup>Written for commit 8a61364e2775ae9b120caa8bc36b512fbf26fea3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

