### PR TITLE
feat(docker): use dedicated svix database for webhook delivery

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -21,6 +21,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./init-scripts:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U airweave"]
       interval: 5s
@@ -137,7 +138,7 @@ services:
       SVIX_WHITELIST_SUBNETS: "[127.0.0.1/32, 172.17.0.0/16, 192.168.0.0/16, 10.0.0.0/8]" # Allow local calls to local for development.
       WAIT_FOR: "true" # We want to wait for the default services
       SVIX_REDIS_DSN: "redis://redis:6379"
-      SVIX_DB_DSN: "postgresql://airweave:airweave1234!@postgres:5432/airweave"
+      SVIX_DB_DSN: "postgresql://airweave:airweave1234!@postgres:5432/svix"
       SVIX_JWT_SECRET: 'default_signing_secret'
     ports:
       - "8071:8071"

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -13,6 +13,7 @@ services:
       - "9432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./init-scripts:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U airweave" ]
       interval: 5s
@@ -65,7 +66,7 @@ services:
       SVIX_WHITELIST_SUBNETS: "[127.0.0.1/32, 172.17.0.0/16, 192.168.0.0/16, 10.0.0.0/8]"
       WAIT_FOR: "true"
       SVIX_REDIS_DSN: "redis://redis:6379"
-      SVIX_DB_DSN: "postgresql://airweave:airweave1234!@postgres:5432/airweave"
+      SVIX_DB_DSN: "postgresql://airweave:airweave1234!@postgres:5432/svix"
       SVIX_JWT_SECRET: "test_signing_secret"
     depends_on:
       postgres:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./init-scripts:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-airweave}" ]
       interval: 5s
@@ -280,7 +281,7 @@ services:
       SVIX_WHITELIST_SUBNETS: "[127.0.0.1/32, 172.17.0.0/16, 192.168.0.0/16, 10.0.0.0/8]"
       WAIT_FOR: "true"
       SVIX_REDIS_DSN: "redis://redis:6379"
-      SVIX_DB_DSN: "postgresql://${POSTGRES_USER:-airweave}:${POSTGRES_PASSWORD:-airweave1234!}@postgres:5432/${POSTGRES_DB:-airweave}"
+      SVIX_DB_DSN: "postgresql://${POSTGRES_USER:-airweave}:${POSTGRES_PASSWORD:-airweave1234!}@postgres:5432/svix"
       SVIX_JWT_SECRET: ${SVIX_JWT_SECRET:-default_signing_secret}
     depends_on:
       postgres:

--- a/docker/init-scripts/create-databases.sh
+++ b/docker/init-scripts/create-databases.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Creates the svix database for webhook delivery
+# This script runs automatically when Postgres initializes (first start only)
+
+set -e
+
+echo "Creating svix database..."
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    SELECT 'CREATE DATABASE svix'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'svix')\gexec
+EOSQL
+
+echo "✓ Svix database created successfully!"


### PR DESCRIPTION
## Summary
- Add `init-scripts/create-databases.sh` to create svix database on first Postgres boot
- Update all docker-compose files to mount init scripts and use dedicated `svix` database
- Separates Svix tables from main airweave database for cleaner schema management

## Why
Svix was creating its tables in the shared `airweave` database, mixing third-party schema with our Alembic-managed tables. This separation:
- Prevents potential migration conflicts
- Makes backup/restore simpler
- Cleaner schema organization

## Test plan
- [x] Fresh docker volume wipe + compose up
- [x] Verified `svix` database created with Svix tables
- [x] Verified `airweave` database has no Svix tables
- [x] Svix health check passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a dedicated Postgres database named svix for webhook delivery and update Docker to create and use it. This isolates third‑party tables from airweave to prevent migration conflicts and simplify backups.

- **New Features**
  - Add init-scripts/create-databases.sh to create the svix database on first Postgres start.
  - Mount init scripts in all docker-compose files and set SVIX_DB_DSN to use the svix database.

- **Migration**
  - If your Postgres volume already exists, the init script won’t run; create the svix DB manually or recreate the volume before compose up.

<sup>Written for commit 3fe11315d758b6b39c6c128cbfb58b7bfb416ab6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

