### PR TITLE
ENG-2096: Implement `fireflies` connector

### DIFF
--- a/backend/airweave/platform/auth/yaml/dev.integrations.yaml
+++ b/backend/airweave/platform/auth/yaml/dev.integrations.yaml
@@ -425,3 +425,5 @@ integrations:
       prompt: "consent"
 
   qdrant:
+
+  fireflies:

--- a/backend/airweave/platform/configs/auth.py
+++ b/backend/airweave/platform/configs/auth.py
@@ -343,6 +343,13 @@ class DropboxAuthConfig(OAuth2BYOCAuthConfig):
     # Inherits client_id, client_secret, refresh_token and access_token from OAuth2BYOCAuthConfig
 
 
+class FirefliesAuthConfig(APIKeyAuthConfig):
+    """Fireflies authentication credentials schema.
+
+    API key from https://app.fireflies.ai/integrations (API & Webhooks).
+    """
+
+
 class ElasticsearchAuthConfig(AuthConfig):
     """Elasticsearch authentication credentials schema."""
 

--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -91,6 +91,16 @@ class DropboxConfig(SourceConfig):
     """Dropbox configuration schema."""
 
 
+class FirefliesConfig(SourceConfig):
+    """Fireflies configuration schema.
+
+    Syncs meeting transcripts (mine: true) from the Fireflies GraphQL API.
+    No additional config required for basic sync.
+    """
+
+    pass
+
+
 class ElasticsearchConfig(SourceConfig):
     """Elasticsearch configuration schema."""
 

--- a/backend/airweave/platform/entities/__init__.py
+++ b/backend/airweave/platform/entities/__init__.py
@@ -4,6 +4,7 @@ Contains entity schemas for various data sources and destinations.
 """
 
 from ._base import AccessControl, BaseEntity, Breadcrumb, CodeFileEntity, FileEntity
+from .fireflies import FirefliesTranscriptEntity
 from .github import (
     GitHubCodeFileEntity,
     GithubContentEntity,
@@ -25,6 +26,7 @@ __all__ = [
     "Breadcrumb",
     "CodeFileEntity",
     "FileEntity",
+    "FirefliesTranscriptEntity",
     "GitHubCodeFileEntity",
     "GitHubDirectoryEntity",
     "GitHubFileDeletionEntity",

--- a/backend/airweave/platform/entities/fireflies.py
+++ b/backend/airweave/platform/entities/fireflies.py
@@ -1,0 +1,97 @@
+"""Entity schemas for Fireflies.
+
+Based on the Fireflies GraphQL API (Transcript schema). We sync meeting transcripts
+as searchable entities with title, organizer, participants, summary, and sentence-level
+content.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import computed_field
+
+from airweave.platform.entities._airweave_field import AirweaveField
+from airweave.platform.entities._base import BaseEntity
+
+
+class FirefliesTranscriptEntity(BaseEntity):
+    """Schema for a Fireflies meeting transcript.
+
+    Maps to the Transcript type in the Fireflies GraphQL API.
+    See https://docs.fireflies.ai/schema/transcript
+    """
+
+    transcript_id: str = AirweaveField(
+        ..., description="Unique identifier of the transcript.", is_entity_id=True
+    )
+    title: str = AirweaveField(
+        ..., description="Title of the meeting/transcript.", embeddable=True, is_name=True
+    )
+    organizer_email: Optional[str] = AirweaveField(
+        None, description="Email address of the meeting organizer.", embeddable=True
+    )
+    transcript_url: Optional[str] = AirweaveField(
+        None,
+        description="URL to view the transcript in the Fireflies dashboard.",
+        embeddable=False,
+        unhashable=True,
+    )
+    participants: List[str] = AirweaveField(
+        default_factory=list,
+        description="Email addresses of meeting participants.",
+        embeddable=True,
+    )
+    duration: Optional[float] = AirweaveField(
+        None, description="Duration of the audio in minutes.", embeddable=True
+    )
+    date: Optional[float] = AirweaveField(
+        None,
+        description="Date the transcript was created (milliseconds since epoch, UTC).",
+        embeddable=False,
+    )
+    date_string: Optional[str] = AirweaveField(
+        None,
+        description="ISO 8601 date-time string when the transcript was created.",
+        embeddable=True,
+    )
+    created_time: Optional[datetime] = AirweaveField(
+        None,
+        description="Parsed creation timestamp for the transcript.",
+        is_created_at=True,
+        embeddable=True,
+    )
+    speakers: List[Dict[str, Any]] = AirweaveField(
+        default_factory=list,
+        description="Speakers in the transcript (id, name).",
+        embeddable=True,
+    )
+    summary_overview: Optional[str] = AirweaveField(
+        None,
+        description="AI-generated summary overview of the meeting.",
+        embeddable=True,
+    )
+    summary_keywords: List[str] = AirweaveField(
+        default_factory=list,
+        description="Keywords extracted from the meeting.",
+        embeddable=True,
+    )
+    summary_action_items: Optional[List[str]] = AirweaveField(
+        None,
+        description="Action items from the meeting summary.",
+        embeddable=True,
+    )
+    content: Optional[str] = AirweaveField(
+        None,
+        description="Full transcript text (concatenated sentences) for search.",
+        embeddable=True,
+    )
+    fireflies_users: List[str] = AirweaveField(
+        default_factory=list,
+        description="Emails of Fireflies users who participated.",
+        embeddable=True,
+    )
+
+    @computed_field(return_type=str)
+    def web_url(self) -> str:
+        """User-facing link to the transcript in Fireflies."""
+        return self.transcript_url or ""

