### PR TITLE
feat: add MCP registry metadata for official server listing

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "airweave-mcp-search",
-  "version": "0.5.7",
+  "version": "0.8.84",
+  "mcpName": "io.github.airweave-ai/search",
   "description": "MCP server for searching Airweave collections",
   "type": "module",
   "main": "build/index.js",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.airweave-ai/search",
+  "title": "Airweave Search",
+  "description": "MCP server for searching Airweave collections with natural language queries, vector search, and AI-powered completions.",
+  "repository": {
+    "url": "https://github.com/airweave-ai/airweave",
+    "source": "github"
+  },
+  "version": "0.8.84",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.airweave.ai/mcp",
+      "headers": [
+        {
+          "name": "X-API-Key",
+          "description": "Your Airweave API key",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "X-Collection-Readable-ID",
+          "description": "The Airweave collection readable ID to search",
+          "isRequired": true
+        }
+      ]
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "airweave-mcp-search",
+      "version": "0.8.84",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "AIRWEAVE_API_KEY",
+          "description": "Your Airweave API key for authentication",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "AIRWEAVE_COLLECTION",
+          "description": "The Airweave collection to search",
+          "isRequired": true
+        },
+        {
+          "name": "AIRWEAVE_BASE_URL",
+          "description": "Airweave API base URL (defaults to https://api.airweave.ai)",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add MCP registry metadata to list Airweave Search as an official MCP server and streamline setup. Includes server.json (streamable-http with X-API-Key and X-Collection-Readable-ID), npm package entry v0.8.84 with AIRWEAVE_API_KEY, AIRWEAVE_COLLECTION, AIRWEAVE_BASE_URL env vars, and sets mcpName to io.github.airweave-ai/search.

<sup>Written for commit f3beab36628b522559bc03704a0fab10512e27ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

