### PR TITLE
feat: add Inject() dependency helper for protocol-based DI in FastAPI

### DIFF
--- a/backend/airweave/api/deps.py
+++ b/backend/airweave/api/deps.py
@@ -1,7 +1,7 @@
 """Dependencies that are used in the API endpoints."""
 
 import uuid
-from typing import Optional, Tuple
+from typing import Optional, Tuple, get_type_hints
 
 from fastapi import Depends, Header, HTTPException, Request
 from fastapi_auth0 import Auth0User
@@ -593,3 +593,58 @@ def get_container() -> Container:
     if c is None:
         raise RuntimeError("Container not initialized. Call initialize_container() first.")
     return c
+
+
+# ---------------------------------------------------------------------------
+# Protocol Injection
+# ---------------------------------------------------------------------------
+
+# Cache of protocol_type → Container field name, built once at first call.
+_INJECT_CACHE: dict[type, str] = {}
+
+
+def _resolve_field_name(protocol_type: type) -> str:
+    """Find which Container field matches the given protocol type.
+
+    Uses get_type_hints() to introspect the Container dataclass.
+    Result is cached so the lookup happens at most once per protocol type.
+    """
+    if not _INJECT_CACHE:
+        # Populate cache on first call
+        for name, hint in get_type_hints(Container).items():
+            _INJECT_CACHE[hint] = name
+
+    field_name = _INJECT_CACHE.get(protocol_type)
+    if field_name is None:
+        available = list(_INJECT_CACHE.values())
+        raise TypeError(
+            f"No binding for {protocol_type.__name__} in Container. Available fields: {available}"
+        )
+    return field_name
+
+
+def Inject(protocol_type: type):  # noqa: N802 — uppercase to match FastAPI convention
+    """Resolve a protocol implementation from the DI container.
+
+    Works like ``Depends()`` but looks up the implementation by protocol type
+    instead of requiring the caller to know about the Container internals.
+
+    Usage in FastAPI endpoints::
+
+        from airweave.api.deps import Inject
+        from airweave.core.protocols import EventBus, WebhookAdmin
+
+
+        @router.post("/")
+        async def create(
+            event_bus: EventBus = Inject(EventBus),
+            webhook_admin: WebhookAdmin = Inject(WebhookAdmin),
+        ):
+            await event_bus.publish(...)
+    """
+    field_name = _resolve_field_name(protocol_type)
+
+    def _resolve(c: Container = Depends(get_container)):
+        return getattr(c, field_name)
+
+    return Depends(_resolve)


### PR DESCRIPTION
## Summary

- Introduces `Inject()` — a FastAPI dependency that resolves protocol implementations from the `Container` by introspecting its type hints. This replaces the verbose `c: Container = Depends(deps.get_container)` + `c.webhook_admin` pattern with `webhook_admin: WebhookAdmin = Inject(WebhookAdmin)`.
- Makes `Container` protocol imports runtime-available (removes `TYPE_CHECKING` guard) so `get_type_hints()` can introspect field types.
- Migrates all 8 webhook endpoints to use `Inject(WebhookAdmin)` as a demonstration of the pattern.

### Before
```python
async def get_messages(
    ctx: ApiContext = Depends(deps.get_context),
    c: Container = Depends(deps.get_container),
) -> List[WebhookMessage]:
    messages = await c.webhook_admin.get_messages(...)
```

### After
```python
async def get_messages(
    ctx: ApiContext = Depends(deps.get_context),
    webhook_admin: WebhookAdmin = Inject(WebhookAdmin),
) -> List[WebhookMessage]:
    messages = await webhook_admin.get_messages(...)
```

## Files changed

| File | Change |
|------|--------|
| `backend/airweave/api/deps.py` | Add `Inject()`, `_resolve_field_name()`, and `_INJECT_CACHE` |
| `backend/airweave/core/container/container.py` | Remove `TYPE_CHECKING` guard, make protocol imports runtime-available |
| `backend/airweave/api/v1/endpoints/webhooks.py` | Migrate all endpoints from `Container` to `Inject(WebhookAdmin)` |

## Test plan

- [ ] Verify webhook endpoints still work (list/create/update/delete subscriptions, list/get messages, recover)
- [ ] Verify `Inject()` raises a clear `TypeError` when given an unregistered protocol type

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Inject() to FastAPI for protocol-based dependency injection, so endpoints pull typed implementations directly from the Container. Migrates webhook endpoints to Inject(WebhookAdmin) and enables runtime type introspection to support this.

- **New Features**
  - Inject(protocol) resolves implementations via Container type hints with a small cache.
  - Container now imports protocol types at runtime (removed TYPE_CHECKING) to enable introspection.
  - Webhook endpoints switched to Inject(WebhookAdmin); functionality is unchanged.
  - Raises a clear TypeError if a protocol has no binding in the Container.

<sup>Written for commit 184326acc52acb7a2a4237a8299acab54f713743. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

