### PR TITLE
refactor(webhooks): rename events to webhooks

### DIFF
--- a/backend/airweave/api/v1/api.py
+++ b/backend/airweave/api/v1/api.py
@@ -13,7 +13,6 @@ from airweave.api.v1.endpoints import (
     embedding_models,
     entities,
     entity_counts,
-    events,
     file_retrieval,
     health,
     organizations,
@@ -26,6 +25,7 @@ from airweave.api.v1.endpoints import (
     transformers,
     usage,
     users,
+    webhooks,
 )
 from airweave.core.config import settings
 
@@ -59,7 +59,7 @@ api_router.include_router(transformers.router, prefix="/transformers", tags=["tr
 api_router.include_router(file_retrieval.router, prefix="/files", tags=["files"])
 api_router.include_router(s3.router, prefix="/s3", tags=["s3"])
 api_router.include_router(admin.router, prefix="/admin", tags=["admin"])
-api_router.include_router(events.router, prefix="/events", tags=["events"])
+api_router.include_router(webhooks.router, prefix="/webhooks", tags=["webhooks"])
 
 # Only include cursor development endpoints if LOCAL_CURSOR_DEVELOPMENT is enabled
 if settings.LOCAL_CURSOR_DEVELOPMENT:

--- a/backend/airweave/schemas/__init__.py
+++ b/backend/airweave/schemas/__init__.py
@@ -57,17 +57,6 @@ from .errors import (
     ValidationErrorDetail,
     ValidationErrorResponse,
 )
-from .events import (
-    # Request schemas
-    CreateSubscriptionRequest,
-    # Response schemas
-    DeliveryAttempt,
-    EventMessage,
-    PatchSubscriptionRequest,
-    RecoverMessagesRequest,
-    RecoveryTask,
-    WebhookSubscription,
-)
 from .integration_credential import (
     IntegrationCredential,
     IntegrationCredentialCreate,
@@ -183,6 +172,17 @@ from .user import (
     UserOrganization,
     UserUpdate,
     UserWithOrganizations,
+)
+from .webhooks import (
+    # Request schemas
+    CreateSubscriptionRequest,
+    # Response schemas
+    DeliveryAttempt,
+    PatchSubscriptionRequest,
+    RecoverMessagesRequest,
+    RecoveryTask,
+    WebhookMessage,
+    WebhookSubscription,
 )
 
 # Rebuild models to resolve forward references

--- a/backend/airweave/schemas/webhooks.py
+++ b/backend/airweave/schemas/webhooks.py
@@ -1,7 +1,7 @@
-"""Event and webhook subscription schemas.
+"""Webhook subscription and message schemas.
 
-This module defines Pydantic schemas for the Events API, which handles webhook
-subscriptions and event message management. Webhooks allow you to receive
+This module defines Pydantic schemas for the Webhooks API, which handles webhook
+subscriptions and message management. Webhooks allow you to receive
 real-time notifications when events occur in Airweave.
 
 All response models use snake_case field names for consistency with the webhook
@@ -39,8 +39,8 @@ __all__ = [
 # payloads delivered to user endpoints. They wrap Svix library types.
 
 
-class EventMessage(BaseModel):
-    """An event message that was sent (or attempted) to webhook subscribers.
+class WebhookMessage(BaseModel):
+    """A webhook message that was sent (or attempted) to webhook subscribers.
 
     The payload contains the actual event data matching the webhook delivery format.
     """
@@ -79,8 +79,8 @@ class EventMessage(BaseModel):
     def from_svix(
         cls,
         msg: MessageOut,
-    ) -> "EventMessage":
-        """Convert a Svix MessageOut to our EventMessage.
+    ) -> "WebhookMessage":
+        """Convert a Svix MessageOut to our WebhookMessage.
 
         Uses event_id (our UUID) as the primary id field.
         """
@@ -119,8 +119,8 @@ class EventMessage(BaseModel):
     }
 
 
-class EventMessageWithAttempts(EventMessage):
-    """An event message with delivery attempts."""
+class WebhookMessageWithAttempts(WebhookMessage):
+    """A webhook message with delivery attempts."""
 
     delivery_attempts: Optional[List["DeliveryAttempt"]] = Field(
         default=None,
@@ -130,8 +130,8 @@ class EventMessageWithAttempts(EventMessage):
     @classmethod
     def from_svix(
         cls, msg: MessageOut, attempts: Optional[List["DeliveryAttempt"]] = None
-    ) -> "EventMessageWithAttempts":
-        """Convert a Svix MessageOut to an EventMessageWithAttempts."""
+    ) -> "WebhookMessageWithAttempts":
+        """Convert a Svix MessageOut to a WebhookMessageWithAttempts."""
         return cls(
             id=msg.id,
             event_type=msg.event_type,

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -29,14 +29,14 @@ navigation:
     path: docs/pages/search.mdx
   - page: MCP Server
     path: docs/pages/mcp-server.mdx
-  - section: Events
+  - section: Webhooks
     contents:
     - page: Overview
-      path: docs/pages/events/overview.mdx
+      path: docs/pages/webhooks/overview.mdx
     - page: Types & Formats
-      path: docs/pages/events/types-and-formats.mdx
+      path: docs/pages/webhooks/types-and-formats.mdx
     - page: Setup Guide
-      path: docs/pages/events/setup.mdx
+      path: docs/pages/webhooks/setup.mdx
   - page: Add New Connector
     path: docs/pages/add-new-source.mdx
   - page: Rate Limits
@@ -175,16 +175,16 @@ navigation:
     contents:
     - GET /sources
     - GET /sources/{short_name}
-  - section: Events
+  - section: Webhooks
     contents:
-    - GET /events/messages
-    - GET /events/messages/{message_id}
-    - GET /events/subscriptions
-    - GET /events/subscriptions/{subscription_id}
-    - POST /events/subscriptions
-    - PATCH /events/subscriptions/{subscription_id}
-    - POST /events/subscriptions/{subscription_id}/recover
-    - DELETE /events/subscriptions/{subscription_id}
+    - GET /webhooks/messages
+    - GET /webhooks/messages/{message_id}
+    - GET /webhooks/subscriptions
+    - GET /webhooks/subscriptions/{subscription_id}
+    - POST /webhooks/subscriptions
+    - PATCH /webhooks/subscriptions/{subscription_id}
+    - POST /webhooks/subscriptions/{subscription_id}/recover
+    - DELETE /webhooks/subscriptions/{subscription_id}
   snippets:
     python: airweave-sdk
     typescript: '@airweave/sdk'

--- a/fern/docs/pages/webhooks/overview.mdx
+++ b/fern/docs/pages/webhooks/overview.mdx
@@ -1,19 +1,19 @@
 ---
-title: Events Overview
+title: Webhooks Overview
 description: Real-time notifications for sync lifecycle events via webhooks
-edit-this-page-url: https://github.com/airweave-ai/airweave/blob/main/fern/docs/pages/events/overview.mdx
-slug: events/overview
+edit-this-page-url: https://github.com/airweave-ai/airweave/blob/main/fern/docs/pages/webhooks/overview.mdx
+slug: webhooks/overview
 ---
 
 <Warning>
 **Beta Feature**
 
-The Events API is currently in beta. The API is stable but may receive enhancements based on feedback.
+The Webhooks API is currently in beta. The API is stable but may receive enhancements based on feedback.
 </Warning>
 
-## What are Events?
+## What are Webhooks?
 
-Events are real-time notifications that Airweave sends when things happen in your organization. Instead of constantly polling the API to check if a sync completed, you register a webhook endpoint and Airweave pushes updates to you the moment they occur.
+Webhooks are real-time notifications that Airweave sends when things happen in your organization. Instead of constantly polling the API to check if a sync completed, you register a webhook endpoint and Airweave pushes updates to you the moment they occur.
 
 This is the foundation for building reactive integrations—trigger downstream workflows, update dashboards, send alerts, or sync state with external systems automatically.
 
@@ -111,11 +111,11 @@ Your server responds with `200 OK` to acknowledge receipt.
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Types & Formats" icon="code" href="/events/types-and-formats">
+  <Card title="Types & Formats" icon="code" href="/webhooks/types-and-formats">
     Learn the detailed structure of event payloads and delivery format.
   </Card>
 
-  <Card title="Setup Guide" icon="wrench" href="/events/setup">
+  <Card title="Setup Guide" icon="wrench" href="/webhooks/setup">
     Create your first webhook subscription and start receiving events.
   </Card>
 </CardGroup>

--- a/fern/docs/pages/webhooks/setup.mdx
+++ b/fern/docs/pages/webhooks/setup.mdx
@@ -1,8 +1,8 @@
 ---
 title: Setup Guide
 description: Create webhooks and start receiving events
-edit-this-page-url: https://github.com/airweave-ai/airweave/blob/main/fern/docs/pages/events/setup.mdx
-slug: events/setup
+edit-this-page-url: https://github.com/airweave-ai/airweave/blob/main/fern/docs/pages/webhooks/setup.mdx
+slug: webhooks/setup
 ---
 
 This guide walks you through setting up webhook subscriptions, handling incoming events, verifying signatures, and managing your event delivery.
@@ -13,7 +13,7 @@ Register your endpoint to start receiving events:
 
 <CodeBlocks>
 ```bash title="cURL"
-curl -X POST 'https://api.airweave.ai/events/subscriptions' \
+curl -X POST 'https://api.airweave.ai/webhooks/subscriptions' \
   -H 'x-api-key: YOUR_API_KEY' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -26,7 +26,7 @@ curl -X POST 'https://api.airweave.ai/events/subscriptions' \
 import requests
 
 response = requests.post(
-    "https://api.airweave.ai/events/subscriptions",
+    "https://api.airweave.ai/webhooks/subscriptions",
     headers={"x-api-key": "YOUR_API_KEY"},
     json={
         "url": "https://your-server.com/webhooks/airweave",
@@ -38,7 +38,7 @@ print(f"Subscription ID: {subscription['id']}")
 ```
 
 ```javascript title="Node.js"
-const response = await fetch("https://api.airweave.ai/events/subscriptions", {
+const response = await fetch("https://api.airweave.ai/webhooks/subscriptions", {
   method: "POST",
   headers: {
     "x-api-key": "YOUR_API_KEY",
@@ -149,7 +149,7 @@ Every webhook delivery is signed. Verify signatures to ensure requests actually 
 First, retrieve your subscription's signing secret:
 
 ```bash
-curl -X GET 'https://api.airweave.ai/events/subscriptions/{subscription_id}?include_secret=true' \
+curl -X GET 'https://api.airweave.ai/webhooks/subscriptions/{subscription_id}?include_secret=true' \
   -H 'x-api-key: YOUR_API_KEY'
 ```
 
@@ -245,14 +245,14 @@ function verifySignature(payload, headers, secret) {
 ### List All Subscriptions
 
 ```bash
-curl -X GET 'https://api.airweave.ai/events/subscriptions' \
+curl -X GET 'https://api.airweave.ai/webhooks/subscriptions' \
   -H 'x-api-key: YOUR_API_KEY'
 ```
 
 ### Get a Specific Subscription
 
 ```bash
-curl -X GET 'https://api.airweave.ai/events/subscriptions/{subscription_id}' \
+curl -X GET 'https://api.airweave.ai/webhooks/subscriptions/{subscription_id}' \
   -H 'x-api-key: YOUR_API_KEY'
 ```
 
@@ -264,7 +264,7 @@ Change the URL, event types, or disable/enable delivery:
 
 <CodeBlocks>
 ```bash title="cURL"
-curl -X PATCH 'https://api.airweave.ai/events/subscriptions/{subscription_id}' \
+curl -X PATCH 'https://api.airweave.ai/webhooks/subscriptions/{subscription_id}' \
   -H 'x-api-key: YOUR_API_KEY' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -275,7 +275,7 @@ curl -X PATCH 'https://api.airweave.ai/events/subscriptions/{subscription_id}' \
 
 ```python title="Python"
 response = requests.patch(
-    f"https://api.airweave.ai/events/subscriptions/{subscription_id}",
+    f"https://api.airweave.ai/webhooks/subscriptions/{subscription_id}",
     headers={"x-api-key": "YOUR_API_KEY"},
     json={
         "event_types": ["sync.completed", "sync.failed", "sync.running"],
@@ -290,7 +290,7 @@ response = requests.patch(
 Temporarily pause delivery without deleting:
 
 ```bash
-curl -X PATCH 'https://api.airweave.ai/events/subscriptions/{subscription_id}' \
+curl -X PATCH 'https://api.airweave.ai/webhooks/subscriptions/{subscription_id}' \
   -H 'x-api-key: YOUR_API_KEY' \
   -H 'Content-Type: application/json' \
   -d '{"disabled": true}'
@@ -301,7 +301,7 @@ curl -X PATCH 'https://api.airweave.ai/events/subscriptions/{subscription_id}' \
 Re-enable a disabled subscription, optionally recovering missed messages:
 
 ```bash
-curl -X PATCH 'https://api.airweave.ai/events/subscriptions/{subscription_id}' \
+curl -X PATCH 'https://api.airweave.ai/webhooks/subscriptions/{subscription_id}' \
   -H 'x-api-key: YOUR_API_KEY' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -317,7 +317,7 @@ The `recover_since` parameter is optional. If provided, Airweave will retry all 
 Permanently remove a subscription:
 
 ```bash
-curl -X DELETE 'https://api.airweave.ai/events/subscriptions/{subscription_id}' \
+curl -X DELETE 'https://api.airweave.ai/webhooks/subscriptions/{subscription_id}' \
   -H 'x-api-key: YOUR_API_KEY'
 ```
 
@@ -325,28 +325,28 @@ curl -X DELETE 'https://api.airweave.ai/events/subscriptions/{subscription_id}' 
 This action cannot be undone. Pending deliveries will be cancelled.
 </Warning>
 
-## Retrieving Event History
+## Retrieving Message History
 
 ### Get All Messages
 
-Retrieve recent event messages sent to your organization:
+Retrieve recent webhook messages sent to your organization:
 
 ```bash
-curl -X GET 'https://api.airweave.ai/events/messages' \
+curl -X GET 'https://api.airweave.ai/webhooks/messages' \
   -H 'x-api-key: YOUR_API_KEY'
 ```
 
 ### Filter by Event Type
 
 ```bash
-curl -X GET 'https://api.airweave.ai/events/messages?event_types=sync.completed&event_types=sync.failed' \
+curl -X GET 'https://api.airweave.ai/webhooks/messages?event_types=sync.completed&event_types=sync.failed' \
   -H 'x-api-key: YOUR_API_KEY'
 ```
 
 ### Get a Specific Message
 
 ```bash
-curl -X GET 'https://api.airweave.ai/events/messages/{message_id}' \
+curl -X GET 'https://api.airweave.ai/webhooks/messages/{message_id}' \
   -H 'x-api-key: YOUR_API_KEY'
 ```
 
@@ -355,7 +355,7 @@ curl -X GET 'https://api.airweave.ai/events/messages/{message_id}' \
 See exactly what happened during delivery:
 
 ```bash
-curl -X GET 'https://api.airweave.ai/events/messages/{message_id}?include_attempts=true' \
+curl -X GET 'https://api.airweave.ai/webhooks/messages/{message_id}?include_attempts=true' \
   -H 'x-api-key: YOUR_API_KEY'
 ```
 
@@ -364,7 +364,7 @@ curl -X GET 'https://api.airweave.ai/events/messages/{message_id}?include_attemp
 If your endpoint was down or had issues, you can replay failed messages:
 
 ```bash
-curl -X POST 'https://api.airweave.ai/events/subscriptions/{subscription_id}/recover' \
+curl -X POST 'https://api.airweave.ai/webhooks/subscriptions/{subscription_id}/recover' \
   -H 'x-api-key: YOUR_API_KEY' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -420,11 +420,11 @@ A complete sample application demonstrating webhook handling, signature verifica
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="API Reference" icon="book" href="/api-reference/events/get-events-messages">
-    Explore the full Events API documentation with request/response examples.
+  <Card title="API Reference" icon="book" href="/api-reference/webhooks/get-webhooks-messages">
+    Explore the full Webhooks API documentation with request/response examples.
   </Card>
 
-  <Card title="Types & Formats" icon="code" href="/events/types-and-formats">
+  <Card title="Types & Formats" icon="code" href="/webhooks/types-and-formats">
     Review the detailed payload structures and delivery format.
   </Card>
 </CardGroup>

--- a/fern/docs/pages/webhooks/types-and-formats.mdx
+++ b/fern/docs/pages/webhooks/types-and-formats.mdx
@@ -1,11 +1,11 @@
 ---
 title: Types & Formats
 description: Event payload structures and delivery format
-edit-this-page-url: https://github.com/airweave-ai/airweave/blob/main/fern/docs/pages/events/types-and-formats.mdx
-slug: events/types-and-formats
+edit-this-page-url: https://github.com/airweave-ai/airweave/blob/main/fern/docs/pages/webhooks/types-and-formats.mdx
+slug: webhooks/types-and-formats
 ---
 
-This page documents the structure of webhook payloads, delivery headers, and the data models used throughout the Events API.
+This page documents the structure of webhook payloads, delivery headers, and the data models used throughout the Webhooks API.
 
 ## Event Types
 
@@ -165,7 +165,7 @@ When you create or retrieve a subscription, you'll see this structure:
 | `created_at` | ISO 8601 | When the subscription was created |
 | `updated_at` | ISO 8601 | When the subscription was last modified |
 
-## Event Message
+## Webhook Message
 
 When retrieving messages via the API, each message has this structure:
 
@@ -238,10 +238,10 @@ Failed deliveries are retried with exponential backoff:
 | 4 | 30 minutes |
 | 5 | 2 hours |
 
-After 5 failed attempts, the message is marked as failed. You can manually recover failed messages using the [recover endpoint](/events/setup#recovering-failed-messages).
+After 5 failed attempts, the message is marked as failed. You can manually recover failed messages using the [recover endpoint](/webhooks/setup#recovering-failed-messages).
 
 ## Next Steps
 
-<Card title="Setup Guide" icon="wrench" href="/events/setup">
+<Card title="Setup Guide" icon="wrench" href="/webhooks/setup">
   Learn how to create subscriptions, verify signatures, and handle events in your application.
 </Card>

--- a/fern/scripts/api_config.py
+++ b/fern/scripts/api_config.py
@@ -20,12 +20,12 @@ INCLUDED_ENDPOINTS = {
     "/source-connections/{source_connection_id}/run/": {"post": True},
     "/source-connections/{source_connection_id}/jobs/": {"get": True},
     "/source-connections/{source_connection_id}/jobs/{job_id}/cancel/": {"post": True},
-    # Events
-    "/events/messages/": {"get": True},
-    "/events/messages/{message_id}/": {"get": True},
-    "/events/subscriptions/": {"get": True, "post": True},
-    "/events/subscriptions/{subscription_id}/": {"get": True, "patch": True, "delete": True},
-    "/events/subscriptions/{subscription_id}/recover/": {"post": True},
+    # Webhooks
+    "/webhooks/messages/": {"get": True},
+    "/webhooks/messages/{message_id}/": {"get": True},
+    "/webhooks/subscriptions/": {"get": True, "post": True},
+    "/webhooks/subscriptions/{subscription_id}/": {"get": True, "patch": True, "delete": True},
+    "/webhooks/subscriptions/{subscription_id}/recover/": {"post": True},
 }
 
 # API group descriptions for documentation
@@ -33,7 +33,7 @@ API_GROUPS = {
     "Sources": "API endpoints for discovering available data source connectors and their configuration requirements",
     "Collections": "API endpoints for managing collections - logical groups of data sources that provide unified search capabilities",
     "Source Connections": "API endpoints for managing live connections to data sources. Source connections are the actual configured instances that Airweave uses to sync data from your apps and databases, transforming it into searchable, structured information within collections",
-    "Events": "API endpoints for managing webhook subscriptions and event messages. Subscribe to events like sync completions to receive real-time notifications at your webhook URL",
+    "Webhooks": "API endpoints for managing webhook subscriptions and messages. Subscribe to events like sync completions to receive real-time notifications at your webhook URL",
 }
 
 

--- a/fern/scripts/generate_openapi.py
+++ b/fern/scripts/generate_openapi.py
@@ -114,7 +114,7 @@ def add_tag_display_names(openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
         "collections": "Collections",
         "source-connections": "Source Connections",
         "sources": "Sources",
-        "events": "Events",
+        "webhooks": "Webhooks",
     }
 
     # Update existing tags with display names

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,7 +25,7 @@ import BillingCancel from '@/pages/BillingCancel';
 import BillingSetup from '@/pages/BillingSetup';
 import BillingPortal from '@/pages/BillingPortal';
 import { AdminDashboard } from '@/pages/AdminDashboard';
-import EventsPage from '@/pages/Events';
+import WebhooksPage from '@/pages/Webhooks';
 
 function App() {
   // Initialize collections event listeners when the app loads
@@ -56,7 +56,7 @@ function App() {
           <Route path={protectedPaths.collectionDetail} element={<CollectionDetailView />} />
           <Route path={protectedPaths.apiKeys} />
           <Route path={protectedPaths.authProviders} element={<AuthProviders />} />
-          <Route path={protectedPaths.events} element={<EventsPage />} />
+          <Route path={protectedPaths.webhooks} element={<WebhooksPage />} />
 
           {/* Organization routes */}
           <Route path="/organization/settings" element={<OrganizationSettingsUnified />} />

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -239,8 +239,8 @@ const DashboardLayout = () => {
     location.pathname.startsWith('/auth-providers'),
     [location.pathname]);
 
-  const isEventsActive = useMemo(() =>
-    location.pathname === '/events',
+  const isWebhooksActive = useMemo(() =>
+    location.pathname === '/webhooks',
     [location.pathname]);
 
   // Fully memoized SidebarContent component
@@ -348,14 +348,14 @@ const DashboardLayout = () => {
             </NavItem>
           </div>
 
-          {/* Events Section */}
+          {/* Webhooks Section */}
           <div>
             <NavItem
-              to="/events"
-              isActive={isEventsActive}
+              to="/webhooks"
+              isActive={isWebhooksActive}
               icon={<Webhook className="mr-2 h-4 w-4 opacity-70 group-hover:opacity-100 transition-opacity" />}
             >
-              Events
+              Webhooks
               <span className="ml-1.5 text-[9px] font-medium text-muted-foreground/60 uppercase tracking-wide">beta</span>
             </NavItem>
           </div>
@@ -368,7 +368,7 @@ const DashboardLayout = () => {
         <UserProfileDropdown />
       </div>
     </div>
-  ), [resolvedTheme, handleCreateCollection, isDashboardActive, isApiKeysActive, isAuthProvidersActive, isEventsActive, currentOrganization?.id, sourceConnectionsAllowed, entitiesAllowed, isCheckingUsage, usageCheckDetails]);
+  ), [resolvedTheme, handleCreateCollection, isDashboardActive, isApiKeysActive, isAuthProvidersActive, isWebhooksActive, currentOrganization?.id, sourceConnectionsAllowed, entitiesAllowed, isCheckingUsage, usageCheckDetails]);
 
   // Main component render
   return (

--- a/frontend/src/components/webhooks/MessageDetail.tsx
+++ b/frontend/src/components/webhooks/MessageDetail.tsx
@@ -96,7 +96,7 @@ function JsonSyntax({ data }: { data: unknown }) {
   );
 }
 
-interface EventDetailProps {
+interface MessageDetailProps {
   message: Message | null;
 }
 
@@ -210,7 +210,7 @@ function DeliveryAttempts({
   );
 }
 
-export function EventDetail({ message }: EventDetailProps) {
+export function MessageDetail({ message }: MessageDetailProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -222,7 +222,7 @@ export function EventDetail({ message }: EventDetailProps) {
   if (!message) {
     return (
       <div className="flex items-center justify-center h-full">
-        <p className="text-xs text-muted-foreground/50">Select an event</p>
+        <p className="text-xs text-muted-foreground/50">Select a message</p>
       </div>
     );
   }

--- a/frontend/src/components/webhooks/MessagesList.tsx
+++ b/frontend/src/components/webhooks/MessagesList.tsx
@@ -1,10 +1,10 @@
 import { Input } from "@/components/ui/input";
 import { Loader2, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { formatTime, getEventSummary } from "./shared";
+import { formatTime, getMessageSummary } from "./shared";
 import type { Message } from "@/hooks/use-webhooks";
 
-interface EventsListProps {
+interface MessagesListProps {
   messages: Message[];
   selectedId: string | null;
   onSelect: (message: Message) => void;
@@ -13,14 +13,14 @@ interface EventsListProps {
   onSearchChange: (query: string) => void;
 }
 
-export function EventsList({
+export function MessagesList({
   messages,
   selectedId,
   onSelect,
   isLoading,
   searchQuery,
   onSearchChange,
-}: EventsListProps) {
+}: MessagesListProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Search */}
@@ -29,7 +29,7 @@ export function EventsList({
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/60" />
           <Input
             type="text"
-            placeholder="Search events..."
+            placeholder="Search messages..."
             className="pl-8 h-8 text-xs bg-transparent border-0 focus-visible:ring-0 placeholder:text-muted-foreground/50"
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
@@ -46,14 +46,14 @@ export function EventsList({
         ) : messages.length === 0 ? (
           <div className="flex items-center justify-center py-16">
             <p className="text-xs text-muted-foreground/60">
-              {searchQuery ? "No results" : "No events"}
+              {searchQuery ? "No results" : "No messages"}
             </p>
           </div>
         ) : (
           <div className="divide-y divide-border/40">
             {messages.map((message) => {
               const isSelected = selectedId === message.id;
-              const summary = getEventSummary(message.payload);
+              const summary = getMessageSummary(message.payload);
 
               return (
                 <div

--- a/frontend/src/components/webhooks/index.ts
+++ b/frontend/src/components/webhooks/index.ts
@@ -1,5 +1,5 @@
-export { EventsList } from "./EventsList";
-export { EventDetail } from "./EventDetail";
+export { MessagesList } from "./MessagesList";
+export { MessageDetail } from "./MessageDetail";
 export { WebhooksTab } from "./WebhooksTab";
 export { CreateWebhookModal } from "./CreateWebhookModal";
 export { EditWebhookModal } from "./EditWebhookModal";

--- a/frontend/src/components/webhooks/shared.tsx
+++ b/frontend/src/components/webhooks/shared.tsx
@@ -121,9 +121,9 @@ export function EventTypeBadge({ eventType }: { eventType: string }) {
 }
 
 /**
- * Get summary from event payload
+ * Get summary from message payload
  */
-export function getEventSummary(payload: Record<string, unknown>): string {
+export function getMessageSummary(payload: Record<string, unknown>): string {
   // Try to build a meaningful summary from the payload
   const collectionName = payload.collection_name as string | undefined;
   const sourceType = payload.source_type as string | undefined;

--- a/frontend/src/constants/paths.ts
+++ b/frontend/src/constants/paths.ts
@@ -6,7 +6,7 @@ export const protectedPaths = {
     apiKeys: "/api-keys",
     authProviders: "/auth-providers",
     authCallback: "/auth/callback/:short_name",
-    events: "/events",
+    webhooks: "/webhooks",
 }
 
 export const publicPaths = {

--- a/frontend/src/hooks/use-webhooks.ts
+++ b/frontend/src/hooks/use-webhooks.ts
@@ -95,7 +95,7 @@ export const webhookKeys = {
  * Fetch all webhook subscriptions
  */
 async function fetchSubscriptions(): Promise<Subscription[]> {
-  const response = await apiClient.get("/events/subscriptions");
+  const response = await apiClient.get("/webhooks/subscriptions");
   if (!response.ok) {
     throw new Error(`Failed to fetch subscriptions: ${response.status}`);
   }
@@ -116,8 +116,8 @@ async function fetchSubscription(
     params.set("include_secret", "true");
   }
   const url = params.toString()
-    ? `/events/subscriptions/${id}?${params}`
-    : `/events/subscriptions/${id}`;
+    ? `/webhooks/subscriptions/${id}?${params}`
+    : `/webhooks/subscriptions/${id}`;
   const response = await apiClient.get(url);
   if (!response.ok) {
     throw new Error(`Failed to fetch subscription: ${response.status}`);
@@ -136,8 +136,8 @@ async function fetchMessage(id: string, includeAttempts = false): Promise<Messag
     params.set("include_attempts", "true");
   }
   const url = params.toString()
-    ? `/events/messages/${id}?${params}`
-    : `/events/messages/${id}`;
+    ? `/webhooks/messages/${id}?${params}`
+    : `/webhooks/messages/${id}`;
   const response = await apiClient.get(url);
   if (!response.ok) {
     throw new Error(`Failed to fetch message: ${response.status}`);
@@ -149,7 +149,7 @@ async function fetchMessage(id: string, includeAttempts = false): Promise<Messag
  * Fetch all messages (events)
  */
 async function fetchMessages(): Promise<Message[]> {
-  const response = await apiClient.get("/events/messages");
+  const response = await apiClient.get("/webhooks/messages");
   if (!response.ok) {
     throw new Error(`Failed to fetch messages: ${response.status}`);
   }
@@ -160,7 +160,7 @@ async function fetchMessages(): Promise<Message[]> {
  * Create a new subscription
  */
 async function createSubscription(data: CreateSubscriptionRequest): Promise<Subscription> {
-  const response = await apiClient.post("/events/subscriptions", data);
+  const response = await apiClient.post("/webhooks/subscriptions", data);
   if (!response.ok) {
     throw new Error(`Failed to create subscription: ${response.status}`);
   }
@@ -174,7 +174,7 @@ async function updateSubscription(
   id: string,
   data: UpdateSubscriptionRequest
 ): Promise<Subscription> {
-  const response = await apiClient.patch(`/events/subscriptions/${id}`, data);
+  const response = await apiClient.patch(`/webhooks/subscriptions/${id}`, data);
   if (!response.ok) {
     throw new Error(`Failed to update subscription: ${response.status}`);
   }
@@ -185,7 +185,7 @@ async function updateSubscription(
  * Delete a subscription
  */
 async function deleteSubscription(id: string): Promise<void> {
-  const response = await apiClient.delete(`/events/subscriptions/${id}`);
+  const response = await apiClient.delete(`/webhooks/subscriptions/${id}`);
   if (!response.ok) {
     throw new Error(`Failed to delete subscription: ${response.status}`);
   }
@@ -198,7 +198,7 @@ async function recoverFailedMessages(
   id: string,
   data: RecoverMessagesRequest
 ): Promise<RecoverOut> {
-  const response = await apiClient.post(`/events/subscriptions/${id}/recover`, data);
+  const response = await apiClient.post(`/webhooks/subscriptions/${id}/recover`, data);
   if (!response.ok) {
     throw new Error(`Failed to recover messages: ${response.status}`);
   }

--- a/frontend/src/lib/stores/index.ts
+++ b/frontend/src/lib/stores/index.ts
@@ -1,6 +1,6 @@
 export * from './collections';
 export * from './sources';
-export * from './events';
+export * from './webhooks';
 
 export { useCollectionsStore } from './collections';
 export { useSourcesStore } from './sources';
@@ -8,4 +8,4 @@ export { default as useUserStore } from './user';
 export { useAuthStore } from './auth-store';
 export { useOrganizationStore } from './organizations';
 export { useUsageStore } from './usage';
-export { useEventsStore } from './events';
+export { useWebhooksStore } from './webhooks';

--- a/frontend/src/lib/stores/webhooks.ts
+++ b/frontend/src/lib/stores/webhooks.ts
@@ -1,14 +1,14 @@
 /**
- * Events/Webhooks store for managing webhook subscriptions and event messages
+ * Webhooks store for managing webhook subscriptions and messages
  */
 
 import { create } from 'zustand';
 import { apiClient } from '../api';
 
 /**
- * Event message type (snake_case to match API response)
+ * Webhook message type (snake_case to match API response)
  */
-export interface EventMessage {
+export interface WebhookMessage {
   id: string;
   event_type: string;
   payload: Record<string, unknown>;
@@ -62,9 +62,9 @@ export interface UpdateSubscriptionRequest {
   event_types?: string[];
 }
 
-interface EventsState {
+interface WebhooksState {
   subscriptions: Subscription[];
-  messages: EventMessage[];
+  messages: WebhookMessage[];
   isLoadingSubscriptions: boolean;
   isLoadingMessages: boolean;
   error: string | null;
@@ -77,10 +77,10 @@ interface EventsState {
   updateSubscription: (subscriptionId: string, request: UpdateSubscriptionRequest) => Promise<Subscription>;
   deleteSubscription: (subscriptionId: string) => Promise<void>;
   deleteSubscriptions: (subscriptionIds: string[]) => Promise<void>;
-  clearEvents: () => void;
+  clearWebhooks: () => void;
 }
 
-export const useEventsStore = create<EventsState>((set, get) => ({
+export const useWebhooksStore = create<WebhooksState>((set, get) => ({
   subscriptions: [],
   messages: [],
   isLoadingSubscriptions: false,
@@ -90,7 +90,7 @@ export const useEventsStore = create<EventsState>((set, get) => ({
   fetchSubscriptions: async () => {
     set({ isLoadingSubscriptions: true, error: null });
     try {
-      const response = await apiClient.get('/events/subscriptions');
+      const response = await apiClient.get('/webhooks/subscriptions');
       if (!response.ok) {
         throw new Error(`Failed to fetch subscriptions: ${response.status}`);
       }
@@ -107,7 +107,7 @@ export const useEventsStore = create<EventsState>((set, get) => ({
   fetchMessages: async (eventTypes?: string[]) => {
     set({ isLoadingMessages: true, error: null });
     try {
-      let endpoint = '/events/messages';
+      let endpoint = '/webhooks/messages';
       if (eventTypes && eventTypes.length > 0) {
         const params = new URLSearchParams();
         eventTypes.forEach((type) => params.append('event_types', type));
@@ -133,8 +133,8 @@ export const useEventsStore = create<EventsState>((set, get) => ({
       params.set("include_secret", "true");
     }
     const url = params.toString()
-      ? `/events/subscriptions/${subscriptionId}?${params}`
-      : `/events/subscriptions/${subscriptionId}`;
+      ? `/webhooks/subscriptions/${subscriptionId}?${params}`
+      : `/webhooks/subscriptions/${subscriptionId}`;
     const response = await apiClient.get(url);
     if (!response.ok) {
       throw new Error(`Failed to fetch subscription: ${response.status}`);
@@ -143,7 +143,7 @@ export const useEventsStore = create<EventsState>((set, get) => ({
   },
 
   createSubscription: async (request: CreateSubscriptionRequest) => {
-    const response = await apiClient.post('/events/subscriptions', request);
+    const response = await apiClient.post('/webhooks/subscriptions', request);
     if (!response.ok) {
       throw new Error(`Failed to create subscription: ${response.status}`);
     }
@@ -154,7 +154,7 @@ export const useEventsStore = create<EventsState>((set, get) => ({
   },
 
   updateSubscription: async (subscriptionId: string, request: UpdateSubscriptionRequest) => {
-    const response = await apiClient.patch(`/events/subscriptions/${subscriptionId}`, request);
+    const response = await apiClient.patch(`/webhooks/subscriptions/${subscriptionId}`, request);
     if (!response.ok) {
       throw new Error(`Failed to update subscription: ${response.status}`);
     }
@@ -165,7 +165,7 @@ export const useEventsStore = create<EventsState>((set, get) => ({
   },
 
   deleteSubscription: async (subscriptionId: string) => {
-    const response = await apiClient.delete(`/events/subscriptions/${subscriptionId}`);
+    const response = await apiClient.delete(`/webhooks/subscriptions/${subscriptionId}`);
     if (!response.ok) {
       throw new Error(`Failed to delete subscription: ${response.status}`);
     }
@@ -177,7 +177,7 @@ export const useEventsStore = create<EventsState>((set, get) => ({
     // Delete all subscriptions in parallel
     const results = await Promise.allSettled(
       subscriptionIds.map(id =>
-        apiClient.delete(`/events/subscriptions/${id}`)
+        apiClient.delete(`/webhooks/subscriptions/${id}`)
       )
     );
 
@@ -191,7 +191,7 @@ export const useEventsStore = create<EventsState>((set, get) => ({
     get().fetchSubscriptions();
   },
 
-  clearEvents: () => {
+  clearWebhooks: () => {
     set({ subscriptions: [], messages: [], error: null });
   },
 }));

--- a/frontend/src/pages/Webhooks.tsx
+++ b/frontend/src/pages/Webhooks.tsx
@@ -10,15 +10,15 @@ import {
   type Message,
 } from "@/hooks/use-webhooks";
 import {
-  EventsList,
-  EventDetail,
+  MessagesList,
+  MessageDetail,
   WebhooksTab,
   CreateWebhookModal,
   EditWebhookModal,
 } from "@/components/webhooks";
 
 /**
- * Logs Tab - Split pane view showing event logs
+ * Logs Tab - Split pane view showing webhook message logs
  */
 function LogsTab() {
   const [selectedMessage, setSelectedMessage] = useState<Message | null>(null);
@@ -46,7 +46,7 @@ function LogsTab() {
     <div className="flex h-[calc(100vh-240px)] min-h-[400px] border rounded-lg overflow-hidden">
       {/* Left - List */}
       <div className="w-[380px] shrink-0 border-r">
-        <EventsList
+        <MessagesList
           messages={filteredMessages}
           selectedId={selectedMessage?.id ?? null}
           onSelect={setSelectedMessage}
@@ -71,7 +71,7 @@ function LogsTab() {
           </Button>
         </div>
         <div className="flex-1 overflow-hidden">
-          <EventDetail message={selectedMessage} />
+          <MessageDetail message={selectedMessage} />
         </div>
       </div>
     </div>
@@ -79,9 +79,9 @@ function LogsTab() {
 }
 
 /**
- * Events Page - Main page for webhooks and event logs
+ * Webhooks Page - Main page for webhooks and message logs
  */
-const EventsPage = () => {
+const WebhooksPage = () => {
   const {
     data: subscriptions = [],
     isLoading: isLoadingSubscriptions,
@@ -121,7 +121,7 @@ const EventsPage = () => {
       {/* Header */}
       <div className="flex items-center justify-between mb-1">
         <h1 className="text-2xl sm:text-3xl font-bold">
-          Events
+          Webhooks
           <span className="ml-2 text-[10px] font-medium text-muted-foreground/60 uppercase tracking-wide align-middle">beta</span>
         </h1>
         <Button onClick={() => setCreateModalOpen(true)} size="sm" className="h-8">
@@ -132,7 +132,7 @@ const EventsPage = () => {
       <p className="text-sm text-muted-foreground mb-4">
         Get notified when syncs complete or fail.{" "}
         <a
-          href="https://docs.airweave.ai/events"
+          href="https://docs.airweave.ai/webhooks"
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center text-primary hover:underline"
@@ -182,4 +182,4 @@ const EventsPage = () => {
   );
 };
 
-export default EventsPage;
+export default WebhooksPage;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the “Events” API to “Webhooks” across backend, frontend, docs, and tests. All endpoints now live under /webhooks with unchanged behavior.

- **Refactors**
  - Moved REST endpoints from /events to /webhooks; updated router, tags, OpenAPI, and Fern config.
  - Renamed schemas: EventMessage → WebhookMessage; EventMessageWithAttempts → WebhookMessageWithAttempts; moved to airweave.schemas.webhooks.
  - Renamed backend endpoint module and updated e2e tests and copy to “webhooks/messages” and “webhooks/subscriptions”.
  - Updated frontend routes to /webhooks and renamed related pages, components, hooks, and stores; sidebar label now “Webhooks”.
  - Updated docs: navigation, pages, examples, and links moved from /events/* to /webhooks/*.

- **Migration**
  - Replace /events/* with /webhooks/* in all API calls (messages, messages/{id}, subscriptions, subscriptions/{id}, recover).
  - Update imports from airweave.schemas.events to airweave.schemas.webhooks.
  - Update any links or routes pointing to /events to use /webhooks. No functional changes.

<sup>Written for commit da04db27d88341cfff83a733e145ae64f79d7b2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

