### PR TITLE
Tighten validation plan self-service

### DIFF
--- a/backend/airweave/core/config.py
+++ b/backend/airweave/core/config.py
@@ -169,6 +169,7 @@ class Settings(BaseSettings):
     STRIPE_TEAM_YEARLY: str = ""
     STRIPE_ENTERPRISE_MONTHLY: str = ""
     STRIPE_YEARLY_DISCOUNT_COUPON_ID: str = ""
+    STRIPE_TEST_CLOCK: Optional[str] = None  # Only for non-production testing via env var
 
     # Email settings - only for production Airweave instance
     RESEND_API_KEY: Optional[str] = None

--- a/backend/airweave/core/organization_service.py
+++ b/backend/airweave/core/organization_service.py
@@ -95,17 +95,11 @@ class OrganizationService:
             # Step 2: Create Stripe customer if enabled
             if settings.STRIPE_ENABLED:
                 logger.info(f"Creating Stripe customer for: {org_data.name}")
-                # Optional test clock support for local/testing
+                # Test clock support only via environment variable in non-production
+                # SECURITY: Never accept test_clock from user input to prevent billing manipulation
                 test_clock_id = None
-                try:
-                    # Read from org_data.org_metadata.onboarding if present
-                    if hasattr(org_data, "org_metadata") and org_data.org_metadata:
-                        onboarding = org_data.org_metadata.get("onboarding", {})
-                        tc = onboarding.get("stripe_test_clock")
-                        if tc:
-                            test_clock_id = tc
-                except Exception:
-                    test_clock_id = None
+                if settings.ENVIRONMENT != "prd":
+                    test_clock_id = settings.STRIPE_TEST_CLOCK  # From env only, not user input
 
                 stripe_customer = await stripe_client.create_customer(
                     email=owner_user.email,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightened signup and billing validation to block self-serve Enterprise selection and lock Stripe test clock to an env var in non‑prod. Only developer, pro, and team plans are allowed via user input; Enterprise requires sales.

- **Bug Fixes**
  - Reject Enterprise plan from org metadata; log a warning and raise InvalidStateError.
  - Restrict selectable plans to developer/pro/team; create $0 Stripe subscription only for developer.
  - Read Stripe test clock from STRIPE_TEST_CLOCK env var (non‑prod only); never from user input; added config setting.

<sup>Written for commit f9a2da391ef8c047376f34ef8be8943d623f8eef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

