### PR TITLE
fix(migrations): Rebase ACL migrations after current head to resolve branching

### DIFF
--- a/backend/alembic/versions/j3k4l5m6n7o8_add_supports_access_control_to_source.py
+++ b/backend/alembic/versions/j3k4l5m6n7o8_add_supports_access_control_to_source.py
@@ -25,15 +25,22 @@ def upgrade():
     1. Sets entity.access on all yielded entities
     2. Implements generate_access_control_memberships() method
     """
-    op.add_column(
-        "source",
-        sa.Column(
-            "supports_access_control",
-            sa.Boolean(),
-            nullable=False,
-            server_default="false",
-        ),
-    )
+    from sqlalchemy import inspect
+
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    columns = [col["name"] for col in inspector.get_columns("source")]
+
+    if "supports_access_control" not in columns:
+        op.add_column(
+            "source",
+            sa.Column(
+                "supports_access_control",
+                sa.Boolean(),
+                nullable=False,
+                server_default="false",
+            ),
+        )
 
 
 def downgrade():


### PR DESCRIPTION
- Moved i2j3k4l5m6n7 and j3k4l5m6n7o8 to follow p2q3r4s5t6u7 (current head)
- Added idempotent checks to handle existing table/column in dev
- Fixes deployment failure: access_control_membership table already exists

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebased ACL Alembic migrations to follow the current head and made them idempotent to prevent failures when tables or columns already exist. Fixes deployment error: access_control_membership table already exists.

- **Bug Fixes**
  - Updated down_revision for i2j3k4l5m6n7 to p2q3r4s5t6u7 to resolve branching.
  - Guarded access_control_membership table and index creation with inspector checks.
  - Only adds source.supports_access_control if the column is missing.
  - No data changes; safe for environments with existing ACL artifacts.

<sup>Written for commit 8b5dc94a2e93288738da243baf931a981e9c7a09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

