### PR TITLE
fix: add PATCH endpoint for collections

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -158,6 +158,7 @@ navigation:
     - GET /collections/{readable_id}/search
     - POST /collections/{readable_id}/search
     - POST /collections
+    - PATCH /collections/{readable_id}
     - POST /collections/{readable_id}/refresh_all
     - DELETE /collections/{readable_id}
   - section: Source Connections


### PR DESCRIPTION
Adds the PATCH endpoint to the documentation, allowing users to update existing collections. This ensures the API reference accurately reflects the available functionality for collections.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add PATCH /collections/{readable_id} to the Collections API docs so users can see how to update existing collections. This keeps the API reference complete and visible in the docs navigation.

<sup>Written for commit df8d24a581e0a22e1791931557009090855020a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

