### PR TITLE
chore: deprecate Qdrant phase 2: remove from DB, migration, UUID cleanup, and OpenAPI spec

### DIFF
--- a/backend/airweave/core/constants/reserved_ids.py
+++ b/backend/airweave/core/constants/reserved_ids.py
@@ -3,12 +3,10 @@
 import uuid
 
 # Native connection UUIDs - these must match the ones in init_db_native.py
-NATIVE_QDRANT_UUID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 NATIVE_NEO4J_UUID = uuid.UUID("22222222-2222-2222-2222-222222222222")
 NATIVE_VESPA_UUID = uuid.UUID("33333333-3333-3333-3333-333333333333")
 
 # String versions for use in frontend code or string contexts
-NATIVE_QDRANT_UUID_STR = str(NATIVE_QDRANT_UUID)
 NATIVE_NEO4J_UUID_STR = str(NATIVE_NEO4J_UUID)
 NATIVE_VESPA_UUID_STR = str(NATIVE_VESPA_UUID)
 

--- a/backend/airweave/core/source_connection_service_helpers.py
+++ b/backend/airweave/core/source_connection_service_helpers.py
@@ -17,7 +17,6 @@ from airweave.api.context import ApiContext
 from airweave.core import credentials
 from airweave.core.config import settings as core_settings
 from airweave.core.constants.reserved_ids import (
-    NATIVE_QDRANT_UUID,
     NATIVE_VESPA_UUID,
 )
 from airweave.core.shared_models import (
@@ -107,7 +106,7 @@ class SourceConnectionHelpers:
     ) -> None:
         """Validate that new source uses same destination as existing sources.
 
-        Prevents mixing Qdrant and Vespa destinations within the same collection.
+        Ensures all sources in a collection write to the same vector database.
 
         Args:
             db: Database session
@@ -142,24 +141,14 @@ class SourceConnectionHelpers:
             if not existing_dest_ids:
                 continue
 
-            # Check if using Qdrant or Vespa
+            # Check Vespa consistency
             existing_uses_vespa = NATIVE_VESPA_UUID in existing_dest_ids
-            existing_uses_qdrant = NATIVE_QDRANT_UUID in existing_dest_ids
-
             new_uses_vespa = NATIVE_VESPA_UUID in new_destination_ids
-            new_uses_qdrant = NATIVE_QDRANT_UUID in new_destination_ids
 
             if existing_uses_vespa and not new_uses_vespa:
                 raise HTTPException(
                     status_code=400,
                     detail=f"Collection '{collection_readable_id}' uses Vespa destination. "
-                    "Cannot add source with a different destination.",
-                )
-
-            if existing_uses_qdrant and not new_uses_qdrant:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Collection '{collection_readable_id}' uses Qdrant destination. "
                     "Cannot add source with a different destination.",
                 )
 

--- a/backend/airweave/platform/builders/destinations.py
+++ b/backend/airweave/platform/builders/destinations.py
@@ -16,7 +16,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from airweave import crud, schemas
 from airweave.core import credentials
 from airweave.core.constants.reserved_ids import (
-    NATIVE_QDRANT_UUID,
     NATIVE_VESPA_UUID,
     RESERVED_TABLE_ENTITY_ID,
 )
@@ -125,9 +124,7 @@ class DestinationsContextBuilder:
             List of destination instances ready for deletion operations.
         """
         # Map native UUIDs to their creator methods
-        # TODO: Add other flexible destination building here for future Vespa deployments
         native_creators = {
-            NATIVE_QDRANT_UUID: cls._create_native_qdrant,
             NATIVE_VESPA_UUID: cls._create_native_vespa,
         }
 
@@ -206,10 +203,6 @@ class DestinationsContextBuilder:
         logger: ContextualLogger,
     ) -> Optional[BaseDestination]:
         """Create a single destination instance."""
-        # Special case: Native Qdrant
-        if destination_connection_id == NATIVE_QDRANT_UUID:
-            return await cls._create_native_qdrant(db, collection, logger)
-
         # Special case: Native Vespa
         if destination_connection_id == NATIVE_VESPA_UUID:
             return await cls._create_native_vespa(db, collection, logger)
@@ -401,9 +394,7 @@ class DestinationsContextBuilder:
             exclusions.update(execution_config.destinations.exclude_destinations)
 
         # Add native vector DB exclusions from boolean flags
-        if execution_config.destinations.skip_qdrant:
-            exclusions.add(NATIVE_QDRANT_UUID)
-            logger.info("Excluding native Qdrant (skip_qdrant=True)")
+        # Note: skip_qdrant is always True (Qdrant deprecated), no UUID to exclude
 
         if execution_config.destinations.skip_vespa:
             exclusions.add(NATIVE_VESPA_UUID)

