### PR TITLE
fix: revert mcp version

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airweave-mcp-search",
-  "version": "0.8.84",
+  "version": "0.5.7",
   "mcpName": "io.github.airweave-ai/search",
   "description": "MCP server for searching Airweave collections",
   "type": "module",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reverted the MCP server package version from 0.8.84 to 0.5.7 to match the intended release.

<sup>Written for commit b958df99de77fe8a2baba5a61770b0056e09bb43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

