### PR TITLE
fix: cap file downloads at 200MB with three layers of protection

### DIFF
--- a/backend/airweave/platform/sources/google_drive.py
+++ b/backend/airweave/platform/sources/google_drive.py
@@ -919,6 +919,15 @@ class GoogleDriveSource(BaseSource):
             self.logger.debug(f"Skipping video file ({mime_type}): {file_name}")
             return None
 
+        # Skip files larger than 200MB using metadata from the listing API
+        MAX_FILE_SIZE_BYTES = 200 * 1024 * 1024
+        file_size = int(file_obj["size"]) if file_obj.get("size") else 0
+        if file_size > MAX_FILE_SIZE_BYTES:
+            file_name = file_obj.get("name", "unknown")
+            size_mb = file_size / (1024 * 1024)
+            self.logger.info(f"Skipping oversized file ({size_mb:.1f}MB, max 200MB): {file_name}")
+            return None
+
         # Create download URL based on file type
         download_url = None
 


### PR DESCRIPTION
1. Google Drive source: skip files >200MB using API metadata before any download starts (file_obj["size"] from listing response)

2. FileService: check Content-Length header from GET response before reading the body (catches oversized files even when HEAD failed)

3. FileService: track bytes written during streaming download and abort if limit exceeded (catches files with no Content-Length, e.g. chunked transfer encoding)

Also reduce MAX_FILE_SIZE_BYTES from 1GB to 200MB. The previous 1GB limit was effectively dead code because it relied on a HEAD request that silently fell through to download on any failure.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce a 200MB max file size with three safeguards to prevent oversized downloads and wasted bandwidth. Skips large Google Drive files early and blocks over-limit files before and during streaming.

- **Bug Fixes**
  - Skip >200MB Google Drive files using listing metadata.
  - On GET, block when Content-Length exceeds the limit.
  - During streaming, abort when bytes exceed the limit.
  - Lower MAX_FILE_SIZE_BYTES from 1GB to 200MB.

<sup>Written for commit cc5876abfcf102215cd49156831ac587f45ca040. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



