### PR TITLE
fix: add missing https:// to Salesforce Contact & Opportunity pagination URLs

### DIFF
--- a/backend/airweave/platform/sources/salesforce.py
+++ b/backend/airweave/platform/sources/salesforce.py
@@ -409,7 +409,7 @@ class SalesforceSource(BaseSource):
             # Check for next page
             next_records_url = data.get("nextRecordsUrl")
             if next_records_url:
-                url = f"{self.instance_url}{next_records_url}"
+                url = f"https://{self.instance_url}{next_records_url}"
                 params = None
             else:
                 url = None
@@ -500,7 +500,7 @@ class SalesforceSource(BaseSource):
             # Check for next page
             next_records_url = data.get("nextRecordsUrl")
             if next_records_url:
-                url = f"{self.instance_url}{next_records_url}"
+                url = f"https://{self.instance_url}{next_records_url}"
                 params = None
             else:
                 url = None


### PR DESCRIPTION
Pagination for Contact and Opportunity was missing the https:// scheme prefix, causing failures for orgs with >2000 records.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Salesforce Contact and Opportunity pagination by adding the missing https:// scheme to next page URLs. This makes the URLs valid and prevents failures on orgs with >2000 records.

<sup>Written for commit ae0c86383ac52a4374b8747985b504bdd1958f17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

