### PR TITLE
feat: add MCP image to GHCR build workflow and matrix-parallelize

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,15 +3,27 @@ name: Build Application and Push Docker Image
 on:
   push:
     tags: ["v*"]
+
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME_BACKEND: ${{ github.repository }}-backend
-  IMAGE_NAME_FRONTEND: ${{ github.repository }}-frontend
-  IMAGE_NAME_MCP: ${{ github.repository }}-mcp
 
 jobs:
-  build-and-push-image:
+  build-and-push:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Backend image is also used for temporal-worker (same code, different entrypoint)
+          - name: backend
+            context: ./backend
+            image: ${{ github.repository }}-backend
+          - name: frontend
+            context: ./frontend
+            image: ${{ github.repository }}-frontend
+          - name: mcp
+            context: ./mcp
+            image: ${{ github.repository }}-mcp
 
     permissions:
       contents: read
@@ -37,50 +49,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
-        id: meta-backend
+        id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_BACKEND }}
+          images: ${{ env.REGISTRY }}/${{ matrix.image }}
 
-      # Backend image is also used for temporal-worker (same code, different entrypoint)
-      - name: Build and push backend image
-        id: push-backend
+      - name: Build and push ${{ matrix.name }} image
         uses: docker/build-push-action@v6
         with:
-          context: ./backend
+          context: ${{ matrix.context }}
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta-backend.outputs.tags }}
-          labels: ${{ steps.meta-backend.outputs.labels }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta-frontend
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_FRONTEND }}
-
-      - name: Build and push frontend image
-        id: push-frontend
-        uses: docker/build-push-action@v6
-        with:
-          context: ./frontend
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta-frontend.outputs.tags }}
-          labels: ${{ steps.meta-frontend.outputs.labels }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta-mcp
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MCP }}
-
-      - name: Build and push MCP server image
-        id: push-mcp
-        uses: docker/build-push-action@v6
-        with:
-          context: ./mcp
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta-mcp.outputs.tags }}
-          labels: ${{ steps.meta-mcp.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add MCP server image to the release build process (builds on tag push v*)
- Backend image is also used for temporal-worker (same code, different entrypoint)
- Images published to GHCR: `backend`, `frontend`, `mcp`

## Why
This enables infra-core to pull pre-built images from GHCR instead of rebuilding from source during deployments, reducing deployment time and ensuring consistency.

## Test plan
- [ ] Create a test tag to verify all 3 images are built and pushed to GHCR
- [ ] Verify images are accessible at ghcr.io/airweave-ai/airweave-{backend,frontend,mcp}

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the MCP server image to the GHCR release workflow. Tag pushes (v*) now build and publish backend, frontend, and MCP images for linux/amd64 and linux/arm64 in parallel, so infra can pull prebuilt images to speed deployments and ensure consistency.

<sup>Written for commit 471a1ae2497b01f7ea6f4e13aeb00e3fd466b283. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

