### PR TITLE
fix: use native async Mistral SDK methods to prevent thread blocking hangs

### DIFF
--- a/backend/airweave/platform/converters/mistral_converter.py
+++ b/backend/airweave/platform/converters/mistral_converter.py
@@ -74,7 +74,10 @@ class MistralConverter(BaseTextConverter):
         try:
             from mistralai import Mistral
 
-            self._mistral_client = Mistral(api_key=settings.MISTRAL_API_KEY)
+            self._mistral_client = Mistral(
+                api_key=settings.MISTRAL_API_KEY,
+                timeout_ms=300_000,  # 5 minute timeout (300 seconds)
+            )
             self._mistral_initialized = True
             logger.debug("Mistral client initialized for document conversion")
         except ImportError:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the Mistral integration to native async SDK methods to prevent thread-blocking hangs in document conversion, and adds a 5-minute client timeout for stuck calls.

- **Bug Fixes**
  - Replaced thread-pool wrapped sync calls with true async endpoints: files.upload_async, files.get_signed_url_async, batch.jobs.create_async, files.delete_async.
  - Simplified retry wrapper to accept coroutines; keeps rate limiting and retries without blocking threads.
  - Initialized Mistral client with timeout_ms=300000 to cap long-running operations.

<sup>Written for commit 51b38951a867d90b3f0b430947a9633908e8a93b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

