### PR TITLE
fix(platform): Sync supports_access_control from source decorator to database

### DIFF
--- a/backend/airweave/platform/db_sync.py
+++ b/backend/airweave/platform/db_sync.py
@@ -489,6 +489,7 @@ async def _sync_sources(
             supports_continuous=getattr(source_class, "_supports_continuous", False),
             federated_search=getattr(source_class, "_federated_search", False),
             supports_temporal_relevance=getattr(source_class, "_supports_temporal_relevance", True),
+            supports_access_control=getattr(source_class, "_supports_access_control", False),
             rate_limit_level=rate_limit_level,
         )
         source_definitions.append(source_def)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Syncs the supports_access_control flag from source decorators to the database during source sync, ensuring SourceDefinition records correctly reflect access control support (defaulting to false if unspecified).

<sup>Written for commit 23fea5cc970cd2e4410ce40eafd8b99cbc412f28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

