### PR TITLE
feat: add `internal` flag to @source decorator, replace hardcoded exclusion lists

### DIFF
--- a/backend/airweave/platform/decorators.py
+++ b/backend/airweave/platform/decorators.py
@@ -24,6 +24,7 @@ def source(
     cursor_class: Optional[Type[BaseModel]] = None,
     supports_access_control: bool = False,
     feature_flag: Optional[str] = None,
+    internal: bool = False,
 ) -> Callable[[type], type]:
     """Enhanced source decorator with OAuth type tracking and typed cursor support.
 
@@ -49,6 +50,8 @@ def source(
             Default is False (entities visible to everyone).
         feature_flag: Optional feature flag (from FeatureFlag enum) required to access this source.
             When set, only organizations with this feature enabled can see/use the source.
+        internal: Whether this is an internal/test source (default False). Internal
+            sources are excluded from docs and only loaded when ENABLE_INTERNAL_SOURCES=true.
 
     Example:
         # OAuth source (no auth config)
@@ -110,6 +113,7 @@ def source(
         cls._rate_limit_level = rate_limit_level
         cls._supports_access_control = supports_access_control
         cls._feature_flag = feature_flag
+        cls._internal = internal
 
         # Add validation method if not present
         if not hasattr(cls, "validate"):

--- a/backend/airweave/platform/sources/_base.py
+++ b/backend/airweave/platform/sources/_base.py
@@ -38,6 +38,7 @@ class BaseSource:
     _oauth_type: ClassVar[Optional[OAuthType]] = None
     _requires_byoc: ClassVar[bool] = False
     _auth_config_class: ClassVar[Optional[str]] = None
+    _internal: ClassVar[bool] = False
 
     def __init__(self):
         """Initialize the base source."""
@@ -151,6 +152,16 @@ class BaseSource:
     def cursor(self):
         """Get the cursor for this source."""
         return getattr(self, "_cursor", None)
+
+    @classmethod
+    def is_internal(cls) -> bool:
+        """Check if this is an internal/test source.
+
+        Internal sources are excluded from documentation generation and only
+        loaded when ENABLE_INTERNAL_SOURCES=true. Set via `internal=True`
+        in the @source decorator.
+        """
+        return cls._internal
 
     @classmethod
     def supports_auth_method(cls, method: AuthenticationMethod) -> bool:

--- a/backend/airweave/platform/sources/file_stub.py
+++ b/backend/airweave/platform/sources/file_stub.py
@@ -357,6 +357,7 @@ class ContentGenerator:
     config_class="FileStubConfig",
     labels=["Internal", "Testing"],
     supports_continuous=False,
+    internal=True,
 )
 class FileStubSource(BaseSource):
     """File stub source for testing document conversion pipelines.

--- a/backend/airweave/platform/sources/snapshot.py
+++ b/backend/airweave/platform/sources/snapshot.py
@@ -53,6 +53,7 @@ AZURE_BLOB_URL_PATTERN = re.compile(r"^https://([^.]+)\.blob\.core\.windows\.net
     config_class="SnapshotConfig",
     labels=["Internal", "Replay"],
     supports_continuous=False,
+    internal=True,
 )
 class SnapshotSource(BaseSource):
     """Source that replays entities from raw data captures.
@@ -166,7 +167,8 @@ class SnapshotSource(BaseSource):
             return None
 
         try:
-            # Strip full storage path if present (ARF may store full paths like raw/{sync_id}/files/...)
+            # Strip full storage path if present
+            # (ARF may store full paths like raw/{sync_id}/files/...)
             # Extract just the relative path within the snapshot directory
             if "/" in stored_file_path and "files/" in stored_file_path:
                 # Extract everything from 'files/' onward

--- a/backend/airweave/platform/sources/stub.py
+++ b/backend/airweave/platform/sources/stub.py
@@ -488,6 +488,7 @@ class ContentGenerator:
     config_class="StubConfig",
     labels=["Internal", "Testing"],
     supports_continuous=False,
+    internal=True,
 )
 class StubSource(BaseSource):
     """Stub source connector for testing purposes.


### PR DESCRIPTION
## Summary
- Adds `internal: bool = False` parameter to the `@source` decorator as a single source of truth for identifying internal/test sources (stub, file_stub, snapshot)
- Replaces three separate hardcoded lists (`db_sync.py` internal_source_files set, label-based `"Internal" in _labels` filtering, and fern `EXCLUDED_SOURCES`) with one declarative `internal=True` flag in the decorator
- Fern docs script now parses `internal=True` via AST instead of maintaining a hardcoded exclusion set — fixes the `file_stub/icon.svg` build error

## Changes
- **`decorators.py`**: Add `internal` param → sets `cls._internal`
- **`_base.py`**: Add `_internal` ClassVar and `is_internal()` classmethod
- **`stub.py`, `file_stub.py`, `snapshot.py`**: Set `internal=True`
- **`db_sync.py`**: Use `is_internal()` instead of hardcoded file set and label check
- **`fern/file_utils.py`**: Parse `internal=True` via AST instead of `EXCLUDED_SOURCES`

## Test plan
- [ ] Verify fern docs build passes (no `file_stub` error)
- [ ] Verify internal sources are excluded from docs output
- [ ] Verify platform sync works with `ENABLE_INTERNAL_SOURCES=false` (internal sources skipped)
- [ ] Verify platform sync works with `ENABLE_INTERNAL_SOURCES=true` (internal sources loaded)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an internal flag to the @source decorator and use it as the single source of truth to identify internal/test sources across the platform and docs. This removes hardcoded exclusion lists and fixes the Fern docs build error.

- **Refactors**
  - Added internal=True to @source; BaseSource exposes is_internal().
  - Replaced filename/label checks in db_sync with is_internal() filtering.
  - Docs script now parses internal=True via AST and removes EXCLUDED_SOURCES.

- **Bug Fixes**
  - Fixes Fern docs build failure caused by file_stub/icon.svg by auto-excluding internal sources.

<sup>Written for commit c2b7b3bb83258586931a13bc6e08dee2773e4ea5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

