### PR TITLE
fix: downgrade unnecessary logs from info to debug

### DIFF
--- a/backend/airweave/core/guard_rail_service.py
+++ b/backend/airweave/core/guard_rail_service.py
@@ -234,8 +234,8 @@ class GuardRailService:
                     current_usage=total_usage,
                 )
 
-            self.logger.info(
-                f"\n\nUsage check: {action_type.value} usage={total_usage}, "
+            self.logger.debug(
+                f"Usage check: {action_type.value} usage={total_usage}, "
                 f"requested={amount}, limit={limit}\n\n"
             )
 
@@ -456,7 +456,7 @@ class GuardRailService:
                 )
                 return BillingPeriodStatus.ACTIVE
 
-            self.logger.info(
+            self.logger.debug(
                 f"\n\nRetrieved billing period for organization {self.organization_id}: "
                 f"status={current_period.status}, plan={current_period.plan}, "
                 f"period_id={current_period.id}, "

--- a/backend/airweave/platform/storage/file_service.py
+++ b/backend/airweave/platform/storage/file_service.py
@@ -218,7 +218,7 @@ class FileService:
         )
 
         if not should_download:
-            logger.info(f"Skipping download of {entity.name}: {skip_reason}")
+            logger.debug(f"Skipping download of {entity.name}: {skip_reason}")
             raise FileSkippedException(reason=skip_reason, filename=entity.name)
 
         file_uuid = str(uuid4())


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Downgraded non-essential info logs to debug in GuardRailService (usage checks, billing status) and FileService (skip download message) to reduce production log noise without changing behavior.

<sup>Written for commit 4e03b60ab39b7d36ac8056add8f7e05af703e0b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

