### PR TITLE
fix: set fail-fast: true to prevent partial releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
-          # Backend image is also used for temporal-worker (same code, different entrypoint)
+          # Backend image is also used for sync-worker (same code, different entrypoint)
           - name: backend
             context: ./backend
             image: ${{ github.repository }}-backend


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set fail-fast: true in the build-and-push workflow so a matrix failure cancels the remaining jobs, preventing partial image releases to GHCR. Updated the backend image comment to note it’s also used for the sync-worker.

<sup>Written for commit dc1ac921cd6b8aa2291c0c1b6ea0a5fe8f7d28e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

