### PR TITLE
fix: add missing env vars to storage integration test CI step

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -69,6 +69,14 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.STORAGE_TEST_AZURE_TENANT_ID }}
           # GCP credentials
           GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.STORAGE_TEST_GCP_CREDENTIALS_JSON }}
+          # Airweave Settings required by transitive import chain (not used by storage tests)
+          FIRST_SUPERUSER: "test@test.com"
+          FIRST_SUPERUSER_PASSWORD: "testpassword"
+          ENCRYPTION_KEY: "test-encryption-key-for-ci-only"
+          STATE_SECRET: "test-state-secret-for-ci-only-must-be-32-chars-long"
+          POSTGRES_HOST: "localhost"
+          POSTGRES_USER: "test"
+          POSTGRES_PASSWORD: "test"
         run: |
           # Write GCP credentials to file
           echo "$GOOGLE_APPLICATION_CREDENTIALS_JSON" > /tmp/gcp-creds.json


### PR DESCRIPTION
## Summary
- The storage integration tests in CI were failing with Settings validation errors because 7 required env vars (FIRST_SUPERUSER, FIRST_SUPERUSER_PASSWORD, ENCRYPTION_KEY, STATE_SECRET, POSTGRES_HOST, POSTGRES_USER, POSTGRES_PASSWORD) were not set.
- These are not used by the storage tests themselves, but get pulled in via the transitive import chain: storage backends -> airweave.core.logging (module-level logger) -> airweave.core.config.settings -> Pydantic Settings validation.
- Added dummy values for these env vars in the integration test workflow step.

## Test plan
- [ ] Verify the storage integration tests pass on a push to main after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing storage integration tests in CI by setting missing Airweave env vars to dummy values so Settings validation passes during transitive imports. Adds FIRST_SUPERUSER, FIRST_SUPERUSER_PASSWORD, ENCRYPTION_KEY, STATE_SECRET, POSTGRES_HOST, POSTGRES_USER, and POSTGRES_PASSWORD to the workflow step.

<sup>Written for commit 86e9a38dcb1b0bca690434830420782d4000606d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

