### PR TITLE
feat: enable multi-platform builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
Configures the build process to support building for multiple platforms (linux/amd64, linux/arm64). This allows for broader compatibility and deployment options.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable multi-platform Docker builds (linux/amd64, linux/arm64) for backend and frontend images in CI. This expands support to Apple Silicon and ARM64 servers.

- **New Features**
  - Set up QEMU and Docker Buildx in the workflow.
  - Build and push multi-platform images for backend and frontend.

<sup>Written for commit c8267aaa45e409b8cceba5de047696a8f200b7ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

