### PR TITLE
fix: disable provenance to create simple images for manifest merging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,8 @@ jobs:
           platforms: ${{ matrix.platform.arch }}
           tags: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.component.name }}:${{ steps.meta.outputs.version }}-${{ matrix.platform.suffix }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Disable provenance to create simple images instead of manifest lists with attestations
+          provenance: false
           cache-from: type=gha,scope=${{ matrix.component.name }}-${{ matrix.platform.suffix }}
           cache-to: type=gha,mode=max,scope=${{ matrix.component.name }}-${{ matrix.platform.suffix }}
 


### PR DESCRIPTION
## Summary
- Disables provenance attestations in Docker buildx to create simple single-platform images
- This fixes the manifest merge step which was failing because buildx was creating manifest lists instead of simple images

## Context
Docker buildx v0.10+ adds provenance attestations by default, wrapping each image in a manifest list. When the merge step tries to combine two manifest lists, it fails with "is a manifest list" error.

Setting `provenance: false` creates simple images that can be properly merged into a multi-arch manifest.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled Docker Buildx provenance so single-platform builds produce simple images instead of manifest lists. This fixes the multi-arch manifest merge step and avoids the "is a manifest list" error.

<sup>Written for commit 9a6966e542dda4aa2447b2a7e61d4a770a48a11a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

