### PR TITLE
ci: split E2E tests into 5 matrix groups with shared build

### DIFF
--- a/.github/workflows/test-public-api.yml
+++ b/.github/workflows/test-public-api.yml
@@ -7,13 +7,43 @@ on:
     branches: [main]
 
 jobs:
+  # ───────────────────────────────────────────────────────────────────
+  # Build: compile the backend Docker image once, share via artifact
+  # ───────────────────────────────────────────────────────────────────
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Build test backend image
+        run: |
+          echo "Building backend image for testing..."
+          docker build -t test-backend:latest ./backend
+
+      - name: Export backend image
+        run: docker save test-backend:latest | gzip > /tmp/test-backend-image.tar.gz
+
+      - name: Upload backend image
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-backend-image
+          path: /tmp/test-backend-image.tar.gz
+          retention-days: 1
+
+  # ───────────────────────────────────────────────────────────────────
+  # Test: 5 parallel runners, each with its own Docker Compose stack
+  # ───────────────────────────────────────────────────────────────────
   test-public-api:
+    needs: build
     runs-on: ubuntu-latest
     environment: dev
     strategy:
       fail-fast: false
       matrix:
-        group: [0, 1]
+        group: [0, 1, 2, 3, 4]
 
     steps:
       - name: Verify prerequisites
@@ -39,13 +69,17 @@ jobs:
           cd backend
           pip install -r tests/e2e/requirements.txt
 
-      - name: Setup Docker layer caching
-        uses: actions/cache@v3
+      - name: Download backend image
+        uses: actions/download-artifact@v4
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-docker-${{ hashFiles('docker/docker-compose.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-docker-
+          name: test-backend-image
+          path: /tmp
+
+      - name: Load backend image
+        run: |
+          echo "Loading pre-built backend image..."
+          docker load < /tmp/test-backend-image.tar.gz
+          docker images test-backend
 
       - name: Pre-pull heavy Docker images
         run: |
@@ -61,11 +95,6 @@ jobs:
           docker pull alpine:3.19 &
           wait
           echo "All images pre-pulled successfully"
-
-      - name: Build test backend image locally
-        run: |
-          echo "Building backend image for testing..."
-          docker build -t test-backend:latest ./backend
 
       - name: Setup environment and start services
         env:
@@ -208,11 +237,12 @@ jobs:
           cd backend
 
           # ── Dynamically discover and split test files ──
-          # Both matrix jobs see the same file list. We shuffle deterministically
+          # All matrix jobs see the same file list. We shuffle deterministically
           # using the commit SHA so each run gets a different (but reproducible)
-          # distribution, and each job picks its own half.
+          # distribution, and each job picks its own slice via round-robin.
           COMMIT_SHA="${GITHUB_SHA:-$(date +%Y%m%d)}"
           GROUP=${{ matrix.group }}
+          TOTAL_GROUPS=5
 
           # Collect all smoke test files (excluding rate-limit-only files)
           ALL_FILES=$(find tests/e2e/smoke -maxdepth 1 -name 'test_*.py' \
@@ -228,17 +258,13 @@ jobs:
           done | sort | awk '{print $2}')
 
           TOTAL=$(echo "$SHUFFLED" | wc -l)
-          HALF=$(( (TOTAL + 1) / 2 ))
 
-          if [ "$GROUP" = "0" ]; then
-            TEST_FILES=$(echo "$SHUFFLED" | head -n "$HALF" | tr '\n' ' ')
-          else
-            TEST_FILES=$(echo "$SHUFFLED" | tail -n +"$((HALF + 1))" | tr '\n' ' ')
-          fi
+          # Round-robin: file at position i goes to group (i % TOTAL_GROUPS)
+          TEST_FILES=$(echo "$SHUFFLED" | awk -v g="$GROUP" -v tg="$TOTAL_GROUPS" '(NR - 1) % tg == g {print}' | tr '\n' ' ')
 
           FILE_COUNT=$(echo "$TEST_FILES" | wc -w)
           echo "=========================================="
-          echo "Group $GROUP: running $FILE_COUNT / $TOTAL test files"
+          echo "Group $GROUP of $TOTAL_GROUPS: running $FILE_COUNT / $TOTAL test files"
           echo "=========================================="
           echo "$TEST_FILES" | tr ' ' '\n' | grep -v '^$'
           echo "=========================================="


### PR DESCRIPTION
## Summary

- **Extracts the backend Docker image build** into a dedicated build job that runs once and uploads the image as an artifact — avoids building the same image 5 times, and fails fast if the build is broken before spinning up test runners.
- **Expands the test matrix from 2 to 5 parallel groups** for faster feedback on PRs. Test files are distributed via deterministic round-robin (seeded by commit SHA).
- Each test runner **downloads the pre-built image** instead of rebuilding, then stands up its own Docker Compose stack and runs its slice of tests.

### What cannot be consolidated
Each matrix runner needs its own Docker Compose stack (Postgres, Redis, Qdrant, Vespa, Temporal, etc.) for test isolation, so pulling images and starting services still happens per-runner.

## Test plan
- [ ] Verify the build job completes and the artifact is uploaded
- [ ] Verify all 5 matrix runners download and load the image correctly
- [ ] Verify test files are split evenly (3-4 files per group for 18 files)
- [ ] Verify tests pass across all groups

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits E2E API tests into 5 parallel groups and builds the backend image once in a separate job shared across runners. This speeds PR feedback and fails fast on build issues while keeping test isolation.

- **CI Changes**
  - Add a build job to create the backend Docker image once and upload it as an artifact.
  - Test jobs depend on the build, download and load the image, and no longer rebuild locally.
  - Replace 2-way split with deterministic round-robin across 5 groups (seeded by commit SHA).
  - Remove unused Docker layer cache step.
  - Each runner still brings up its own Docker Compose stack for isolation.

<sup>Written for commit b4ae56992534570438321db118fccb2b63ebcd19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

