### PR TITLE
fix: increase Vespa query timeout and enable soft timeout

### DIFF
--- a/backend/airweave/platform/destinations/vespa/query_builder.py
+++ b/backend/airweave/platform/destinations/vespa/query_builder.py
@@ -156,7 +156,11 @@ class QueryBuilder:
             "hits": limit,
             "offset": offset,
             "presentation.summary": "full",
-            "ranking.softtimeout.enable": "false",
+            # Timeout: increase from default 500ms to prevent soft doom during setup
+            # Soft timeout: enable graceful degradation with partial results
+            # See: https://docs.vespa.ai/en/performance/graceful-degradation.html
+            "timeout": "10s",
+            "ranking.softtimeout.enable": "true",
             # Rerank count must be >= offset + limit to ensure correct pagination
             "ranking.globalPhase.rerankCount": global_phase_rerank,
         }


### PR DESCRIPTION
## Summary

- Increase Vespa query timeout from default 500ms to 10s to prevent soft doomed errors
- Enable soft timeout for graceful degradation (returns partial results instead of failing)

## Problem

Complex hybrid queries with multiple nearestNeighbor operators across 5 schemas were hitting Vespa default 500ms timeout during query setup/parsing phase, causing search failures.

## Solution

- Set explicit timeout: 10s query parameter
- Enable ranking.softtimeout.enable: true for graceful degradation

## Reference

https://docs.vespa.ai/en/performance/graceful-degradation.html

## Test plan

- [ ] Verify complex hybrid queries no longer fail with soft doomed errors
- [ ] Verify partial results are returned when queries approach timeout limits

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased Vespa query timeout to 10s and enabled soft timeout to prevent setup-time “soft doomed” failures on complex hybrid searches and return partial results when near limits.

- **Bug Fixes**
  - Set query param timeout=10s to avoid default 500ms timeouts during parsing.
  - Enabled ranking.softtimeout.enable=true for graceful degradation.

<sup>Written for commit 0933ca647c688db963a8434cff23e673666a9d00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

