### PR TITLE
tests: add larger tail logs in case of failure

### DIFF
--- a/.github/workflows/test-public-api.yml
+++ b/.github/workflows/test-public-api.yml
@@ -344,21 +344,39 @@ jobs:
 
           echo ""
           echo "=========================================="
-          echo "FASTAPI SERVER LOGS (last 200 lines)"
+          echo "CONTAINER STATUS"
           echo "=========================================="
-          docker logs airweave-backend --tail 200 2>&1 || echo "Could not fetch backend logs"
+          docker ps -a --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
 
           echo ""
           echo "=========================================="
-          echo "TEMPORAL WORKER LOGS (last 800 lines)"
+          echo "SVIX SERVER LOGS (last 400 lines)"
           echo "=========================================="
-          docker logs airweave-temporal-worker --tail 800 2>&1 || echo "Could not fetch worker logs"
+          docker logs airweave-svix --tail 400 2>&1 || echo "Could not fetch Svix logs"
 
           echo ""
           echo "=========================================="
-          echo "All running containers:"
+          echo "FASTAPI SERVER LOGS (last 1000 lines)"
           echo "=========================================="
-          docker ps
+          docker logs airweave-backend --tail 1000 2>&1 || echo "Could not fetch backend logs"
+
+          echo ""
+          echo "=========================================="
+          echo "TEMPORAL WORKER LOGS (last 2000 lines)"
+          echo "=========================================="
+          docker logs airweave-temporal-worker --tail 2000 2>&1 || echo "Could not fetch worker logs"
+
+          echo ""
+          echo "=========================================="
+          echo "ERROR / WARNING LINES (worker, last 200 lines)"
+          echo "=========================================="
+          docker logs airweave-temporal-worker 2>&1 | grep -iE "ERROR|WARNING|WARN|exception|traceback" | tail -200 || echo "No error/warning lines found"
+
+          echo ""
+          echo "=========================================="
+          echo "ERROR / WARNING LINES (backend, last 200 lines)"
+          echo "=========================================="
+          docker logs airweave-backend 2>&1 | grep -iE "ERROR|WARNING|WARN|exception|traceback" | tail -200 || echo "No error/warning lines found"
 
       - name: Cleanup Docker containers
         if: always()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve CI failure diagnostics for the public API workflow by increasing Docker log tails and adding targeted error summaries. On failure we now show container status, Svix logs, 1000-line backend logs, 2000-line worker logs, and the last 200 error/warning lines for each.

<sup>Written for commit dd1caa525a92075493c0b3f25e72e4a5c291fa12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