--- a/backend/airweave/platform/sources/fireflies.py
+++ b/backend/airweave/platform/sources/fireflies.py
@@ -1,0 +1,237 @@
+"""Fireflies source implementation.
+
+Syncs meeting transcripts from the Fireflies GraphQL API.
+See https://docs.fireflies.ai/graphql-api/query/transcripts and
+https://docs.fireflies.ai/schema/transcript.
+"""
+
+from datetime import datetime
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+import httpx
+
+from airweave.platform.configs.auth import FirefliesAuthConfig
+from airweave.platform.decorators import source
+from airweave.platform.entities._base import BaseEntity
+from airweave.platform.entities.fireflies import FirefliesTranscriptEntity
+from airweave.platform.sources._base import BaseSource
+from airweave.schemas.source_connection import AuthenticationMethod
+
+FIREFLIES_GRAPHQL_URL = "https://api.fireflies.ai/graphql"
+TRANSCRIPTS_PAGE_SIZE = 50
+
+
+@source(
+    name="Fireflies",
+    short_name="fireflies",
+    auth_methods=[AuthenticationMethod.DIRECT, AuthenticationMethod.AUTH_PROVIDER],
+    oauth_type=None,
+    auth_config_class="FirefliesAuthConfig",
+    config_class="FirefliesConfig",
+    labels=["Meetings", "Transcription", "Productivity"],
+    supports_continuous=False,
+)
+class FirefliesSource(BaseSource):
+    """Fireflies source connector.
+
+    Syncs meeting transcripts from Fireflies.ai. Uses the GraphQL API with
+    Bearer token (API key) authentication.
+    """
+
+    @classmethod
+    async def create(
+        cls,
+        credentials: FirefliesAuthConfig,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> "FirefliesSource":
+        """Create and configure the Fireflies source.
+
+        Args:
+            credentials: Fireflies API key from app.fireflies.ai/integrations.
+            config: Optional source configuration (unused for now).
+
+        Returns:
+            Configured FirefliesSource instance.
+        """
+        instance = cls()
+        api_key = (credentials.api_key or "").strip()
+        if not api_key:
+            raise ValueError(
+                "Fireflies API key is required. Get it from app.fireflies.ai/integrations."
+            )
+        instance.api_key = api_key
+        return instance
+
+    async def _graphql(
+        self, client: httpx.AsyncClient, query: str, variables: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Execute a GraphQL request against the Fireflies API.
+
+        Args:
+            client: HTTP client.
+            query: GraphQL query or mutation string (will be stripped).
+            variables: Optional variables dict.
+
+        Returns:
+            JSON response body (data or errors).
+
+        Raises:
+            httpx.HTTPStatusError: On non-2xx response (message includes response body).
+            ValueError: If the response contains GraphQL errors.
+        """
+        payload: Dict[str, Any] = {"query": query.strip()}
+        if variables:
+            payload["variables"] = variables
+        response = await client.post(
+            FIREFLIES_GRAPHQL_URL,
+            json=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            },
+            timeout=30.0,
+        )
+        if response.status_code >= 400:
+            body = response.text
+            try:
+                err_json = response.json()
+                if "errors" in err_json and err_json["errors"]:
+                    messages = [e.get("message", str(e)) for e in err_json["errors"]]
+                    body = "; ".join(messages)
+            except Exception:
+                pass
+            raise httpx.HTTPStatusError(
+                f"Fireflies API {response.status_code}: {body}",
+                request=response.request,
+                response=response,
+            )
+        data = response.json()
+        if "errors" in data and data["errors"]:
+            msg = "; ".join(e.get("message", str(e)) for e in data["errors"])
+            raise ValueError(f"Fireflies GraphQL errors: {msg}")
+        return data
+
+    @staticmethod
+    def _parse_date(ms: Optional[float]) -> Optional[datetime]:
+        """Convert milliseconds since epoch to UTC datetime."""
+        if ms is None:
+            return None
+        try:
+            return datetime.utcfromtimestamp(ms / 1000.0)
+        except (OSError, ValueError):
+            return None
+
+    @staticmethod
+    def _normalize_action_items(value: Any) -> Optional[List[str]]:
+        """Normalize action_items from API (string or list) to List[str]."""
+        if value is None:
+            return None
+        if isinstance(value, list):
+            return [str(x).strip() for x in value if str(x).strip()]
+        if isinstance(value, str):
+            return [s.strip() for s in value.split("\n") if s.strip()] or None
+        return None
+
+    def _transcript_to_entity(self, t: Dict[str, Any]) -> FirefliesTranscriptEntity:
+        """Map a raw transcript object from the API to FirefliesTranscriptEntity."""
+        transcript_id = t.get("id") or ""
+        title = t.get("title") or "Untitled meeting"
+        date_ms = t.get("date")
+        created_time = self._parse_date(date_ms)
+        summary = t.get("summary") or {}
+        sentences = t.get("sentences") or []
+        content_parts = []
+        for s in sentences:
+            raw = (s.get("raw_text") or s.get("text") or "").strip()
+            if raw:
+                content_parts.append(raw)
+        content = "\n".join(content_parts) if content_parts else None
+
+        return FirefliesTranscriptEntity(
+            entity_id=transcript_id,
+            breadcrumbs=[],
+            name=title,
+            created_at=created_time,
+            updated_at=created_time,
+            transcript_id=transcript_id,
+            title=title,
+            organizer_email=t.get("organizer_email"),
+            transcript_url=t.get("transcript_url"),
+            participants=t.get("participants") or [],
+            duration=t.get("duration"),
+            date=date_ms,
+            date_string=t.get("dateString"),
+            created_time=created_time,
+            speakers=t.get("speakers") or [],
+            summary_overview=summary.get("overview") or summary.get("short_summary"),
+            summary_keywords=summary.get("keywords") or [],
+            summary_action_items=self._normalize_action_items(summary.get("action_items")),
+            content=content,
+            fireflies_users=t.get("fireflies_users") or [],
+        )
+
+    async def generate_entities(self) -> AsyncGenerator[BaseEntity, None]:
+        """Generate transcript entities from the Fireflies API.
+
+        Paginates through the transcripts query (limit 50 per request).
+        """
+        query = """
+        query Transcripts($limit: Int, $skip: Int) {
+          transcripts(limit: $limit, skip: $skip, mine: true) {
+            id
+            title
+            organizer_email
+            transcript_url
+            participants
+            duration
+            date
+            dateString
+            fireflies_users
+            speakers { id name }
+            summary {
+              overview
+              short_summary
+              keywords
+              action_items
+            }
+            sentences {
+              raw_text
+              text
+              speaker_name
+            }
+          }
+        }
+        """
+        skip = 0
+        async with self.http_client() as client:
+            while True:
+                variables = {"limit": TRANSCRIPTS_PAGE_SIZE, "skip": skip}
+                data = await self._graphql(client, query, variables)
+                transcripts = (data.get("data") or {}).get("transcripts") or []
+                if not transcripts:
+                    break
+                for t in transcripts:
+                    yield self._transcript_to_entity(t)
+                if len(transcripts) < TRANSCRIPTS_PAGE_SIZE:
+                    break
+                skip += TRANSCRIPTS_PAGE_SIZE
+
+    async def validate(self) -> bool:
+        """Validate credentials by running a minimal transcripts query.
+
+        Returns:
+            True if the API key is valid and the request succeeds.
+        """
+        query = """
+        query Validate {
+          transcripts(limit: 1, mine: true) {
+            id
+          }
+        }
+        """
+        try:
+            async with self.http_client() as client:
+                await self._graphql(client, query)
+            return True
+        except (httpx.HTTPStatusError, ValueError):
+            return False

--- a/frontend/src/components/creation-views/SourceSelectView.tsx
+++ b/frontend/src/components/creation-views/SourceSelectView.tsx
@@ -41,6 +41,7 @@ const getSourceDescription = (shortName: string, fallbackDescription?: string): 
     'github': 'Connect to GitHub to sync repositories, repository contents, directories, and code files. Includes repository metadata, file contents, directory structures, and development information.',
     'stripe': 'Connect to Stripe to sync balance, transactions, charges, customers, events, invoices, payment intents, payment methods, payouts, refunds, and subscriptions.',
     'dropbox': 'Connect to Dropbox to sync files, folders, sharing information, and cloud storage data. Includes file versions, collaboration features, storage metadata, and account information.',
+    'fireflies': 'Connect to Fireflies to sync meeting transcripts, summaries, and conversation content. Includes speaker attribution, action items, keywords, and searchable transcript text.',
     'asana': 'Connect to Asana to sync workspaces, projects, tasks, sections, comments, and file attachments. Includes project hierarchies, team assignments, progress tracking, and workflow management.',
     'outlook_calendar': 'Connect to Outlook Calendar to sync events, meetings, calendars, and scheduling data. Includes recurring appointments, attendees, calendar organization, and meeting details.',
     'outlook_mail': 'Connect to Outlook Mail to sync emails, folders, message data, and inbox organization. Includes email threads, attachments, mailbox structure, and message metadata.',

--- a/monke/bongos/fireflies.py
+++ b/monke/bongos/fireflies.py
@@ -1,0 +1,328 @@
+"""Fireflies-specific bongo implementation.
+
+Monke creates test transcripts by giving Fireflies a public audio URL; Fireflies
+transcribes it and we poll until the transcript exists. Airweave then syncs only
+the transcript text (no media). We need the audio URL only so Fireflies can create
+a transcript for the test.
+
+Create (upload URL + poll) → sync → verify → update → delete → cleanup.
+Requires Fireflies paid plan for uploads.
+"""
+
+import asyncio
+import os
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+import httpx
+from monke.bongos.base_bongo import BaseBongo
+from monke.utils.logging import get_logger
+
+FIREFLIES_GRAPHQL_URL = "https://api.fireflies.ai/graphql"
+# deleteTranscript is rate-limited to 10/min
+DELETE_RATE_LIMIT_SECONDS = 6.5
+POLL_INTERVAL_SECONDS = 20
+
+
+class FirefliesBongo(BaseBongo):
+    """Bongo for Fireflies: upload audio URL, poll for transcript, update title, delete, cleanup."""
+
+    connector_type = "fireflies"
+
+    def __init__(self, credentials: Dict[str, Any], **kwargs):
+        """Initialize the Fireflies bongo.
+
+        Args:
+            credentials: Must contain api_key (Bearer).
+            **kwargs: entity_count, audio_url, transcript_ready_timeout_seconds, etc.
+        """
+        super().__init__(credentials)
+        self.api_key = credentials.get("api_key")
+        if not self.api_key:
+            raise ValueError(
+                "Missing Fireflies api_key. Set MONKE_FIREFLIES_API_KEY."
+            )
+
+        self.entity_count = int(kwargs.get("entity_count", 1))
+        # Public audio URL for Fireflies to transcribe (creates a transcript for the test)
+        self.audio_url = (kwargs.get("audio_url") or "").strip() or os.getenv(
+            "MONKE_FIREFLIES_AUDIO_URL", ""
+        ).strip()
+        if not self.audio_url:
+            raise ValueError(
+                "Fireflies test needs a public audio URL so Fireflies can create a transcript. "
+                "Set audio_url in config or MONKE_FIREFLIES_AUDIO_URL."
+            )
+        self.transcript_ready_timeout_seconds = int(
+            kwargs.get("transcript_ready_timeout_seconds", 300)
+        )
+        self.logger = get_logger("fireflies_bongo")
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+
+    async def _graphql(
+        self,
+        client: httpx.AsyncClient,
+        query: str,
+        variables: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Execute a GraphQL request. Raises on HTTP or GraphQL errors."""
+        payload: Dict[str, Any] = {"query": query.strip()}
+        if variables:
+            payload["variables"] = variables
+        resp = await client.post(
+            FIREFLIES_GRAPHQL_URL,
+            json=payload,
+            headers=self._headers(),
+            timeout=60.0,
+        )
+        if resp.status_code >= 400:
+            body = resp.text
+            try:
+                err_json = resp.json()
+                if "errors" in err_json and err_json["errors"]:
+                    messages = [e.get("message", str(e)) for e in err_json["errors"]]
+                    body = "; ".join(messages)
+            except Exception:
+                pass
+            raise httpx.HTTPStatusError(
+                f"Fireflies API {resp.status_code}: {body}",
+                request=resp.request,
+                response=resp,
+            )
+        data = resp.json()
+        if "errors" in data and data["errors"]:
+            messages = [e.get("message", str(e)) for e in data["errors"]]
+            raise RuntimeError(f"Fireflies GraphQL errors: {'; '.join(messages)}")
+        return data
+
+    async def _upload_audio(
+        self,
+        client: httpx.AsyncClient,
+        title: str,
+        client_reference_id: Optional[str] = None,
+    ) -> None:
+        """Send audio URL to Fireflies; they transcribe it and create a transcript (queued)."""
+        mutation = """
+        mutation UploadAudio($input: AudioUploadInput) {
+          uploadAudio(input: $input) {
+            success
+            title
+            message
+          }
+        }
+        """
+        inp: Dict[str, Any] = {
+            "url": self.audio_url,
+            "title": title,
+            "bypass_size_check": True,
+        }
+        if client_reference_id:
+            inp["client_reference_id"] = client_reference_id
+        await self._graphql(client, mutation, {"input": inp})
+
+    async def _list_transcripts(
+        self, client: httpx.AsyncClient, limit: int = 50, skip: int = 0
+    ) -> List[Dict[str, Any]]:
+        """Return list of transcripts (id, title) for mine: true."""
+        query = """
+        query Transcripts($limit: Int, $skip: Int) {
+          transcripts(limit: $limit, skip: $skip, mine: true) {
+            id
+            title
+          }
+        }
+        """
+        data = await self._graphql(
+            client, query, {"limit": limit, "skip": skip}
+        )
+        return (data.get("data") or {}).get("transcripts") or []
+
+    async def _find_transcript_by_title(
+        self, client: httpx.AsyncClient, title_substring: str
+    ) -> Optional[Dict[str, Any]]:
+        """Scan transcripts (paginated) and return first whose title contains title_substring."""
+        skip = 0
+        while True:
+            batch = await self._list_transcripts(client, limit=50, skip=skip)
+            if not batch:
+                return None
+            for t in batch:
+                if title_substring in (t.get("title") or ""):
+                    return t
+            if len(batch) < 50:
+                return None
+            skip += 50
+
+    async def _poll_for_transcript(
+        self, client: httpx.AsyncClient, token: str, title: str
+    ) -> Optional[str]:
+        """Poll until a transcript with title containing token appears; return its id or None."""
+        deadline = time.monotonic() + self.transcript_ready_timeout_seconds
+        while time.monotonic() < deadline:
+            transcript = await self._find_transcript_by_title(client, token)
+            if transcript:
+                return transcript.get("id")
+            self.logger.info(
+                f"   Waiting for transcript '{title}' to be ready (poll every {POLL_INTERVAL_SECONDS}s)..."
+            )
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+        return None
+
+    async def create_entities(self) -> List[Dict[str, Any]]:
+        """Upload audio URL to Fireflies (title with token), poll until transcript exists."""
+        self.logger.info(
+            f"🥁 Creating {self.entity_count} Fireflies transcript(s) via upload + poll"
+        )
+        entities: List[Dict[str, Any]] = []
+
+        async with httpx.AsyncClient() as client:
+            for _ in range(self.entity_count):
+                token = str(uuid.uuid4())[:8]
+                title = f"Monke Test [{token}]"
+                self.logger.info(f"   Uploading audio with title: {title}")
+                await self._upload_audio(
+                    client, title, client_reference_id=token
+                )
+                transcript_id = await self._poll_for_transcript(
+                    client, token, title
+                )
+                if not transcript_id:
+                    raise RuntimeError(
+                        f"Transcript for '{title}' did not appear within "
+                        f"{self.transcript_ready_timeout_seconds}s"
+                    )
+                self.logger.info(f"   ✅ Transcript ready: {transcript_id}")
+                entities.append(
+                    {
+                        "type": "transcript",
+                        "id": transcript_id,
+                        "token": token,
+                        "title": title,
+                        "expected_content": token,
+                    }
+                )
+
+        self.created_entities = entities
+        return entities
+
+    async def update_entities(self) -> List[Dict[str, Any]]:
+        """Update meeting title for first transcript so token remains searchable."""
+        if not self.created_entities:
+            return []
+
+        self.logger.info("🥁 Updating Fireflies transcript title(s)")
+        updated: List[Dict[str, Any]] = []
+        to_update = self.created_entities[:1]
+
+        async with httpx.AsyncClient() as client:
+            mutation = """
+            mutation UpdateMeetingTitle($input: UpdateMeetingTitleInput!) {
+              updateMeetingTitle(input: $input) {
+                title
+              }
+            }
+            """
+            for entity in to_update:
+                token = entity.get("token", "")
+                new_title = f"Monke Test [{token}] (updated)"
+                try:
+                    await self._graphql(
+                        client,
+                        mutation,
+                        {
+                            "input": {
+                                "id": entity["id"],
+                                "title": new_title,
+                            }
+                        },
+                    )
+                    updated.append(
+                        {**entity, "title": new_title, "expected_content": token}
+                    )
+                    self.logger.info(f"   ✅ Updated title: {entity['id']}")
+                except Exception as e:
+                    self.logger.warning(
+                        f"   updateMeetingTitle failed (may require admin): {e}"
+                    )
+                    updated.append(entity)
+
+        return updated
+
+    async def delete_entities(self) -> List[str]:
+        """Delete all created transcripts (rate-limited)."""
+        return await self.delete_specific_entities(self.created_entities)
+
+    async def delete_specific_entities(
+        self, entities: List[Dict[str, Any]]
+    ) -> List[str]:
+        """Delete given transcripts via deleteTranscript; 10/min rate limit."""
+        self.logger.info(f"🥁 Deleting {len(entities)} Fireflies transcript(s)")
+        deleted: List[str] = []
+        mutation = """
+        mutation DeleteTranscript($id: String!) {
+          deleteTranscript(id: $id) {
+            title
+          }
+        }
+        """
+        async with httpx.AsyncClient() as client:
+            for i, entity in enumerate(entities):
+                if i > 0:
+                    await asyncio.sleep(DELETE_RATE_LIMIT_SECONDS)
+                try:
+                    await self._graphql(
+                        client, mutation, {"id": entity["id"]}
+                    )
+                    deleted.append(entity["id"])
+                    self.logger.info(f"   ✅ Deleted: {entity['id']}")
+                except Exception as e:
+                    self.logger.warning(
+                        f"   deleteTranscript failed for {entity['id']}: {e}"
+                    )
+        return deleted
+
+    async def cleanup(self) -> None:
+        """Find transcripts with 'Monke Test' in title and delete them (rate-limited)."""
+        self.logger.info("🥁 Cleanup: removing any remaining Monke Test transcripts")
+        async with httpx.AsyncClient() as client:
+            to_delete: List[Dict[str, Any]] = []
+            skip = 0
+            while True:
+                batch = await self._list_transcripts(client, limit=50, skip=skip)
+                if not batch:
+                    break
+                for t in batch:
+                    if "Monke Test" in (t.get("title") or ""):
+                        to_delete.append(
+                            {"id": t["id"], "title": t.get("title", "")}
+                        )
+                if len(batch) < 50:
+                    break
+                skip += 50
+
+            if to_delete:
+                mutation = """
+                mutation DeleteTranscript($id: String!) {
+                  deleteTranscript(id: $id) { title }
+                }
+                """
+                for i, t in enumerate(to_delete):
+                    if i > 0:
+                        await asyncio.sleep(DELETE_RATE_LIMIT_SECONDS)
+                    try:
+                        await self._graphql(
+                            client, mutation, {"id": t["id"]}
+                        )
+                        self.logger.info(f"   ✅ Cleanup deleted: {t['id']}")
+                    except Exception as e:
+                        self.logger.warning(
+                            f"   Cleanup delete failed for {t['id']}: {e}"
+                        )
+            else:
+                self.logger.info("   No Monke Test transcripts to clean up")

--- a/monke/configs/fireflies.yaml
+++ b/monke/configs/fireflies.yaml
@@ -1,0 +1,59 @@
+# Fireflies connector test configuration.
+#
+# Flow: Monke uploads a file URL to Fireflies (their API creates a transcript by transcribing it).
+# Airweave then syncs only the transcript text from Fireflies—no media is indexed.
+# We need the audio URL only so Fireflies can create a transcript for the test.
+#
+# Requires: Fireflies paid plan. Set audio_url in config or MONKE_FIREFLIES_AUDIO_URL (public URL).
+# Processing after upload may take 2–5 min.
+name: "Fireflies Connector Test"
+description: "E2E test for Fireflies transcripts via Monke (upload, sync, verify, update, delete)"
+
+connector:
+  name: "fireflies_test"
+  type: "fireflies"
+  auth_mode: direct
+  auth_fields:
+    api_key: MONKE_FIREFLIES_API_KEY
+  config_fields:
+    # Public audio (or video) URL for Fireflies to transcribe. Override via MONKE_FIREFLIES_AUDIO_URL.
+    audio_url: ""
+    transcript_ready_timeout_seconds: 300
+    post_create_sleep_seconds: 15
+
+test_flow:
+  steps:
+    - cleanup
+    - create
+    - sync
+    - verify
+    - update
+    - sync
+    - verify
+    - partial_delete
+    - sync
+    - verify_partial_deletion
+    - verify_remaining_entities
+    - complete_delete
+    - sync
+    - verify_complete_deletion
+    - cleanup
+    - collection_cleanup
+
+entity_count: 1  # Transcripts are slow to process; increase later if needed
+
+deletion:
+  partial_delete_count: 1
+  verify_partial_deletion: true
+  verify_remaining_entities: true
+  verify_complete_deletion: true
+
+collection:
+  name_template: "monke-{connector_type}-test-{timestamp}"
+  description: "Test collection for {connector_type} connector"
+
+verification:
+  score_threshold: 0.0
+  retries: 5
+  retry_backoff_seconds: 10
+  initial_wait_seconds: 30


### PR DESCRIPTION
- [ ] Add service logo
- [ ] Fixup monke test
- [ ] Cleanup some obsolete generated code
- [ ] Add a proper description

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Fireflies connector to sync meeting transcripts via GraphQL using an API key. Indexes titles, participants, summaries, and transcript text for search. Addresses ENG-2096.

- **New Features**
  - Backend source: FirefliesSource with API key auth, paginated transcripts (mine: true), entity mapping, and a validate check.
  - Entities: FirefliesTranscriptEntity with title, organizer, participants, speakers, summary, keywords, action items, content, and timestamps.
  - Auth/Config: FirefliesAuthConfig (API key) and FirefliesConfig (no extra fields).
  - Integration hooks: Registered in dev.integrations.yaml and entities __init__; added source description in SourceSelectView.
  - Monke: Bongo to upload a public audio URL, poll for transcript, update title, delete, and cleanup; includes fireflies.yaml test config.

<sup>Written for commit 9a307c5fc62abeae799cecfe615444a12ed4df2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

