### PR TITLE
feat(embedders): modular embedding system with Mistral and local support

### DIFF
--- a/backend/airweave/platform/embedders/__init__.py
+++ b/backend/airweave/platform/embedders/__init__.py
@@ -15,6 +15,7 @@ from .config import (
     get_provider_for_model,
 )
 from .fastembed import SparseEmbedder
+from .local import LocalDenseEmbedder
 from .mistral import MistralDenseEmbedder
 from .openai import OpenAIDenseEmbedder
 
@@ -28,18 +29,6 @@ def _resolve_provider(model_name: str | None, provider: str | None) -> str:
         if inferred:
             return inferred
     return get_default_provider()
-
-
-def _create_local_fallback_embedder(vector_size: int) -> BaseEmbedder:
-    """Create embedder for 'local' provider (falls back to cloud providers)."""
-    if settings.OPENAI_API_KEY:
-        return OpenAIDenseEmbedder(vector_size=vector_size)
-    if settings.MISTRAL_API_KEY:
-        return MistralDenseEmbedder(model_name="mistral-embed", vector_size=vector_size)
-    raise ValueError(
-        "Local dense embeddings not yet implemented. "
-        "Set OPENAI_API_KEY or MISTRAL_API_KEY for dense embeddings."
-    )
 
 
 def get_dense_embedder(
@@ -76,7 +65,8 @@ def get_dense_embedder(
     if provider == "openai":
         return OpenAIDenseEmbedder(vector_size=vector_size)
     if provider == "local":
-        return _create_local_fallback_embedder(vector_size)
+        return LocalDenseEmbedder(vector_size=vector_size, model_name=model_name)
+
     raise ValueError(f"Unknown embedding provider: {provider}")
 
 
@@ -89,6 +79,7 @@ __all__ = [
     # Dense embedders
     "OpenAIDenseEmbedder",
     "MistralDenseEmbedder",
+    "LocalDenseEmbedder",
     "DenseEmbedder",  # Legacy alias
     # Sparse embedders
     "SparseEmbedder",

--- a/backend/airweave/platform/embedders/local.py
+++ b/backend/airweave/platform/embedders/local.py
@@ -1,0 +1,206 @@
+"""Local dense embedder using text2vec-transformers container.
+
+Uses the semitechnologies/transformers-inference container running locally
+or in a sidecar. Default model is all-MiniLM-L6-v2 (384 dimensions).
+"""
+
+import asyncio
+import time
+from typing import TYPE_CHECKING, List, Optional, Union
+
+import httpx
+
+from airweave.core.config import settings
+from airweave.core.logging import ContextualLogger
+from airweave.core.logging import logger as default_logger
+from airweave.platform.sync.exceptions import SyncFailureError
+
+from ._base import BaseEmbedder
+
+if TYPE_CHECKING:
+    from airweave.platform.contexts import SyncContext
+
+
+class LocalDenseEmbedder(BaseEmbedder):
+    """Local dense embedder using text2vec-transformers inference service.
+
+    Features:
+    - No API keys required - runs locally via Docker
+    - Default: all-MiniLM-L6-v2 (384 dimensions)
+    - Concurrent requests with configurable limits
+    - Automatic batching for efficiency
+    """
+
+    # Configuration
+    MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+    VECTOR_DIMENSIONS = 384
+    MAX_CONCURRENT_REQUESTS = 10
+    MAX_BATCH_SIZE = 64  # Local service can handle smaller batches faster
+    REQUEST_TIMEOUT = 60.0  # Local inference is fast
+
+    def __new__(cls, vector_size: int = None):
+        """Create fresh instance (override singleton from BaseEmbedder)."""
+        return object.__new__(cls)
+
+    def __init__(self, vector_size: int = None, model_name: str = None):
+        """Initialize local embedder.
+
+        Args:
+            vector_size: Expected vector dimensions (default: 384)
+            model_name: Model name for logging (default: all-MiniLM-L6-v2)
+        """
+        self._inference_url = settings.TEXT2VEC_INFERENCE_URL
+        if not self._inference_url:
+            raise SyncFailureError(
+                "TEXT2VEC_INFERENCE_URL required for local embeddings. "
+                "Start the text2vec-transformers container or set an API key."
+            )
+
+        self.VECTOR_DIMENSIONS = vector_size or 384
+        self.MODEL_NAME = model_name or "sentence-transformers/all-MiniLM-L6-v2"
+
+        # Create async HTTP client
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(self.REQUEST_TIMEOUT),
+            limits=httpx.Limits(max_connections=self.MAX_CONCURRENT_REQUESTS * 2),
+        )
+
+    async def embed_many(
+        self,
+        texts: List[str],
+        context: Union["SyncContext", ContextualLogger, None] = None,
+        dimensions: Optional[int] = None,
+    ) -> List[List[float]]:
+        """Embed batch of texts using local inference service.
+
+        Args:
+            texts: List of text strings to embed
+            context: Sync context or logger for debug output
+            dimensions: Ignored (local model has fixed dimensions)
+
+        Returns:
+            List of embedding vectors
+
+        Raises:
+            SyncFailureError: On any error
+        """
+        # Extract logger
+        if context is None:
+            logger = default_logger
+        elif isinstance(context, ContextualLogger):
+            logger = context
+        else:
+            logger = context.logger
+
+        if not texts:
+            return []
+
+        # Validate no empty texts
+        for i, text in enumerate(texts):
+            if not text or not text.strip():
+                raise SyncFailureError(
+                    f"Empty text at index {i}. "
+                    f"Textual representation must be set before embedding."
+                )
+
+        logger.debug(
+            f"[LocalEmbed] Embedding {len(texts)} texts -> {self.VECTOR_DIMENSIONS}-dim vectors"
+        )
+
+        # Process in batches with concurrency
+        if len(texts) > self.MAX_BATCH_SIZE:
+            return await self._embed_batched(texts, logger)
+
+        # Single batch
+        return await self._embed_batch(texts, logger)
+
+    async def _embed_batched(
+        self, texts: List[str], logger: ContextualLogger
+    ) -> List[List[float]]:
+        """Embed texts in concurrent batches."""
+        batches = [
+            texts[i : i + self.MAX_BATCH_SIZE]
+            for i in range(0, len(texts), self.MAX_BATCH_SIZE)
+        ]
+
+        logger.debug(
+            f"[LocalEmbed] Processing {len(batches)} batches "
+            f"(max {self.MAX_CONCURRENT_REQUESTS} concurrent)"
+        )
+
+        semaphore = asyncio.Semaphore(self.MAX_CONCURRENT_REQUESTS)
+        start_time = time.monotonic()
+
+        async def embed_with_limit(batch_idx: int, batch: List[str]) -> List[List[float]]:
+            async with semaphore:
+                return await self._embed_batch(batch, logger, batch_idx, len(batches))
+
+        results = await asyncio.gather(
+            *[embed_with_limit(i, batch) for i, batch in enumerate(batches)]
+        )
+
+        elapsed = time.monotonic() - start_time
+        logger.debug(f"[LocalEmbed] All {len(batches)} batches completed in {elapsed:.2f}s")
+
+        # Flatten results
+        return [emb for batch_result in results for emb in batch_result]
+
+    async def _embed_batch(
+        self,
+        batch: List[str],
+        logger: ContextualLogger,
+        batch_idx: int = 0,
+        total_batches: int = 1,
+    ) -> List[List[float]]:
+        """Embed a single batch by calling inference service for each text.
+
+        The text2vec-transformers service processes one text at a time,
+        so we parallelize within the batch.
+        """
+        start_time = time.monotonic()
+
+        # Process texts in parallel within batch
+        async def embed_single(text: str) -> List[float]:
+            try:
+                response = await self._client.post(
+                    f"{self._inference_url}/vectors",
+                    json={"text": text},
+                )
+                response.raise_for_status()
+                data = response.json()
+                return data["vector"]
+            except httpx.HTTPStatusError as e:
+                raise SyncFailureError(
+                    f"Local embedding service error: {e.response.status_code} - {e.response.text}"
+                )
+            except httpx.RequestError as e:
+                raise SyncFailureError(
+                    f"Local embedding service unavailable at {self._inference_url}: {e}"
+                )
+            except KeyError:
+                raise SyncFailureError(
+                    "Invalid response from local embedding service: missing 'vector' key"
+                )
+
+        embeddings = await asyncio.gather(*[embed_single(text) for text in batch])
+
+        elapsed = time.monotonic() - start_time
+        if elapsed > 1.0 or total_batches > 1:
+            logger.debug(
+                f"[LocalEmbed] Batch {batch_idx + 1}/{total_batches} "
+                f"({len(batch)} texts) completed in {elapsed:.2f}s"
+            )
+
+        # Validate dimensions
+        for emb in embeddings:
+            if len(emb) != self.VECTOR_DIMENSIONS:
+                raise SyncFailureError(
+                    f"Local model returned {len(emb)}-dim vector, "
+                    f"expected {self.VECTOR_DIMENSIONS}"
+                )
+
+        return list(embeddings)
+
+    async def close(self):
+        """Close the HTTP client."""
+        await self._client.aclose()


### PR DESCRIPTION
## Summary

- Introduces a modular embedding architecture with provider abstraction
- Adds Mistral as a first-class embedding and search provider
- Adds LocalDenseEmbedder for text2vec-transformers (no API keys required)
- Adds startup validation to catch embedding misconfiguration early
- Makes `EMBEDDING_DIMENSIONS` configurable across the stack (backend, Vespa, Qdrant)

## Changes

### Embedders (`backend/airweave/platform/embedders/`)
- **Factory pattern**: `get_dense_embedder()` selects provider based on available API keys
- **Provider priority**: OpenAI > Mistral > Local (when no keys configured)
- **New**: `MistralDenseEmbedder` with batching and concurrency
- **New**: `LocalDenseEmbedder` using text2vec-transformers container
- **New**: `config.py` for provider/model resolution

### Tokenizers (`backend/airweave/platform/tokenizers/`)
- Unified `BaseTokenizer` interface
- `TikTokenTokenizer` (OpenAI) and `MistralTokenizer` implementations
- Factory function `get_tokenizer(model_name)`

### Search Providers (`backend/airweave/search/providers/`)
- **New**: `MistralProvider` with LLM, embedding, and reranking support
- Updated `defaults.yml` with Mistral and local provider configs

### Validation (`backend/airweave/core/embedding_validation.py`)
- Validates `EMBEDDING_DIMENSIONS` against available providers at startup
- Clear error messages for misconfiguration

### Vespa Integration
- `base_entity.sd` now uses `{{EMBEDDING_DIM}}` placeholder
- `vespa/deploy.sh` and `init-vespa.sh` substitute from environment

## Configuration

```bash
# OpenAI (default if key set)
OPENAI_API_KEY=sk-...
EMBEDDING_DIMENSIONS=1536

# Mistral
MISTRAL_API_KEY=...
EMBEDDING_DIMENSIONS=1024

# Local (no API keys needed)
TEXT2VEC_INFERENCE_URL=http://localhost:9878
EMBEDDING_DIMENSIONS=384
```

## Test plan

- [x] Unit tests for embedder config, tokenizers, and Mistral provider
- [x] Embedding alignment test (all providers return correct dimensions)
- [x] Validation tests (startup catches misconfigurations)
- [ ] E2E: Run sync with local embeddings (no API keys)
- [ ] E2E: Run sync with Mistral embeddings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modularized the embedding system and added first-class Mistral and fully local embeddings. EMBEDDING_DIMENSIONS is now configurable end-to-end with startup validation to prevent misconfig.

- New Features
  - Provider factory with priority: OpenAI > Mistral > Local
  - LocalDenseEmbedder via text2vec-transformers (all-MiniLM-L6-v2, 384-dim), batched and concurrent, no API keys
  - MistralDenseEmbedder with batching/concurrency; added MistralProvider for LLM, embeddings, reranking
  - Unified tokenizer interface with OpenAI and Mistral tokenizers
  - Startup validation checks dimension/provider alignment
  - Vespa/Qdrant use EMBEDDING_DIM across configs

- Migration
  - Set EMBEDDING_DIMENSIONS to match provider: OpenAI 1536, Mistral 1024, Local 384
  - For local, run the text2vec container and set TEXT2VEC_INFERENCE_URL (e.g., http://localhost:9878)
  - Re-deploy Vespa to apply the new embedding dimension

<sup>Written for commit bd57c524c3abcb11a5a9ffc3cfa134f3fb83af24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

