### PR TITLE
fix: use buildx imagetools for multi-arch manifest creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,9 @@ jobs:
       packages: write
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -103,18 +106,14 @@ jobs:
 
           echo "Creating manifest for ${IMAGE}:${VERSION}"
 
-          # Create manifest from platform-specific images
-          docker manifest create "${IMAGE}:${VERSION}" \
+          # Use buildx imagetools to create multi-arch manifest from platform images
+          docker buildx imagetools create -t "${IMAGE}:${VERSION}" \
             "${IMAGE}:${VERSION}-amd64" \
             "${IMAGE}:${VERSION}-arm64"
 
-          # Push the manifest
-          docker manifest push "${IMAGE}:${VERSION}"
-
-          # Also create 'latest' manifest for version tags
+          # Also create 'latest' tag for version tags
           if [[ "${VERSION}" == v* ]]; then
-            docker manifest create "${IMAGE}:latest" \
+            docker buildx imagetools create -t "${IMAGE}:latest" \
               "${IMAGE}:${VERSION}-amd64" \
               "${IMAGE}:${VERSION}-arm64"
-            docker manifest push "${IMAGE}:latest"
           fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the publish workflow to Docker Buildx imagetools to create and push multi-arch manifests to GHCR. Adds Buildx setup, replaces manual docker manifest create/push, and tags :latest when VERSION starts with v.

<sup>Written for commit 5912bdf063943726569318a79418066bc51d2e9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

