### PR TITLE
fix(search): skip non-filterable source fields in query interpretation

### DIFF
--- a/backend/airweave/search/prompts/query_interpretation.py
+++ b/backend/airweave/search/prompts/query_interpretation.py
@@ -1,49 +1,47 @@
 """System prompt for query interpretation operation."""
 
-QUERY_INTERPRETATION_SYSTEM_PROMPT = """You are a search query analyzer. Extract Qdrant \
+QUERY_INTERPRETATION_SYSTEM_PROMPT = """You are a search query analyzer. Extract structured \
 filters from natural language queries.
 
-CRITICAL FIELD STRUCTURE INFORMATION:
-In the Qdrant database, fields are stored in a nested structure within the payload:
-- Fields marked with 'airweave_system_metadata.' prefix are nested under that object
-- Other fields are stored directly in the payload
-- The system will AUTOMATICALLY map the field names to their correct nested paths
+FILTERABLE FIELDS:
+Only the fields listed below are filterable. Source-specific fields (e.g. title, status, \
+assignee, priority) are NOT filterable — they are stored as unstructured text and can only \
+be found via semantic search, not filters.
+
+- The system will AUTOMATICALLY map field names to their correct paths
 - You should use the field names AS SHOWN in the list below
 - DO NOT manually add 'airweave_system_metadata.' prefix - the system handles this
 
 For example:
-- If you see 'airweave_system_metadata.source_name' in the list, just use \
-'source_name' in your filter
-- If you see 'entity_id' in the list, use 'entity_id' as-is
-- The system knows which fields need the nested path and will apply it automatically
+- Use 'source_name' (not 'airweave_system_metadata.source_name')
+- Use 'entity_id' as-is
+- Use 'created_at' or 'updated_at' for time-based filtering
 
 {available_fields}
 
-Generate Qdrant filter conditions in this format:
+Generate filter conditions in this format:
 - For exact matches: {{"key": "field_name", "match": {{"value": "exact_value"}}}}
 - For multiple values: {{"key": "field_name", "match": {{"any": ["value1", "value2"]}}}}
 - For date ranges: {{"key": "field_name", "range": {{"gte": "2024-01-01T00:00:00Z", \
 "lte": "2024-12-31T23:59:59Z"}}}}
-- For number ranges: {{"key": "field_name", "range": {{"gte": 0, "lte": 100}}}}
 
 Common patterns to look for:
-- Source/platform mentions: "in Asana", "from GitHub", "on Slack" → source_name field \
-(will be mapped to airweave_system_metadata.source_name)
-- Status indicators: "open", "closed", "pending", "completed" → status or state field
-- Time references: "last week", "yesterday", "past month" → choose a date/time field \
-that EXISTS for the relevant source (see lists above).
-- Assignee mentions: "assigned to John" → assignee field
-- Priority levels: "high priority", "critical" → priority field
+- Source/platform mentions: "in Asana", "from GitHub", "on Slack" → source_name filter
+- Entity type mentions: "messages", "issues", "documents" → entity_type filter
+- Time references: "last week", "yesterday", "past month" → created_at or updated_at \
+range filter
+- Specific entity lookups: entity_id or name filter
 
 IMPORTANT CONSTRAINTS:
-- Do NOT invent sources or fields. Use only the sources listed above and only the field \
-names explicitly listed for each source or in Common fields.
+- ONLY use field names from the list above. Do NOT filter on source-specific fields like \
+status, assignee, priority, description, etc. — these are not filterable.
+- If the query mentions source-specific attributes (e.g. "open issues", "assigned to John"), \
+keep those terms in the search query for semantic matching but do NOT create a filter for them.
+- Do NOT invent sources or fields.
 - If you cannot confidently map a term to an available field, omit the filter and lower \
 the confidence.
 - The value for source_name MUST be the exact short_name from the sources list (lowercase, \
 e.g., "asana", "github", "google_docs"). These are case-sensitive and stored exactly as shown.
-- When time-based language is used, identify the most relevant date field from the listed \
-fields.
 
 Be conservative with confidence:
 - High confidence (>0.8): Clear, unambiguous filter terms with exact field matches


### PR DESCRIPTION
After the Vespa migration, source-specific entity fields (e.g. title, status, assignee) are stored in the payload JSON field and are not individually indexed as filterable attributes. The query interpretation LLM was still discovering and filtering on these fields, causing 500 errors from Vespa.

- Add VESPA_FILTERABLE_FIELDS set with actually filterable Vespa attributes
- Skip non-filterable fields in _validate_filters() as a safety net
- Stop presenting non-filterable fields to the LLM in _get_source_fields()
- Update prompt to explicitly tell the LLM not to filter on source-specific fields and to keep those terms for semantic search instead

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Vespa 500 errors by only allowing filters on fields that are actually indexed as attributes. Source-specific fields (e.g., title, status, assignee) are now kept for semantic search only.

- **Bug Fixes**
  - Added VESPA_FILTERABLE_FIELDS to whitelist filterable attributes.
  - Skips non-filterable fields in _get_source_fields() and _validate_filters().
  - Updated the prompt to instruct the model not to create filters for source-specific fields.

<sup>Written for commit 1b0d7e052b70f9ce9695076d57353b886061d872. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

