### PR TITLE
fix: OCR chunk failures skip entity instead of killing entire sync 

### DIFF
--- a/backend/airweave/platform/ocr/mistral/ocr_client.py
+++ b/backend/airweave/platform/ocr/mistral/ocr_client.py
@@ -216,9 +216,14 @@ class MistralOcrClient:
                 final_results.append(r)
 
         if failed:
-            logger.error(
-                f"OCR failed for {len(failed)}/{len(chunks)} chunks: " + "; ".join(failed)
-            )
+            logger.error(f"OCR failed for {len(failed)}/{len(chunks)} chunks: " + "; ".join(failed))
+
+            # If ALL chunks failed, Mistral is likely down -- fail the sync
+            if len(failed) == len(chunks):
+                raise SyncFailureError(
+                    f"OCR failed for ALL {len(chunks)} chunks (Mistral outage?): "
+                    + "; ".join(failed)
+                )
 
         logger.debug(f"OCR batch complete: {len(final_results)}/{len(chunks)} succeeded")
         return final_results


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Continue OCR sync when some chunks fail by skipping only the affected entities. Capture real per‑chunk errors and fail fast only if every chunk in the batch fails.

- **Bug Fixes**
  - Catch exceptions inside _process_one and store them in results[idx] (no reliance on gather(return_exceptions=True)).
  - Log per-chunk errors and return partial results instead of raising.
  - Raise SyncFailureError only when all chunks fail (likely outage).

<sup>Written for commit 9efd85e52db210472617729a83194d45bb2d6717. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

