### PR TITLE
fix: wrap Tiktoken encoding for special tokens

### DIFF
--- a/backend/airweave/platform/chunkers/_base.py
+++ b/backend/airweave/platform/chunkers/_base.py
@@ -1,49 +1,9 @@
 """Base chunker interface for all chunker implementations."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List
 
-__all__ = ["BaseChunker", "SafeTiktokenEncoding"]
-
-
-class SafeTiktokenEncoding:
-    """Wrapper that forces allowed_special='all' on tiktoken encoding.
-
-    This is needed because Chonkie calls the encoding's encode() method directly,
-    bypassing our TikTokenTokenizer wrapper. Without this, special tokens like
-    <|endoftext|> in code comments/strings cause encoding failures.
-
-    Example special tokens that may appear in user content:
-    - <|endoftext|> (AI-generated text pasted into docs/Linear)
-    - <|fim_prefix|>, <|fim_suffix|>, <|fim_middle|> (Codex FIM tokens)
-    """
-
-    def __init__(self, encoding):
-        self._encoding = encoding
-        # Copy attributes that Chonkie's AutoTokenizer checks for backend detection
-        self.name = getattr(encoding, "name", "cl100k_base")
-
-    def encode(self, text: str, **kwargs) -> List[int]:
-        """Encode text, allowing all special tokens."""
-        kwargs.setdefault("allowed_special", "all")
-        return self._encoding.encode(text, **kwargs)
-
-    def decode(self, tokens: Sequence[int]) -> str:
-        """Decode tokens back to text."""
-        return self._encoding.decode(list(tokens))
-
-    def encode_batch(self, texts: List[str], **kwargs) -> List[List[int]]:
-        """Encode multiple texts."""
-        kwargs.setdefault("allowed_special", "all")
-        return [self._encoding.encode(text, **kwargs) for text in texts]
-
-    def decode_batch(self, token_lists: List[List[int]]) -> List[str]:
-        """Decode multiple token sequences."""
-        return [self._encoding.decode(tokens) for tokens in token_lists]
-
-    # Delegate attribute access to underlying encoding for Chonkie compatibility
-    def __getattr__(self, name):
-        return getattr(self._encoding, name)
+__all__ = ["BaseChunker"]
 
 
 class BaseChunker(ABC):

--- a/backend/airweave/platform/chunkers/code.py
+++ b/backend/airweave/platform/chunkers/code.py
@@ -3,7 +3,8 @@
 from typing import Any, Dict, List, Optional
 
 from airweave.core.logging import logger
-from airweave.platform.chunkers._base import BaseChunker, SafeTiktokenEncoding
+from airweave.platform.chunkers._base import BaseChunker
+from airweave.platform.chunkers.tiktoken_compat import SafeEncoding
 from airweave.platform.sync.async_helpers import run_in_thread_pool
 from airweave.platform.sync.exceptions import SyncFailureError
 from airweave.platform.tokenizers import TikTokenTokenizer, get_tokenizer
@@ -80,7 +81,7 @@ class CodeChunker(BaseChunker):
             # Wrap the raw encoding to allow special tokens like <|endoftext|>
             # that may appear in code comments/strings. Without this wrapper,
             # Chonkie calls encode() directly without allowed_special='all'.
-            safe_encoding = SafeTiktokenEncoding(tokenizer.encoding)
+            safe_encoding = SafeEncoding(tokenizer.encoding)
 
             # Initialize Chonkie's CodeChunker with auto language detection
             self._code_chunker = ChonkieCodeChunker(

--- a/backend/airweave/platform/chunkers/semantic.py
+++ b/backend/airweave/platform/chunkers/semantic.py
@@ -3,7 +3,8 @@
 from typing import Any, Dict, List, Optional
 
 from airweave.core.logging import logger
-from airweave.platform.chunkers._base import BaseChunker, SafeTiktokenEncoding
+from airweave.platform.chunkers._base import BaseChunker
+from airweave.platform.chunkers.tiktoken_compat import SafeEncoding
 from airweave.platform.sync.async_helpers import run_in_thread_pool
 from airweave.platform.sync.exceptions import SyncFailureError
 from airweave.platform.tokenizers import TikTokenTokenizer, get_tokenizer
@@ -112,7 +113,7 @@ class SemanticChunker(BaseChunker):
 
             # Wrap the raw encoding to allow special tokens like <|endoftext|>
             # that may appear in user content (e.g., AI-generated text pasted into Linear)
-            safe_encoding = SafeTiktokenEncoding(tokenizer.encoding)
+            safe_encoding = SafeEncoding(tokenizer.encoding)
 
             # Initialize Chonkie's SemanticChunker
             # NOTE: Uses local embedding model for chunking decisions (fast, no API calls)

--- a/backend/airweave/platform/chunkers/tiktoken_compat.py
+++ b/backend/airweave/platform/chunkers/tiktoken_compat.py
@@ -1,0 +1,64 @@
+"""Tiktoken compatibility wrapper for Chonkie.
+
+This module provides a wrapper around tiktoken encodings that allows special tokens
+(like <|endoftext|>) to be encoded without errors.
+
+IMPORTANT: This file MUST be named with "tiktoken" in the path because Chonkie's
+AutoTokenizer._get_backend() detects the tokenizer backend by checking:
+
+    if "tiktoken" in str(type(tokenizer)):
+        return "tiktoken"
+
+By placing our wrapper in a module named tiktoken_compat.py, the type string becomes:
+    <class 'airweave.platform.chunkers.tiktoken_compat.SafeEncoding'>
+
+which contains "tiktoken" and passes Chonkie's backend detection.
+"""
+
+from typing import List, Sequence
+
+
+class SafeEncoding:
+    """Wrapper that forces allowed_special='all' on tiktoken encoding.
+
+    This wrapper is needed because Chonkie calls the encoding's encode() method
+    directly, bypassing our TikTokenTokenizer wrapper. Without this, special
+    tokens like <|endoftext|> in code comments/strings cause encoding failures.
+
+    Example special tokens that may appear in user content:
+    - <|endoftext|> (AI-generated text pasted into docs/Linear)
+    - <|fim_prefix|>, <|fim_suffix|>, <|fim_middle|> (Codex FIM tokens)
+    """
+
+    def __init__(self, encoding):
+        """Initialize the wrapper with a tiktoken encoding.
+
+        Args:
+            encoding: A tiktoken.Encoding instance
+        """
+        self._encoding = encoding
+        # Copy attributes that Chonkie might check
+        self.name = getattr(encoding, "name", "cl100k_base")
+
+    def encode(self, text: str, **kwargs) -> List[int]:
+        """Encode text, allowing all special tokens."""
+        kwargs.setdefault("allowed_special", "all")
+        return self._encoding.encode(text, **kwargs)
+
+    def decode(self, tokens: Sequence[int]) -> str:
+        """Decode tokens back to text."""
+        return self._encoding.decode(list(tokens))
+
+    def encode_batch(self, texts: List[str], **kwargs) -> List[List[int]]:
+        """Encode multiple texts."""
+        kwargs.setdefault("allowed_special", "all")
+        return [self._encoding.encode(text, **kwargs) for text in texts]
+
+    def decode_batch(self, token_lists: List[List[int]]) -> List[str]:
+        """Decode multiple token sequences."""
+        return [self._encoding.decode(tokens) for tokens in token_lists]
+
+    # Delegate attribute access to underlying encoding for compatibility
+    def __getattr__(self, name):
+        """Delegate attribute access to underlying encoding."""
+        return getattr(self._encoding, name)

--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -656,6 +656,24 @@ class StubConfig(SourceConfig):
         le=100,
     )
 
+    inject_special_tokens: bool = Field(
+        default=False,
+        title="Inject Special Tokens",
+        description=(
+            "If true, injects special tokenizer tokens (like <|endoftext|>) into generated "
+            "content. Used for testing chunker/embedder handling of edge cases."
+        ),
+    )
+
+    custom_content_prefix: Optional[str] = Field(
+        default=None,
+        title="Custom Content Prefix",
+        description=(
+            "Optional string to prepend to all generated content. Useful for testing "
+            "specific strings like special tokens or edge case characters."
+        ),
+    )
+
     @field_validator(
         "small_entity_weight",
         "medium_entity_weight",

--- a/backend/tests/e2e/smoke/test_special_tokens.py
+++ b/backend/tests/e2e/smoke/test_special_tokens.py
@@ -1,0 +1,322 @@
+"""
+E2E smoke tests for special token handling in the sync pipeline.
+
+Tests that the chunker/embedder correctly handles special tokenizer tokens
+like <|endoftext|> that may appear in user content (e.g., AI-generated text
+pasted into documents).
+
+This validates the TiktokenSafeEncoding wrapper in the chunker pipeline.
+"""
+
+import asyncio
+import time
+import pytest
+import pytest_asyncio
+import httpx
+from typing import AsyncGenerator, Dict, Optional
+
+
+@pytest_asyncio.fixture(scope="function")
+async def special_token_client() -> AsyncGenerator[httpx.AsyncClient, None]:
+    """Create HTTP client for special token tests."""
+    from config import settings
+
+    async with httpx.AsyncClient(
+        base_url=settings.api_url,
+        headers=settings.api_headers,
+        timeout=httpx.Timeout(120),  # Longer timeout for sync operations
+        follow_redirects=True,
+    ) as client:
+        yield client
+
+
+async def wait_for_sync_completion(
+    client: httpx.AsyncClient,
+    connection_id: str,
+    max_wait_time: int = 180,
+    poll_interval: int = 3,
+) -> Dict:
+    """Wait for a source connection sync to complete and return final status.
+
+    Args:
+        client: HTTP client
+        connection_id: Source connection ID to monitor
+        max_wait_time: Maximum seconds to wait
+        poll_interval: Seconds between status checks
+
+    Returns:
+        Final connection status dict
+
+    Raises:
+        TimeoutError: If sync doesn't complete within max_wait_time
+    """
+    elapsed = 0
+    while elapsed < max_wait_time:
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+
+        response = await client.get(f"/source-connections/{connection_id}")
+        if response.status_code != 200:
+            continue
+
+        conn = response.json()
+        status = conn.get("status")
+
+        if status == "active":
+            return conn
+        elif status == "error":
+            return conn
+
+    raise TimeoutError(f"Sync did not complete within {max_wait_time}s")
+
+
+@pytest.mark.asyncio
+async def test_sync_with_special_tokens_inject_flag(
+    special_token_client: httpx.AsyncClient,
+):
+    """Test that sync succeeds when stub source injects special tokens.
+
+    This tests the TiktokenSafeEncoding wrapper by:
+    1. Creating a collection
+    2. Creating a stub source connection with inject_special_tokens=True
+    3. Running a sync (which will inject <|endoftext|> etc. into content)
+    4. Verifying the sync completes successfully (not fails with tokenizer error)
+    5. Verifying entities are searchable
+    """
+    client = special_token_client
+    collection_readable_id: Optional[str] = None
+    connection_id: Optional[str] = None
+
+    try:
+        # Step 1: Create collection
+        collection_response = await client.post(
+            "/collections/",
+            json={"name": f"Special Token Test {int(time.time())}"},
+        )
+        assert collection_response.status_code == 200, (
+            f"Failed to create collection: {collection_response.text}"
+        )
+        collection = collection_response.json()
+        collection_readable_id = collection["readable_id"]
+
+        # Step 2: Create stub source with special token injection enabled
+        connection_data = {
+            "name": f"Special Token Stub {int(time.time())}",
+            "short_name": "stub",
+            "readable_collection_id": collection_readable_id,
+            "authentication": {"credentials": {"stub_key": "test"}},
+            "config": {
+                "seed": 12345,  # Deterministic seed
+                "entity_count": 5,  # Small count for fast test
+                "generation_delay_ms": 0,
+                # Enable special token injection - this is what we're testing!
+                "inject_special_tokens": True,
+                # Mix of entity types to test both semantic and code chunkers
+                "small_entity_weight": 30,
+                "medium_entity_weight": 30,
+                "large_entity_weight": 20,
+                "small_file_weight": 0,
+                "large_file_weight": 10,
+                "code_file_weight": 10,
+            },
+            "sync_immediately": True,
+        }
+
+        connection_response = await client.post(
+            "/source-connections",
+            json=connection_data,
+        )
+        assert connection_response.status_code == 200, (
+            f"Failed to create source connection: {connection_response.text}"
+        )
+        connection = connection_response.json()
+        connection_id = connection["id"]
+
+        # Step 3: Wait for sync to complete
+        print("\n" + "=" * 60)
+        print("TEST: test_sync_with_special_tokens_inject_flag")
+        print("=" * 60)
+        print("Waiting for sync with inject_special_tokens=True...")
+
+        try:
+            final_status = await wait_for_sync_completion(
+                client,
+                connection_id,
+                max_wait_time=180,
+            )
+        except TimeoutError as e:
+            pytest.fail(f"Sync timed out: {e}")
+
+        # Step 4: Verify sync succeeded (this is the main assertion!)
+        status = final_status.get("status")
+        print(f"Sync completed with status: {status}")
+
+        if status == "error":
+            # Get the sync job for more details
+            jobs_response = await client.get(
+                f"/source-connections/{connection_id}/sync-jobs?limit=1"
+            )
+            if jobs_response.status_code == 200:
+                jobs = jobs_response.json()
+                if jobs:
+                    error_msg = jobs[0].get("error_message", "Unknown error")
+                    print(f"Sync error: {error_msg}")
+
+                    # This is what we're testing - the sync should NOT fail
+                    # with tokenizer errors like "disallowed special token"
+                    assert "disallowed special token" not in error_msg.lower(), (
+                        f"Sync failed due to special token handling: {error_msg}"
+                    )
+                    assert "endoftext" not in error_msg.lower(), (
+                        f"Sync failed due to <|endoftext|> token: {error_msg}"
+                    )
+
+            pytest.fail(f"Sync failed: {final_status}")
+
+        assert status == "active", f"Expected active status, got: {status}"
+
+        # Step 5: Verify entities are searchable (optional but good to confirm)
+        # Give Vespa/Qdrant a moment to index
+        await asyncio.sleep(3)
+
+        search_response = await client.post(
+            f"/collections/{collection_readable_id}/search",
+            json={
+                "query": "test content",
+                "limit": 10,
+                "expand_query": False,
+                "interpret_filters": False,
+                "rerank": False,
+                "generate_answer": False,
+            },
+            timeout=60,
+        )
+
+        assert search_response.status_code == 200, (
+            f"Search failed: {search_response.text}"
+        )
+
+        results = search_response.json()
+        result_count = len(results.get("results", []))
+        print(f"Search returned {result_count} results")
+
+        # We should have some indexed content
+        assert result_count > 0, (
+            "Expected search results after sync with special tokens"
+        )
+
+        print("=" * 60)
+        print("SUCCESS: Sync with special tokens completed successfully!")
+        print("=" * 60 + "\n")
+
+    finally:
+        # Cleanup
+        if connection_id:
+            try:
+                await client.delete(f"/source-connections/{connection_id}")
+            except Exception:
+                pass
+
+        if collection_readable_id:
+            try:
+                await client.delete(f"/collections/{collection_readable_id}")
+            except Exception:
+                pass
+
+
+@pytest.mark.asyncio
+async def test_sync_with_custom_content_prefix_special_token(
+    special_token_client: httpx.AsyncClient,
+):
+    """Test sync with a custom content prefix containing special tokens.
+
+    This tests explicit special token injection via custom_content_prefix,
+    which gives more control over exactly what token is tested.
+    """
+    client = special_token_client
+    collection_readable_id: Optional[str] = None
+    connection_id: Optional[str] = None
+
+    try:
+        # Create collection
+        collection_response = await client.post(
+            "/collections/",
+            json={"name": f"Custom Prefix Token Test {int(time.time())}"},
+        )
+        assert collection_response.status_code == 200
+        collection = collection_response.json()
+        collection_readable_id = collection["readable_id"]
+
+        # Create stub source with explicit <|endoftext|> in custom prefix
+        connection_data = {
+            "name": f"Custom Prefix Stub {int(time.time())}",
+            "short_name": "stub",
+            "readable_collection_id": collection_readable_id,
+            "authentication": {"credentials": {"stub_key": "test"}},
+            "config": {
+                "seed": 99999,
+                "entity_count": 3,  # Minimal for fast test
+                "generation_delay_ms": 0,
+                # Explicit special token in prefix - very direct test
+                "custom_content_prefix": (
+                    "This content contains a special token: <|endoftext|>\n"
+                    "And another: <|fim_prefix|> code here <|fim_suffix|>"
+                ),
+                # Simple entities only (faster)
+                "small_entity_weight": 50,
+                "medium_entity_weight": 50,
+                "large_entity_weight": 0,
+                "small_file_weight": 0,
+                "large_file_weight": 0,
+                "code_file_weight": 0,
+            },
+            "sync_immediately": True,
+        }
+
+        connection_response = await client.post(
+            "/source-connections",
+            json=connection_data,
+        )
+        assert connection_response.status_code == 200
+        connection = connection_response.json()
+        connection_id = connection["id"]
+
+        print("\n" + "=" * 60)
+        print("TEST: test_sync_with_custom_content_prefix_special_token")
+        print("=" * 60)
+        print("Syncing with explicit <|endoftext|> in content prefix...")
+
+        # Wait for sync
+        try:
+            final_status = await wait_for_sync_completion(
+                client,
+                connection_id,
+                max_wait_time=120,
+            )
+        except TimeoutError as e:
+            pytest.fail(f"Sync timed out: {e}")
+
+        status = final_status.get("status")
+        print(f"Sync completed with status: {status}")
+
+        # Main assertion: sync should succeed, not fail on special tokens
+        assert status == "active", (
+            f"Sync failed - likely due to special token handling. Status: {status}"
+        )
+
+        print("=" * 60)
+        print("SUCCESS: Custom prefix with special tokens handled correctly!")
+        print("=" * 60 + "\n")
+
+    finally:
+        if connection_id:
+            try:
+                await client.delete(f"/source-connections/{connection_id}")
+            except Exception:
+                pass
+
+        if collection_readable_id:
+            try:
+                await client.delete(f"/collections/{collection_readable_id}")
+            except Exception:
+                pass


### PR DESCRIPTION
Ensures Chonkie chunkers handle special tokens (e.g., <|endoftext|>) correctly by wrapping the raw Tiktoken encoding.

This prevents encoding failures when special tokens are present in user content, such as AI-generated text or code comments.

Updates CodeChunker and SemanticChunker to use the safe encoding wrapper.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap Tiktoken encoding with a SafeEncoding to allow special tokens and prevent Chonkie chunker failures on content like <|endoftext|>. Updates CodeChunker and SemanticChunker to use the safe encoding for both main and fallback chunkers.

- **Bug Fixes**
  - Added SafeEncoding that forces allowed_special='all' and preserves encoding name/behavior for Chonkie compatibility.
  - Switched CodeChunker and SemanticChunker to pass the safe encoding to Chonkie chunkers and TokenChunker, avoiding encode errors on special tokens (e.g., <|endoftext|>, FIM tokens).

<sup>Written for commit f40cee0f7d5536cfb9ef28eabc95d7a173502e87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

