### PR TITLE
chore: deprecate Qdrant phase 1: stop writing and default to Vespa as sole vector DB

### DIFF
--- a/backend/airweave/core/config/settings.py
+++ b/backend/airweave/core/config/settings.py
@@ -127,7 +127,7 @@ class Settings(BaseSettings):
     TEXT2VEC_INFERENCE_URL: str = "http://localhost:9878"
 
     # Embedding configuration (source of truth for entire stack)
-    # Must match: provider model, Vespa schema, Qdrant collection
+    # Must match: provider model dimensions and Vespa schema
     # Common values: 384 (local), 1024 (Mistral), 1536 (OpenAI small), 3072 (OpenAI large)
     EMBEDDING_DIMENSIONS: int = 1536
 

--- a/backend/airweave/core/source_connection_service_helpers.py
+++ b/backend/airweave/core/source_connection_service_helpers.py
@@ -58,24 +58,21 @@ class SourceConnectionHelpers:
     ) -> list[UUID]:
         """Get destination connection IDs based on feature flags.
 
-        By default, writes to BOTH Qdrant and Vespa:
-        - Qdrant: Primary search destination (default for search queries)
-        - Vespa: Secondary destination (for future advanced search features)
+        Writes to Vespa as the primary (and only) vector database destination.
 
         Args:
             db: Database session
             ctx: API context with organization and feature flags
 
         Returns:
-            List of destination connection IDs (always includes Qdrant + Vespa, adds S3 if enabled)
+            List of destination connection IDs (Vespa + S3 if enabled)
         """
         from sqlalchemy import and_, select
 
         from airweave.models.connection import Connection
 
-        # Write to both Qdrant and Vespa by default
-        # TODO: Remove Qdrant once we Vespa is fully supported
-        destination_ids = [NATIVE_QDRANT_UUID, NATIVE_VESPA_UUID]
+        # Vespa is the sole vector database destination (Qdrant deprecated)
+        destination_ids = [NATIVE_VESPA_UUID]
 
         # Add S3 if feature flag enabled
         if ctx.has_feature(FeatureFlag.S3_DESTINATION):

--- a/backend/airweave/db/init_db_native.py
+++ b/backend/airweave/db/init_db_native.py
@@ -5,7 +5,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave.core.constants.reserved_ids import (
     NATIVE_NEO4J_UUID,
-    NATIVE_QDRANT_UUID,
     NATIVE_VESPA_UUID,
     RESERVED_TABLE_ENTITY_ID,
 )
