### PR TITLE
Fix: Populate textual_representation for federated Slack search

### DIFF
--- a/backend/airweave/platform/sync/pipeline/text_builder.py
+++ b/backend/airweave/platform/sync/pipeline/text_builder.py
@@ -81,21 +81,24 @@ class TextualRepresentationBuilder:
         """
 
         async def build_metadata(entity: BaseEntity):
-            metadata = self._build_metadata_section(entity, source_name)
+            metadata = self.build_metadata_section(entity, source_name)
             if not metadata and not isinstance(entity, CodeFileEntity):
                 raise EntityProcessingError(f"Empty metadata for {entity.entity_id}")
             entity.textual_representation = metadata
 
         await asyncio.gather(*[build_metadata(e) for e in entities])
 
-    def _build_metadata_section(self, entity: BaseEntity, source_name: str) -> str:
+    def build_metadata_section(self, entity: BaseEntity, source_name: str) -> str:
         """Build metadata section for any entity type.
+
+        This method is public to allow federated search sources to build
+        textual representations without going through the full sync pipeline.
 
         For CodeFileEntity, returns empty string - code is self-documenting.
 
         Args:
             entity: Entity to build metadata for
-            source_name: Name of the source
+            source_name: Name of the source (e.g., "slack", "github")
 
         Returns:
             Markdown formatted metadata section


### PR DESCRIPTION
Federated search bypasses the normal sync pipeline, so entities were missing textual_representation and system_metadata fields. This caused issues with reranking and answer generation.

Changes:
- Make text_builder.build_metadata_section() public for reuse
- SlackSource now builds textual_representation using shared utility
- SlackSource now populates airweave_system_metadata for federated entities

The shared utility automatically extracts embeddable fields via AirweaveField flags, ensuring consistency with sync pipeline output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate textual_representation and system metadata for federated Slack search entities to restore proper reranking and answer generation, aligning federated output with the sync pipeline.

- **Bug Fixes**
  - SlackSource builds textual_representation using the shared text_builder and sets AirweaveSystemMetadata for federated entities.
  - text_builder exposes build_metadata_section() for reuse by federated sources, ensuring consistent embeddable field extraction.

<sup>Written for commit b8eec6076bea452f2772868ad4ff58f3211bb362. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

