### PR TITLE
docs: update section title from "OpenClaw listing" to "OpenClaw Skill…

### DIFF
--- a/fern/docs/pages/skills.mdx
+++ b/fern/docs/pages/skills.mdx
@@ -95,7 +95,7 @@ Skills work with MCP tools, code execution, and as guided instructions depending
 
 ---
 
-## OpenClaw listing
+## OpenClaw Skill
 
 Airweave is also listed on [OpenClaw](https://clawhub.ai/lennertjansen/airweave), a community directory for AI agent tools and integrations. The OpenClaw listing provides an alternative way to discover and evaluate Airweave's capabilities for your agent workflows.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the "OpenClaw listing" section to "OpenClaw Skill" on the Skills page to improve clarity and match terminology. No content changes.

<sup>Written for commit 37661ac30115166d96045e425a68de70582bc2aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