@@ -17,25 +16,16 @@ async def init_db_with_native_connections(db: AsyncSession) -> None:
     """Initialize the database with native connections.
 
     Creates the built-in connections for:
-    - qdrant_native (vector database destination)
     - neo4j_native (graph database destination)
     - vespa_native (vector database destination with internal chunking/embedding)
 
-    Note: Embedding models are no longer managed as connections.
-    They are handled internally by DenseEmbedder and SparseEmbedder.
+    Note: Qdrant has been deprecated. Vespa is the sole vector database destination.
+    Embedding models are handled internally by DenseEmbedder and SparseEmbedder.
 
     These connections are system-level and don't belong to any organization.
     """
     # Check if connections already exist to avoid duplication on restarts
     native_connections = {
-        "qdrant_native": {
-            "id": NATIVE_QDRANT_UUID,
-            "name": "Native Qdrant",
-            "readable_id": "native-qdrant",
-            "integration_type": IntegrationType.DESTINATION,
-            "short_name": "qdrant_native",
-            "status": ConnectionStatus.ACTIVE,
-        },
         "neo4j_native": {
             "id": NATIVE_NEO4J_UUID,
             "name": "Native Neo4j",

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -39,20 +39,21 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-  qdrant:
-    container_name: airweave-qdrant
-    image: qdrant/qdrant:latest
-    command: bash -c "apt-get update && apt-get install -y curl && ./entrypoint.sh" # we need to install curl to check health
-    ports:
-      - "6333:6333"
-    volumes:
-      - qdrant_data:/qdrant/storage
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:6333/healthz"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-    restart: on-failure
+  # qdrant: DEPRECATED -- Vespa is the sole vector database
+  # qdrant:
+  #   container_name: airweave-qdrant
+  #   image: qdrant/qdrant:latest
+  #   command: bash -c "apt-get update && apt-get install -y curl && ./entrypoint.sh"
+  #   ports:
+  #     - "6333:6333"
+  #   volumes:
+  #     - qdrant_data:/qdrant/storage
+  #   healthcheck:
+  #     test: ["CMD", "wget", "--spider", "-q", "http://localhost:6333/healthz"]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 3
+  #   restart: on-failure
   temporal:
     container_name: airweave-temporal
     image: temporalio/auto-setup:1.24.2

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -45,18 +45,19 @@ services:
       timeout: 10s
       retries: 3
 
-  qdrant:
-    image: qdrant/qdrant:latest
-    command: bash -c "apt-get update && apt-get install -y curl && ./entrypoint.sh" # we need to install curl to check health
-    ports:
-      - "9333:6333"
-    volumes:
-      - qdrant_data:/qdrant/storage
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:6333/healthz" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+  # qdrant: DEPRECATED -- Vespa is the sole vector database
+  # qdrant:
+  #   image: qdrant/qdrant:latest
+  #   command: bash -c "apt-get update && apt-get install -y curl && ./entrypoint.sh"
+  #   ports:
+  #     - "9333:6333"
+  #   volumes:
+  #     - qdrant_data:/qdrant/storage
+  #   healthcheck:
+  #     test: [ "CMD", "curl", "-f", "http://localhost:6333/healthz" ]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 5
 
   svix:
     image: svix/svix-server
@@ -89,8 +90,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-      qdrant:
-        condition: service_healthy
       svix:
         condition: service_healthy
 
@@ -98,8 +97,7 @@ services:
     environment:
       - DATABASE_URL=postgresql+asyncpg://airweave:airweave1234!@postgres:5432/airweave
       - REDIS_HOST=redis
-      - QDRANT_HOST=qdrant
-      - QDRANT_PORT=6333
+      - SYNC_CONFIG__DESTINATIONS__SKIP_QDRANT=true
       - TESTING=true
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,11 +64,11 @@ services:
       # Override any localhost references for container networking
       - POSTGRES_HOST=postgres
       - REDIS_HOST=redis
-      - QDRANT_HOST=qdrant
-      - QDRANT_PORT=6333
       - TEXT2VEC_INFERENCE_URL=http://text2vec-transformers:8080
       - VESPA_URL=http://vespa
       - VESPA_PORT=8081
+      # Qdrant deprecated -- skip by default
+      - SYNC_CONFIG__DESTINATIONS__SKIP_QDRANT=true
       # Environment configuration (can be overridden in .env)
       - ENVIRONMENT=${ENVIRONMENT:-local}
       - LOCAL_DEVELOPMENT=${LOCAL_DEVELOPMENT:-true}
@@ -86,8 +86,6 @@ services:
       postgres:
         condition: service_healthy
       redis:
-        condition: service_healthy
-      qdrant:
         condition: service_healthy
       svix:
         condition: service_healthy
@@ -141,20 +139,22 @@ services:
       retries: 3
     restart: on-failure
 
-  qdrant:
-    container_name: airweave-qdrant
-    image: qdrant/qdrant:latest
-    command: bash -c "apt-get update && apt-get install -y curl && ./entrypoint.sh" # we need to install curl to check health
-    ports:
-      - "6333:6333"
-    volumes:
-      - qdrant_data:/qdrant/storage
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:6333/healthz" ]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-    restart: on-failure
+  # qdrant: DEPRECATED -- Vespa is the sole vector database
+  # To re-enable for rollback, uncomment and add depends_on to backend/worker
+  # qdrant:
+  #   container_name: airweave-qdrant
+  #   image: qdrant/qdrant:latest
+  #   command: bash -c "apt-get update && apt-get install -y curl && ./entrypoint.sh"
+  #   ports:
+  #     - "6333:6333"
+  #   volumes:
+  #     - qdrant_data:/qdrant/storage
+  #   healthcheck:
+  #     test: [ "CMD", "curl", "-f", "http://localhost:6333/healthz" ]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 3
+  #   restart: on-failure
 
   temporal:
     container_name: airweave-temporal
@@ -205,11 +205,11 @@ services:
       # Override any localhost references for container networking
       - POSTGRES_HOST=postgres
       - REDIS_HOST=redis
-      - QDRANT_HOST=qdrant
-      - QDRANT_PORT=6333
       - TEXT2VEC_INFERENCE_URL=http://text2vec-transformers:8080
       - VESPA_URL=http://vespa
       - VESPA_PORT=8081
+      # Qdrant deprecated -- skip by default
+      - SYNC_CONFIG__DESTINATIONS__SKIP_QDRANT=true
       # Environment configuration (can be overridden in .env)
       - ENVIRONMENT=${ENVIRONMENT:-local}
       - LOCAL_DEVELOPMENT=${LOCAL_DEVELOPMENT:-true}

--- a/frontend/src/components/S3ConfigModal.tsx
+++ b/frontend/src/components/S3ConfigModal.tsx
@@ -486,7 +486,7 @@ export function S3ConfigModal({ isOpen, onClose, onSuccess }: S3ConfigModalProps
                   </div>
                 </div>
                 <p className="text-xs text-muted-foreground pt-2 border-t border-border/30">
-                  Once configured, all future syncs will automatically write data to both Qdrant
+                  Once configured, all future syncs will automatically write data to both Vespa
                   (for search) and your S3 bucket (in ARF format).
                 </p>
               </div>

--- a/frontend/src/pages/admin/SyncsTab.tsx
+++ b/frontend/src/pages/admin/SyncsTab.tsx
@@ -49,7 +49,6 @@ interface SyncInfo {
     source_is_authenticated?: boolean;
     total_entity_count?: number;
     total_arf_entity_count?: number;
-    total_qdrant_entity_count?: number;
     total_vespa_entity_count?: number;
     last_job_status?: string;
     last_job_at?: string;
@@ -310,7 +309,7 @@ export function SyncsTab() {
 
     const handleBulkDelete = async () => {
         const selected = getSelectedSyncsDetails();
-        const confirmMessage = `⚠️ DELETE ${selected.length} SYNC(S)?\n\nThis will permanently delete ALL data including:\n• Qdrant and Vespa data\n• ARF storage\n• All jobs and schedules\n\n⚠️ THIS CANNOT BE UNDONE!\n\nType DELETE to confirm:`;
+        const confirmMessage = `⚠️ DELETE ${selected.length} SYNC(S)?\n\nThis will permanently delete ALL data including:\n• Vespa data\n• ARF storage\n• All jobs and schedules\n\n⚠️ THIS CANNOT BE UNDONE!\n\nType DELETE to confirm:`;
 
         const userInput = prompt(confirmMessage);
         if (userInput !== 'DELETE') {
@@ -385,7 +384,7 @@ export function SyncsTab() {
     };
 
     const handleDeleteSync = async (syncId: string, syncName: string) => {
-        const confirmMessage = `⚠️ DELETE SYNC: "${syncName}"?\n\nThis will permanently delete:\n• The sync and all its data\n• All jobs and schedules\n• Data from Qdrant and Vespa\n• ARF storage\n• Postgres records\n\n⚠️ THIS CANNOT BE UNDONE!\n\nType DELETE to confirm:`;
+        const confirmMessage = `⚠️ DELETE SYNC: "${syncName}"?\n\nThis will permanently delete:\n• The sync and all its data\n• All jobs and schedules\n• Data from Vespa\n• ARF storage\n• Postgres records\n\n⚠️ THIS CANNOT BE UNDONE!\n\nType DELETE to confirm:`;
 
         const userInput = prompt(confirmMessage);
 
@@ -656,7 +655,7 @@ export function SyncsTab() {
                                 htmlFor="destination-counts-filter"
                                 className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
                             >
-                                Include Destination Counts (Qdrant/Vespa - slower)
+                                Include Destination Counts (Vespa - slower)
                             </Label>
                         </div>
                         <div className="flex items-center space-x-2">
@@ -909,10 +908,6 @@ export function SyncsTab() {
                                                             <span>{sync.total_arf_entity_count !== null && sync.total_arf_entity_count !== undefined ? formatNumber(sync.total_arf_entity_count) : '-'}</span>
                                                         </div>
                                                         <div className="flex items-center gap-2">
-                                                            <span className="text-muted-foreground">Qdrant:</span>
-                                                            <span>{sync.total_qdrant_entity_count !== null && sync.total_qdrant_entity_count !== undefined ? formatNumber(sync.total_qdrant_entity_count) : '-'}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-2">
                                                             <span className="text-muted-foreground">Vespa:</span>
                                                             <span>{sync.total_vespa_entity_count !== null && sync.total_vespa_entity_count !== undefined ? formatNumber(sync.total_vespa_entity_count) : '-'}</span>
                                                         </div>
@@ -1086,22 +1081,6 @@ export function SyncsTab() {
                         <div className="space-y-3">
                             <h3 className="text-sm font-semibold">Destination Toggles</h3>
                             <div className="space-y-2">
-                                <div className="flex items-center space-x-2">
-                                    <Checkbox
-                                        id="skip-qdrant"
-                                        checked={resyncConfig.destinations?.skip_qdrant || false}
-                                        onCheckedChange={(checked) => {
-                                            setSelectedPreset('custom');
-                                            setResyncConfig({
-                                                ...resyncConfig,
-                                                destinations: { ...resyncConfig.destinations, skip_qdrant: checked as boolean },
-                                            });
-                                        }}
-                                    />
-                                    <Label htmlFor="skip-qdrant" className="text-sm cursor-pointer">
-                                        Skip Qdrant
-                                    </Label>
-                                </div>
                                 <div className="flex items-center space-x-2">
                                     <Checkbox
                                         id="skip-vespa"
@@ -1369,22 +1348,6 @@ export function SyncsTab() {
                         <div className="space-y-3">
                             <h3 className="text-sm font-semibold">Destination Toggles</h3>
                             <div className="space-y-2">
-                                <div className="flex items-center space-x-2">
-                                    <Checkbox
-                                        id="bulk-skip-qdrant"
-                                        checked={resyncConfig.destinations?.skip_qdrant || false}
-                                        onCheckedChange={(checked) => {
-                                            setSelectedPreset('custom');
-                                            setResyncConfig({
-                                                ...resyncConfig,
-                                                destinations: { ...resyncConfig.destinations, skip_qdrant: checked as boolean },
-                                            });
-                                        }}
-                                    />
-                                    <Label htmlFor="bulk-skip-qdrant" className="text-sm cursor-pointer">
-                                        Skip Qdrant
-                                    </Label>
-                                </div>
                                 <div className="flex items-center space-x-2">
                                     <Checkbox
                                         id="bulk-skip-vespa"

--- a/frontend/src/types/sync-config.ts
+++ b/frontend/src/types/sync-config.ts
@@ -37,7 +37,7 @@ export interface SyncConfig {
 /**
  * Preset configurations matching backend factory methods
  */
-export type SyncPreset = 'default' | 'arf_capture_only' | 'replay_from_arf' | 'qdrant_only' | 'vespa_only' | 'custom';
+export type SyncPreset = 'default' | 'arf_capture_only' | 'replay_from_arf' | 'vespa_only' | 'custom';
 
 export interface PresetDefinition {
     id: SyncPreset;
@@ -50,9 +50,9 @@ export const SYNC_PRESETS: PresetDefinition[] = [
     {
         id: 'default',
         label: 'Default (Normal Sync)',
-        description: 'Standard sync to all destinations with all handlers enabled',
+        description: 'Standard sync to Vespa with all handlers enabled',
         config: {
-            destinations: { skip_qdrant: false, skip_vespa: false },
+            destinations: { skip_qdrant: true, skip_vespa: false },
             handlers: { enable_vector_handlers: true, enable_raw_data_handler: true, enable_postgres_handler: true },
             cursor: { skip_load: false, skip_updates: false },
             behavior: { skip_hash_comparison: false, replay_from_arf: false },
@@ -79,17 +79,9 @@ export const SYNC_PRESETS: PresetDefinition[] = [
         },
     },
     {
-        id: 'qdrant_only',
-        label: 'Qdrant Only',
-        description: 'Sync to Qdrant only, skip Vespa',
-        config: {
-            destinations: { skip_vespa: true, skip_qdrant: false },
-        },
-    },
-    {
         id: 'vespa_only',
         label: 'Vespa Only',
-        description: 'Sync to Vespa only, skip Qdrant',
+        description: 'Sync to Vespa only (default destination)',
         config: {
             destinations: { skip_qdrant: true, skip_vespa: false },
         },

--- a/monke/core/steps.py
+++ b/monke/core/steps.py
@@ -419,7 +419,7 @@ def _search_limit_from_config(config: TestConfig, default: int = 50) -> int:
 
 
 class VerifyStep(TestStep):
-    """Verify data in Qdrant step."""
+    """Verify data in vector database step."""
 
     async def execute(self) -> None:
         self.logger.info("=" * 80)
@@ -451,8 +451,8 @@ class VerifyStep(TestStep):
             )
             return entity, ok
 
-        # Add a wait after sync completion to allow Qdrant indexing
-        self.logger.info("⏳ Waiting 10s for Qdrant indexing to complete...")
+        # Add a wait after sync completion to allow vector database indexing
+        self.logger.info("⏳ Waiting 10s for vector database indexing to complete...")
         await asyncio.sleep(10)
 
         # Retry support + optional one-time rescue resync
@@ -500,7 +500,7 @@ class VerifyStep(TestStep):
         for entity, ok in results:
             if not ok:
                 errors.append(
-                    f"Entity {self._display_name(entity)} not found in Qdrant"
+                    f"Entity {self._display_name(entity)} not found in vector database"
                 )
             else:
                 verified_count += 1
@@ -604,7 +604,7 @@ class PartialDeleteStep(TestStep):
 
 
 class VerifyPartialDeletionStep(TestStep):
-    """Verify that partially deleted entities are removed from Qdrant."""
+    """Verify that partially deleted entities are removed from vector database."""
 
     async def execute(self) -> None:
         self.logger.info("🔍 Verifying partial deletion")
@@ -647,11 +647,11 @@ class VerifyPartialDeletionStep(TestStep):
         for entity, is_removed in results:
             if not is_removed:
                 errors.append(
-                    f"Entity {self._display_name(entity)} still exists in Qdrant after deletion"
+                    f"Entity {self._display_name(entity)} still exists in vector database after deletion"
                 )
             else:
                 self.logger.info(
-                    f"✅ Entity {self._display_name(entity)} confirmed removed from Qdrant"
+                    f"✅ Entity {self._display_name(entity)} confirmed removed from vector database"
                 )
 
         if errors:
@@ -661,7 +661,7 @@ class VerifyPartialDeletionStep(TestStep):
 
 
 class VerifyRemainingEntitiesStep(TestStep):
-    """Verify that remaining entities are still present in Qdrant."""
+    """Verify that remaining entities are still present in vector database."""
 
     async def execute(self) -> None:
         self.logger.info("🔍 Verifying remaining entities are still present")
@@ -696,11 +696,11 @@ class VerifyRemainingEntitiesStep(TestStep):
         for entity, is_present in results:
             if not is_present:
                 errors.append(
-                    f"Entity {self._display_name(entity)} was incorrectly removed from Qdrant"
+                    f"Entity {self._display_name(entity)} was incorrectly removed from vector database"
                 )
             else:
                 self.logger.info(
-                    f"✅ Entity {self._display_name(entity)} confirmed still present in Qdrant"
+                    f"✅ Entity {self._display_name(entity)} confirmed still present in vector database"
                 )
 
         if errors:
@@ -732,7 +732,7 @@ class CompleteDeleteStep(TestStep):
 
 
 class VerifyCompleteDeletionStep(TestStep):
-    """Verify that all test entities are completely removed from Qdrant."""
+    """Verify that all test entities are completely removed from vector database."""
 
     async def execute(self) -> None:
         self.logger.info("🔍 Verifying complete deletion")
@@ -770,7 +770,7 @@ class VerifyCompleteDeletionStep(TestStep):
                 self.logger.warning(
                     f"⚠️ Entity {self._display_name(entity)} still found with token: {expected_token}"
                 )
-                # Do a more detailed search to see what's in Qdrant
+                # Do a more detailed search to see what's in vector database
                 try:
                     results = await _search_collection_async(
                         client, self.context.collection_readable_id, expected_token, 5
@@ -778,7 +778,7 @@ class VerifyCompleteDeletionStep(TestStep):
                     for r in results[:2]:  # Show first 2 results
                         # New structure: id and name are at top level
                         self.logger.info(
-                            f"   Found in Qdrant: id={r.get('id')}, name={r.get('name')}"
+                            f"   Found in vector DB: id={r.get('id')}, name={r.get('name')}"
                         )
                 except Exception as e:
                     self.logger.debug(f"Could not get detailed results: {e}")
@@ -791,11 +791,11 @@ class VerifyCompleteDeletionStep(TestStep):
         for entity, is_removed in results:
             if not is_removed:
                 errors.append(
-                    f"Entity {self._display_name(entity)} still exists in Qdrant after complete deletion"
+                    f"Entity {self._display_name(entity)} still exists in vector database after complete deletion"
                 )
             else:
                 self.logger.info(
-                    f"✅ Entity {self._display_name(entity)} confirmed removed from Qdrant"
+                    f"✅ Entity {self._display_name(entity)} confirmed removed from vector database"
                 )
 
         if errors:
@@ -807,10 +807,10 @@ class VerifyCompleteDeletionStep(TestStep):
         )
         if not collection_empty:
             self.logger.warning(
-                "⚠️ Qdrant collection still contains some data (may be metadata entities)"
+                "⚠️ Collection still contains some data (may be metadata entities)"
             )
         else:
-            self.logger.info("✅ Qdrant collection confirmed empty of test data")
+            self.logger.info("✅ Collection confirmed empty of test data")
 
         self.logger.info("✅ Complete deletion verification completed")
 


### PR DESCRIPTION
Phase 1: Stop Writing to Qdrant

- Change skip_qdrant default from False to True in DestinationConfig
- Remove NATIVE_QDRANT_UUID from default destination_ids list (keep only NATIVE_VESPA_UUID)
- Make QDRANT_HOST / QDRANT_PORT optional with None default
- Skip inserting the native Qdrant connection row on startup (guard with if not skip_qdrant)

Frontend:
- Remove total_qdrant_entity_count from SyncInfo interface
- Remove the "Qdrant:" row in entity counts display (lines 911-913)
- Update bulk delete confirmation text (line 313) and single delete confirmation (line 388) to drop "Qdrant"
- Remove "Skip Qdrant" checkbox from both single and bulk resync dialogs
- Remove qdrant_filter event handling and Qdrant-specific comments
- Update help text to remove Qdrant mention

Monke:
- Replace all "Qdrant" string literals in docstrings, error messages, and log messages with "vector database". No functional changes needed (verification goes through the Airweave search API, not Qdrant directly).

Docker:
- Comment out qdrant service, remove depends_on: qdrant from backend, keep env vars temporarily

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecate Qdrant (phase 1): stop writing to Qdrant and make Vespa the sole vector DB by default. Updates backend config, UI copy, and Docker to reflect the change while keeping an easy rollback path.

- **Refactors**
  - Backend: default skip_qdrant=true; destinations now include only Vespa (+S3 if enabled); QDRANT_HOST/PORT optional; skip inserting native Qdrant on startup; validation updated; removed qdrant_only preset method; comments updated.
  - Frontend: removed Qdrant counts and toggles; updated confirmations and help text to reference Vespa only; default presets now target Vespa; SearchResponse handles generic filter events (qdrant_filter or vespa_filter).
  - Docker: commented out qdrant service in all compose files and removed depends_on; set SYNC_CONFIG__DESTINATIONS__SKIP_QDRANT=true for backend/worker; kept Qdrant env vars temporarily.
  - Monke: replaced “Qdrant” strings with “vector database”; no functional changes.

- **Migration**
  - Compose users: no action required; Vespa must be running; Qdrant is disabled by default.
  - External deploys: set SYNC_CONFIG__DESTINATIONS__SKIP_QDRANT=true and ensure VESPA_URL/PORT are set; QDRANT_HOST/PORT can be unset.
  - Rollback (if needed): uncomment the qdrant service and restore depends_on/env vars; flip the skip_qdrant flag to false.

<sup>Written for commit 3a395730a2a978cf1dcdc9b4288e1b5751c6d4b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

