### PR TITLE
chore: make tests run from PR action

### DIFF
--- a/.github/workflows/test-public-api.yml
+++ b/.github/workflows/test-public-api.yml
@@ -1,7 +1,7 @@
 name: Public API Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
   push:
     branches: [main]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the Public API test workflow to trigger on pull_request instead of pull_request_target, so tests run in the PR context for main and avoid elevated permissions for better security.

<sup>Written for commit d08ced7ff62bf8c9fa9d64167e43e2789141b0c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

