### PR TITLE
Fix MCP StreamableHTTP stateless session handling

### DIFF
--- a/mcp/src/session/redis-session-manager.ts
+++ b/mcp/src/session/redis-session-manager.ts
@@ -26,6 +26,7 @@ export interface SessionData {
     baseUrl: string;
     createdAt: number;
     lastAccessedAt: number;
+    initialized: boolean;  // Track if MCP initialize was called
     // Security: Client binding to prevent session hijacking
     clientIP?: string;
     userAgent?: string;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes stateless MCP StreamableHTTP sessions so each POST can recreate the transport without breaking initialization. Disables transport session validation and persists an initialized flag to restore state across requests.

- **Bug Fixes**
  - Disabled session validation by setting sessionIdGenerator to undefined for stateless operation.
  - Added initialized: boolean to SessionData; set false on create, set true after successful initialize, and persist.
  - On restore, mark transport as initialized (sets internal flag) to avoid re-initialization.

<sup>Written for commit 0ecd8ae50e75b5c0a717db562f681fea078f3186. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