--- a/backend/alembic/versions/q3r4s5t6u7v8_remove_qdrant_native_destination.py
+++ b/backend/alembic/versions/q3r4s5t6u7v8_remove_qdrant_native_destination.py
@@ -1,0 +1,82 @@
+"""Remove Qdrant native destination from all syncs and connections.
+
+Revision ID: q3r4s5t6u7v8
+Revises: p2q3r4s5t6u7
+Create Date: 2026-02-09 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "q3r4s5t6u7v8"
+down_revision = "p2q3r4s5t6u7"
+branch_labels = None
+depends_on = None
+
+# Native destination connection UUIDs (must match core/constants/reserved_ids.py)
+QDRANT_CONNECTION_ID = "11111111-1111-1111-1111-111111111111"
+VESPA_CONNECTION_ID = "33333333-3333-3333-3333-333333333333"
+
+
+def upgrade():
+    """Remove all Qdrant sync_connection rows and the native Qdrant connection.
+
+    Phase 2 of Qdrant deprecation: after Phase 1 stopped all writes to Qdrant,
+    this migration cleans up the database references.
+    """
+    # 1. Remove all sync_connection rows pointing to the native Qdrant destination
+    op.execute(f"""
+        DELETE FROM sync_connection
+        WHERE connection_id = '{QDRANT_CONNECTION_ID}'::uuid;
+    """)
+
+    # 2. Remove the native Qdrant connection row itself
+    op.execute(f"""
+        DELETE FROM connection
+        WHERE id = '{QDRANT_CONNECTION_ID}'::uuid
+          AND short_name = 'qdrant_native';
+    """)
+
+
+def downgrade():
+    """Re-insert the native Qdrant connection and restore sync_connection rows.
+
+    Restores Qdrant as a destination for all syncs that currently have Vespa,
+    matching the state before Phase 2 deprecation.
+    """
+    # 1. Re-insert the native Qdrant connection
+    op.execute(f"""
+        INSERT INTO connection (id, name, readable_id, integration_type, short_name, status, created_at, modified_at)
+        VALUES (
+            '{QDRANT_CONNECTION_ID}'::uuid,
+            'Native Qdrant',
+            'native-qdrant',
+            'DESTINATION',
+            'qdrant_native',
+            'ACTIVE',
+            NOW(),
+            NOW()
+        )
+        ON CONFLICT (id) DO NOTHING;
+    """)
+
+    # 2. Re-insert sync_connection rows for all syncs that have Vespa
+    #    (mirrors the state before deprecation when all syncs had both)
+    op.execute(f"""
+        INSERT INTO sync_connection (id, sync_id, connection_id, created_at, modified_at)
+        SELECT
+            gen_random_uuid(),
+            sc.sync_id,
+            '{QDRANT_CONNECTION_ID}'::uuid,
+            NOW(),
+            NOW()
+        FROM sync_connection sc
+        WHERE sc.connection_id = '{VESPA_CONNECTION_ID}'::uuid
+          AND NOT EXISTS (
+            SELECT 1
+            FROM sync_connection sc2
+            WHERE sc2.sync_id = sc.sync_id
+              AND sc2.connection_id = '{QDRANT_CONNECTION_ID}'::uuid
+          );
+    """)

--- a/fern/definition/openapi.json
+++ b/fern/definition/openapi.json
@@ -2343,7 +2343,6 @@
       "AdminSearchDestination": {
         "type": "string",
         "enum": [
-          "qdrant",
           "vespa"
         ],
         "title": "AdminSearchDestination",
@@ -2502,17 +2501,6 @@
               }
             ],
             "title": "Total Arf Entity Count"
-          },
-          "total_qdrant_entity_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Qdrant Entity Count"
           },
           "total_vespa_entity_count": {
             "anyOf": [
@@ -4293,12 +4281,6 @@
       },
       "DestinationConfig": {
         "properties": {
-          "skip_qdrant": {
-            "type": "boolean",
-            "title": "Skip Qdrant",
-            "description": "Skip writing to native Qdrant",
-            "default": false
-          },
           "skip_vespa": {
             "type": "boolean",
             "title": "Skip Vespa",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Completes phase 2 of Qdrant deprecation: removes Qdrant from the DB and code, and updates the OpenAPI spec to reflect Vespa-only support.

- **Migration**
  - Delete all sync_connection rows for Qdrant.
  - Delete the native Qdrant connection.
  - Downgrade restores the Qdrant connection and sync mappings for Vespa-backed syncs.

- **Refactors**
  - Remove Qdrant UUID/constants from reserved_ids.
  - Remove Qdrant handling from destination builders and cleanup paths.
  - Update destination validation to keep all sources on the same vector DB (Vespa).
  - OpenAPI: drop "qdrant" from AdminSearchDestination; remove total_qdrant_entity_count and skip_qdrant.

<sup>Written for commit ba5c2e45eb213d974a9b35ff92803301e8a28f8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

