### PR TITLE
Docs: actualize Cursor's connectors doc reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,9 +108,9 @@ Adding a source with Cursor should be pretty easy. Follow these steps to automat
 4. **Explain your integration plan to Cursor Agent**
    - Describe what you want your Cursor Agent to do.
    - Reference the newly added API reference or OpenAPI spec: `@your-docs` or `@your-openapi-spec`
-   - Also reference our Cursor rules with `@source-integration-rules.mdc`
+   - Also reference our Cursor rules with `@connector-development-end-to-end.mdc`
 
-   Example: `Write the source integration for Microsoft Teams with (@microsoft-teams-docs) and @source-integration-rules.mdc`
+   Example: `Write the source integration for Microsoft Teams with (@microsoft-teams-docs) and @connector-development-end-to-end.mdc`
 
 5. **Let Cursor generate the integration code**
    - Cursor will help generate both the entity schemas and source connector code


### PR DESCRIPTION
The `@source-integration-rules.mdc` has been replaced with `@connector-development-end-to-end.mdc`. I was told the entire CONTRIBUTING manual is kinda outdated, sending the patch just in case anyways

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated CONTRIBUTING.md to replace @source-integration-rules.mdc with @connector-development-end-to-end.mdc in the Cursor integration steps. Keeps the reference and example current so contributors use the correct doc in prompts.

<sup>Written for commit dbe7cc3836646a6167ff36f978d3fc620bc5d8f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

