### PR TITLE
feat: add Google Document AI OCR adapter 

### DIFF
--- a/backend/airweave/adapters/ocr/__init__.py
+++ b/backend/airweave/adapters/ocr/__init__.py
@@ -1,6 +1,7 @@
 """OCR adapters."""
 
 from airweave.adapters.ocr.fake import FakeOcrProvider
+from airweave.adapters.ocr.fallback import FallbackOcrProvider
 from airweave.adapters.ocr.mistral import MistralOcrAdapter
 
-__all__ = ["MistralOcrAdapter", "FakeOcrProvider"]
+__all__ = ["MistralOcrAdapter", "FallbackOcrProvider", "FakeOcrProvider"]

--- a/backend/airweave/adapters/ocr/__init__.py
+++ b/backend/airweave/adapters/ocr/__init__.py
@@ -2,6 +2,12 @@
 
 from airweave.adapters.ocr.fake import FakeOcrProvider
 from airweave.adapters.ocr.fallback import FallbackOcrProvider
+from airweave.adapters.ocr.google_document_ai import GoogleDocumentAIOcrAdapter
 from airweave.adapters.ocr.mistral import MistralOcrAdapter
 
-__all__ = ["MistralOcrAdapter", "FallbackOcrProvider", "FakeOcrProvider"]
+__all__ = [
+    "MistralOcrAdapter",
+    "GoogleDocumentAIOcrAdapter",
+    "FallbackOcrProvider",
+    "FakeOcrProvider",
+]

--- a/backend/airweave/adapters/ocr/fake.py
+++ b/backend/airweave/adapters/ocr/fake.py
@@ -12,19 +12,23 @@ class FakeOcrProvider:
     """Test implementation of OcrProvider.
 
     Returns configurable markdown for each file path. Records all calls
-    for assertions.
+    for assertions. Optionally raises to simulate provider failure.
 
     Usage::
 
         fake = FakeOcrProvider(default_markdown="# Hello")
         results = await fake.convert_batch(["/tmp/doc.pdf"])
         assert results["/tmp/doc.pdf"] == "# Hello"
+
+        # Simulate provider failure
+        failing = FakeOcrProvider(should_raise=RuntimeError("down"))
     """
 
     def __init__(
         self,
         default_markdown: Optional[str] = "# Fake OCR output",
         overrides: Optional[Dict[str, Optional[str]]] = None,
+        should_raise: Optional[Exception] = None,
     ) -> None:
         """Initialize the fake.
 
@@ -32,14 +36,19 @@ class FakeOcrProvider:
             default_markdown: Markdown returned for any file without an
                 explicit override. Set to ``None`` to simulate failure.
             overrides: Per-path overrides (path → markdown or ``None``).
+            should_raise: If set, ``convert_batch`` raises this exception
+                instead of returning results. Useful for testing failover.
         """
         self._default = default_markdown
         self._overrides: Dict[str, Optional[str]] = overrides or {}
+        self._should_raise = should_raise
         self.calls: list[List[str]] = []
 
     async def convert_batch(self, file_paths: List[str]) -> Dict[str, Optional[str]]:
         """Return canned results and record the call."""
         self.calls.append(list(file_paths))
+        if self._should_raise is not None:
+            raise self._should_raise
         return {path: self._overrides.get(path, self._default) for path in file_paths}
 
     # Test helpers

--- a/backend/airweave/adapters/ocr/fallback.py
+++ b/backend/airweave/adapters/ocr/fallback.py
@@ -1,0 +1,85 @@
+"""Fallback OCR provider with circuit breaker integration.
+
+Tries OCR providers in order, skipping circuit-broken ones. Satisfies
+the OcrProvider protocol — drop-in replacement anywhere a single
+provider is accepted.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+from airweave.core.logging import logger
+
+if TYPE_CHECKING:
+    from airweave.core.protocols import CircuitBreaker, OcrProvider
+
+
+class FallbackOcrProvider:
+    """Tries OCR providers in priority order, skipping circuit-broken ones.
+
+    Wraps multiple OcrProvider implementations behind a single OcrProvider
+    interface. Uses a CircuitBreaker to track which providers are healthy.
+
+    Usage::
+
+        ocr = FallbackOcrProvider(
+            providers=[
+                ("mistral-ocr", MistralOcrAdapter()),
+                ("google-document-ai", GoogleDocAIOcrAdapter()),
+            ],
+            circuit_breaker=InMemoryCircuitBreaker(cooldown_seconds=120),
+        )
+        results = await ocr.convert_batch(["/tmp/doc.pdf"])
+    """
+
+    def __init__(
+        self,
+        providers: List[Tuple[str, "OcrProvider"]],
+        circuit_breaker: "CircuitBreaker",
+    ) -> None:
+        """Initialize the fallback provider.
+
+        Args:
+            providers: Ordered list of (provider_key, provider) pairs.
+                Tried first-to-last; first available wins.
+            circuit_breaker: Tracks provider health and cooldowns.
+        """
+        if not providers:
+            raise ValueError("At least one OCR provider is required")
+        self._providers = providers
+        self._cb = circuit_breaker
+
+    async def convert_batch(self, file_paths: List[str]) -> Dict[str, Optional[str]]:
+        """Convert files to markdown, trying providers in order.
+
+        Skips circuit-broken providers. On failure, records the failure
+        and tries the next provider. If all providers are exhausted,
+        returns None for every file.
+
+        Args:
+            file_paths: Local file paths to convert.
+
+        Returns:
+            Mapping of ``file_path -> markdown`` (``None`` on failure).
+        """
+        for provider_key, provider in self._providers:
+            if not await self._cb.is_available(provider_key):
+                logger.info(
+                    f"[FallbackOCR] Skipping '{provider_key}' (circuit-broken)"
+                )
+                continue
+
+            try:
+                results = await provider.convert_batch(file_paths)
+                await self._cb.record_success(provider_key)
+                return results
+            except Exception as exc:
+                await self._cb.record_failure(provider_key)
+                logger.warning(
+                    f"[FallbackOCR] '{provider_key}' failed ({exc}), "
+                    f"trying next provider"
+                )
+
+        logger.error("[FallbackOCR] All OCR providers unavailable or failed")
+        return {path: None for path in file_paths}

--- a/backend/airweave/adapters/ocr/google_document_ai.py
+++ b/backend/airweave/adapters/ocr/google_document_ai.py
@@ -88,13 +88,8 @@ class GoogleDocumentAIOcrAdapter:
         if self._client is not None:
             return
 
-        try:
-            from google.api_core.client_options import ClientOptions
-            from google.cloud import documentai
-        except ImportError:
-            raise RuntimeError(
-                "google-cloud-documentai package required but not installed"
-            )
+        from google.api_core.client_options import ClientOptions
+        from google.cloud import documentai
 
         opts = ClientOptions(
             api_endpoint=f"{self._location}-documentai.googleapis.com"

--- a/backend/airweave/adapters/ocr/google_document_ai.py
+++ b/backend/airweave/adapters/ocr/google_document_ai.py
@@ -1,0 +1,207 @@
+"""Google Document AI OCR adapter.
+
+Satisfies the :class:`~airweave.core.protocols.ocr.OcrProvider` protocol
+using Google Cloud's Enterprise Document OCR processor.
+
+The SDK is synchronous, so calls are wrapped in ``asyncio.to_thread()``
+with bounded concurrency via a semaphore.
+
+Auth wiring is deferred — the adapter accepts raw config at init.
+Settings / infra integration will be added in a follow-up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Dict, List, Optional
+
+from airweave.core.logging import logger
+
+# Google Document AI online processing limit (20 MB).
+MAX_FILE_SIZE_BYTES = 20_000_000
+
+# Default concurrent OCR calls.
+DEFAULT_CONCURRENCY = 5
+
+# Extension → MIME type for Document AI.
+_MIME_TYPES: Dict[str, str] = {
+    ".pdf": "application/pdf",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".tiff": "image/tiff",
+    ".tif": "image/tiff",
+    ".gif": "image/gif",
+    ".bmp": "image/bmp",
+    ".webp": "image/webp",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+
+class GoogleDocumentAIOcrAdapter:
+    """Google Document AI OCR adapter.
+
+    Wraps the ``google-cloud-documentai`` SDK behind the ``OcrProvider``
+    protocol. Each file is sent to the online (synchronous) processing
+    endpoint; results are the full extracted text.
+
+    Usage::
+
+        ocr = GoogleDocumentAIOcrAdapter(
+            project_id="my-gcp-project",
+            location="us",
+            processor_id="abc123def456",
+        )
+        results = await ocr.convert_batch(["/tmp/doc.pdf"])
+    """
+
+    def __init__(
+        self,
+        project_id: str,
+        location: str,
+        processor_id: str,
+        concurrency: int = DEFAULT_CONCURRENCY,
+    ) -> None:
+        """Initialize the adapter.
+
+        Args:
+            project_id: GCP project ID with Document AI API enabled.
+            location: Processor region (``us`` or ``eu``).
+            processor_id: ID of the Document AI OCR processor.
+            concurrency: Max concurrent processing requests.
+        """
+        self._project_id = project_id
+        self._location = location
+        self._processor_id = processor_id
+        self._concurrency = concurrency
+        self._client: Any = None
+        self._processor_name: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Lazy client initialisation
+    # ------------------------------------------------------------------
+
+    def _ensure_client(self) -> None:
+        """Create the Document AI client on first use."""
+        if self._client is not None:
+            return
+
+        try:
+            from google.api_core.client_options import ClientOptions
+            from google.cloud import documentai
+        except ImportError:
+            raise RuntimeError(
+                "google-cloud-documentai package required but not installed"
+            )
+
+        opts = ClientOptions(
+            api_endpoint=f"{self._location}-documentai.googleapis.com"
+        )
+        self._client = documentai.DocumentProcessorServiceClient(
+            client_options=opts
+        )
+        self._processor_name = self._client.processor_path(
+            self._project_id, self._location, self._processor_id
+        )
+        logger.debug(
+            f"Google Document AI client initialized "
+            f"(processor={self._processor_name})"
+        )
+
+    # ------------------------------------------------------------------
+    # OcrProvider protocol
+    # ------------------------------------------------------------------
+
+    async def convert_batch(
+        self, file_paths: List[str]
+    ) -> Dict[str, Optional[str]]:
+        """Convert files to text via Google Document AI OCR.
+
+        Args:
+            file_paths: Local file paths to OCR.
+
+        Returns:
+            Mapping of ``file_path -> text`` (``None`` on per-file failure).
+        """
+        self._ensure_client()
+
+        if not file_paths:
+            return {}
+
+        semaphore = asyncio.Semaphore(self._concurrency)
+        results: Dict[str, Optional[str]] = {}
+
+        async def _process_one(path: str) -> None:
+            async with semaphore:
+                results[path] = await self._ocr_single(path)
+
+        await asyncio.gather(*[_process_one(p) for p in file_paths])
+        return results
+
+    # ------------------------------------------------------------------
+    # Single file OCR
+    # ------------------------------------------------------------------
+
+    async def _ocr_single(self, path: str) -> Optional[str]:
+        """OCR a single file via the online processing endpoint."""
+        name = os.path.basename(path)
+
+        # Check file size (20 MB online limit)
+        try:
+            file_size = os.path.getsize(path)
+        except OSError as exc:
+            logger.error(f"[GoogleDocAI] Cannot stat {name}: {exc}")
+            return None
+
+        if file_size > MAX_FILE_SIZE_BYTES:
+            logger.warning(
+                f"[GoogleDocAI] {name} is {file_size / 1_000_000:.1f}MB, "
+                f"exceeds 20MB online limit — skipping"
+            )
+            return None
+
+        # Determine MIME type
+        _, ext = os.path.splitext(path)
+        mime_type = _MIME_TYPES.get(ext.lower())
+        if mime_type is None:
+            logger.warning(f"[GoogleDocAI] Unsupported extension: {ext}")
+            return None
+
+        # Read file
+        try:
+            with open(path, "rb") as fh:
+                content = fh.read()
+        except OSError as exc:
+            logger.error(f"[GoogleDocAI] Cannot read {name}: {exc}")
+            return None
+
+        # Call Document AI (sync SDK → thread)
+        try:
+            text = await asyncio.to_thread(
+                self._process_document, content, mime_type
+            )
+        except Exception as exc:
+            logger.error(f"[GoogleDocAI] OCR failed for {name}: {exc}")
+            return None
+
+        if not text or not text.strip():
+            logger.warning(f"[GoogleDocAI] Empty text for {name}")
+            return ""
+
+        return text
+
+    def _process_document(self, content: bytes, mime_type: str) -> str:
+        """Synchronous Document AI call (runs in thread)."""
+        from google.cloud import documentai
+
+        raw_document = documentai.RawDocument(
+            content=content, mime_type=mime_type
+        )
+        request = documentai.ProcessRequest(
+            name=self._processor_name,
+            raw_document=raw_document,
+        )
+        result = self._client.process_document(request=request)
+        return result.document.text

--- a/backend/airweave/core/container/container.py
+++ b/backend/airweave/core/container/container.py
@@ -14,7 +14,9 @@ from dataclasses import dataclass, replace
 from typing import Any
 
 from airweave.core.protocols import (
+    CircuitBreaker,
     EventBus,
+    OcrProvider,
     WebhookAdmin,
     WebhookPublisher,
 )
@@ -31,10 +33,14 @@ class Container:
 
         # Testing: construct directly with fakes
         from airweave.adapters.event_bus import FakeEventBus
+        from airweave.adapters.circuit_breaker import FakeCircuitBreaker
+        from airweave.adapters.ocr import FakeOcrProvider
         test_container = Container(
             event_bus=FakeEventBus(),
             webhook_publisher=FakeWebhookPublisher(),
             webhook_admin=FakeWebhookAdmin(),
+            circuit_breaker=FakeCircuitBreaker(),
+            ocr_provider=FakeOcrProvider(),
         )
 
         # FastAPI endpoints: use Inject() to pull individual protocols
@@ -49,6 +55,12 @@ class Container:
     # Webhook protocols (Svix-backed)
     webhook_publisher: WebhookPublisher  # Internal: publish sync events
     webhook_admin: WebhookAdmin  # External API: subscriptions + history
+
+    # Circuit breaker for provider failover
+    circuit_breaker: CircuitBreaker
+
+    # OCR provider (with fallback chain + circuit breaking)
+    ocr_provider: OcrProvider
 
     # -----------------------------------------------------------------
     # Convenience methods

--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -115,7 +115,8 @@ def _create_ocr_provider(circuit_breaker: "CircuitBreaker") -> "OcrProvider":
     """Create OCR provider with fallback chain.
 
     Currently: Mistral only.
-    Future: add more providers to the list for automatic failover.
+    To enable Google Document AI as a fallback, uncomment the block below
+    and set the GCP_DOCUMENT_AI_* settings in core/config/settings.py.
     """
     from airweave.adapters.ocr.fallback import FallbackOcrProvider
     from airweave.adapters.ocr.mistral import MistralOcrAdapter
@@ -123,6 +124,12 @@ def _create_ocr_provider(circuit_breaker: "CircuitBreaker") -> "OcrProvider":
     return FallbackOcrProvider(
         providers=[
             ("mistral-ocr", MistralOcrAdapter()),
+            # Uncomment to enable Google Document AI as fallback:
+            # ("google-document-ai", GoogleDocumentAIOcrAdapter(
+            #     project_id=settings.GCP_DOCUMENT_AI_PROJECT,
+            #     location=settings.GCP_DOCUMENT_AI_LOCATION,
+            #     processor_id=settings.GCP_DOCUMENT_AI_PROCESSOR_ID,
+            # )),
         ],
         circuit_breaker=circuit_breaker,
     )

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1944,17 +1944,17 @@ huggingface-hub = ">=0.20,<2.0"
 loguru = ">=0.7.2,<0.8.0"
 mmh3 = ">=4.1.0,<6.0.0"
 numpy = [
+    {version = ">=2.1.0", markers = "python_version == \"3.13\""},
     {version = ">=1.21", markers = "python_version == \"3.11\""},
     {version = ">=1.26", markers = "python_version == \"3.12\""},
-    {version = ">=2.1.0", markers = "python_version == \"3.13\""},
 ]
 onnxruntime = [
-    {version = ">=1.17.0,<1.20.0 || >1.20.0", markers = "python_version >= \"3.10\" and python_version < \"3.13\""},
     {version = ">1.20.0", markers = "python_version >= \"3.13\""},
+    {version = ">=1.17.0,<1.20.0 || >1.20.0", markers = "python_version >= \"3.10\" and python_version < \"3.13\""},
 ]
 pillow = [
-    {version = ">=10.3.0,<12.0", markers = "python_version >= \"3.10\" and python_version < \"3.13\""},
     {version = ">=11.0.0,<12.0", markers = "python_version >= \"3.13\""},
+    {version = ">=10.3.0,<12.0", markers = "python_version >= \"3.10\" and python_version < \"3.13\""},
 ]
 py-rust-stemmers = ">=0.1.0,<0.2.0"
 requests = ">=2.31,<3.0"
@@ -2290,9 +2290,11 @@ files = [
 [package.dependencies]
 google-auth = ">=2.14.1,<3.0.0"
 googleapis-common-protos = ">=1.56.2,<2.0.0"
+grpcio = {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""}
+grpcio-status = {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""}
 proto-plus = [
-    {version = ">=1.22.3,<2.0.0"},
     {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
+    {version = ">=1.22.3,<2.0.0"},
 ]
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<7.0.0"
 requests = ">=2.18.0,<3.0.0"
@@ -2349,6 +2351,28 @@ google-auth = ">=1.25.0,<3.0.0"
 
 [package.extras]
 grpc = ["grpcio (>=1.38.0,<2.0.0) ; python_version < \"3.14\"", "grpcio (>=1.75.1,<2.0.0) ; python_version >= \"3.14\"", "grpcio-status (>=1.38.0,<2.0.0)"]
+
+[[package]]
+name = "google-cloud-documentai"
+version = "3.9.0"
+description = "Google Cloud Documentai API client library"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "google_cloud_documentai-3.9.0-py3-none-any.whl", hash = "sha256:5d38075a02f77de262e114f5b07275011b6c9ba5f004b9bb9f190bc9a03b7b91"},
+    {file = "google_cloud_documentai-3.9.0.tar.gz", hash = "sha256:294cb0f484e36acebc352ec36b3a8993ec0be68e3ad9b383e1eeed7b28f4be9c"},
+]
+
+[package.dependencies]
+google-api-core = {version = ">=1.34.1,<2.0.dev0 || >=2.11.dev0,<3.0.0", extras = ["grpc"]}
+google-auth = ">=2.14.1,<2.24.0 || >2.24.0,<2.25.0 || >2.25.0,<3.0.0"
+grpcio = ">=1.33.2,<2.0.0"
+proto-plus = [
+    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
+    {version = ">=1.22.3,<2.0.0", markers = "python_version < \"3.13\""},
+]
+protobuf = ">=3.20.2,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<7.0.0"
 
 [[package]]
 name = "google-cloud-storage"
@@ -2741,6 +2765,23 @@ typing-extensions = ">=4.12,<5.0"
 
 [package.extras]
 protobuf = ["grpcio-tools (>=1.76.0)"]
+
+[[package]]
+name = "grpcio-status"
+version = "1.76.0"
+description = "Status proto mapping for gRPC"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "grpcio_status-1.76.0-py3-none-any.whl", hash = "sha256:380568794055a8efbbd8871162df92012e0228a5f6dffaf57f2a00c534103b18"},
+    {file = "grpcio_status-1.76.0.tar.gz", hash = "sha256:25fcbfec74c15d1a1cb5da3fab8ee9672852dc16a5a9eeb5baf7d7a9952943cd"},
+]
+
+[package.dependencies]
+googleapis-common-protos = ">=1.5.5"
+grpcio = ">=1.76.0"
+protobuf = ">=6.31.1,<7.0.0"
 
 [[package]]
 name = "h11"
@@ -3633,9 +3674,9 @@ files = [
 [package.dependencies]
 click = ">=8.1.7"
 numpy = [
+    {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
     {version = ">=1.24", markers = "python_version < \"3.12\""},
     {version = ">=1.26", markers = "python_version == \"3.12\""},
-    {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
 ]
 onnxruntime = [
     {version = ">=1.17.0,<=1.20.1", markers = "sys_platform == \"win32\" and python_version > \"3.9\""},
@@ -8552,4 +8593,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "93f1d644b222173769108a3433a010b5906e021ae43e57b1ceebd53c554b0d83"
+content-hash = "6afb2667cf3f3aa638b321c841cff66c7e2e5d489daf925f95d611be731352b5"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -80,6 +80,7 @@ svix = "^1.84.1"
 pyjwt = "^2.10.1"
 mistral_common = {version = "1.8.8", extras = ["sentencepiece"]}
 google-cloud-storage = "^3.8.0"
+google-cloud-documentai = "^3.9.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/backend/tests/unit/adapters/test_fallback_ocr.py
+++ b/backend/tests/unit/adapters/test_fallback_ocr.py
@@ -1,0 +1,176 @@
+"""Tests for FallbackOcrProvider with circuit breaker integration."""
+
+import pytest
+
+from airweave.adapters.circuit_breaker.fake import FakeCircuitBreaker
+from airweave.adapters.ocr.fake import FakeOcrProvider
+from airweave.adapters.ocr.fallback import FallbackOcrProvider
+from airweave.core.protocols.ocr import OcrProvider
+
+FILES = ["/tmp/doc.pdf", "/tmp/img.png"]
+
+class TestProtocolConformance:
+    def test_fallback_is_ocr_provider(self):
+        fb = FallbackOcrProvider(
+            providers=[("fake", FakeOcrProvider())],
+            circuit_breaker=FakeCircuitBreaker(),
+        )
+        assert isinstance(fb, OcrProvider)
+
+
+class TestFallbackOcrProvider:
+    @pytest.fixture
+    def cb(self):
+        return FakeCircuitBreaker()
+
+    @pytest.fixture
+    def primary(self):
+        return FakeOcrProvider(default_markdown="# Primary")
+
+    @pytest.fixture
+    def secondary(self):
+        return FakeOcrProvider(default_markdown="# Secondary")
+
+    @pytest.fixture
+    def failing(self):
+        return FakeOcrProvider(should_raise=RuntimeError("provider down"))
+
+    # ---- Happy path ----
+
+    @pytest.mark.asyncio
+    async def test_uses_first_available_provider(self, cb, primary, secondary):
+        fb = FallbackOcrProvider(
+            providers=[("primary", primary), ("secondary", secondary)],
+            circuit_breaker=cb,
+        )
+        results = await fb.convert_batch(FILES)
+
+        assert results[FILES[0]] == "# Primary"
+        assert primary.call_count == 1
+        assert secondary.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_records_success_on_primary(self, cb, primary):
+        fb = FallbackOcrProvider(
+            providers=[("primary", primary)],
+            circuit_breaker=cb,
+        )
+        await fb.convert_batch(FILES)
+
+        assert cb.successes == ["primary"]
+
+    # ---- Failover ----
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_failure(self, cb, failing, secondary):
+        fb = FallbackOcrProvider(
+            providers=[("failing", failing), ("secondary", secondary)],
+            circuit_breaker=cb,
+        )
+        results = await fb.convert_batch(FILES)
+
+        assert results[FILES[0]] == "# Secondary"
+        assert cb.is_tripped("failing")
+        assert cb.successes == ["secondary"]
+
+    @pytest.mark.asyncio
+    async def test_records_failure_then_success(self, cb, failing, secondary):
+        fb = FallbackOcrProvider(
+            providers=[("failing", failing), ("secondary", secondary)],
+            circuit_breaker=cb,
+        )
+        await fb.convert_batch(FILES)
+
+        assert cb.failures == ["failing"]
+        assert cb.successes == ["secondary"]
+
+    @pytest.mark.asyncio
+    async def test_failing_provider_still_called(self, cb, failing, secondary):
+        """Failing provider is attempted (call recorded) before fallback."""
+        fb = FallbackOcrProvider(
+            providers=[("failing", failing), ("secondary", secondary)],
+            circuit_breaker=cb,
+        )
+        await fb.convert_batch(FILES)
+
+        assert failing.call_count == 1
+        assert secondary.call_count == 1
+
+    # ---- Circuit breaker skipping ----
+
+    @pytest.mark.asyncio
+    async def test_skips_circuit_broken_provider(self, cb, primary, secondary):
+        await cb.record_failure("primary")
+
+        fb = FallbackOcrProvider(
+            providers=[("primary", primary), ("secondary", secondary)],
+            circuit_breaker=cb,
+        )
+        results = await fb.convert_batch(FILES)
+
+        assert results[FILES[0]] == "# Secondary"
+        assert primary.call_count == 0
+        assert secondary.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_multiple_circuit_broken_providers(self, cb, secondary):
+        await cb.record_failure("first")
+        await cb.record_failure("second")
+
+        fb = FallbackOcrProvider(
+            providers=[
+                ("first", FakeOcrProvider(should_raise=RuntimeError("down"))),
+                ("second", FakeOcrProvider(should_raise=RuntimeError("down"))),
+                ("secondary", secondary),
+            ],
+            circuit_breaker=cb,
+        )
+        results = await fb.convert_batch(FILES)
+
+        assert results[FILES[0]] == "# Secondary"
+
+    # ---- All providers exhausted ----
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_all_fail(self, cb):
+        fb = FallbackOcrProvider(
+            providers=[
+                ("a", FakeOcrProvider(should_raise=RuntimeError("down"))),
+                ("b", FakeOcrProvider(should_raise=RuntimeError("down"))),
+            ],
+            circuit_breaker=cb,
+        )
+        results = await fb.convert_batch(FILES)
+
+        assert all(v is None for v in results.values())
+        assert cb.failure_count == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_all_circuit_broken(self, cb, primary):
+        await cb.record_failure("primary")
+
+        fb = FallbackOcrProvider(
+            providers=[("primary", primary)],
+            circuit_breaker=cb,
+        )
+        results = await fb.convert_batch(FILES)
+
+        assert all(v is None for v in results.values())
+        assert primary.call_count == 0
+
+    # ---- Edge cases ----
+
+    def test_rejects_empty_providers(self, cb):
+        with pytest.raises(ValueError, match="At least one"):
+            FallbackOcrProvider(providers=[], circuit_breaker=cb)
+
+    @pytest.mark.asyncio
+    async def test_empty_file_list(self, cb, primary):
+        fb = FallbackOcrProvider(
+            providers=[("primary", primary)],
+            circuit_breaker=cb,
+        )
+        results = await fb.convert_batch([])
+
+        assert results == {}
+        assert primary.call_count == 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Google Document AI OCR adapter to support GCP OCR with bounded concurrency and optional fallback in the OCR chain. This enables high‑quality OCR for PDFs and common image formats.

- **New Features**
  - GoogleDocumentAIOcrAdapter implements OcrProvider with async batch processing via asyncio.to_thread and a semaphore.
  - Enforces the 20MB online limit and maps supported MIME types. Returns None on failure and empty string on empty results.
  - Exported in the OCR package. Optional fallback wiring is commented in container/factory.py; set GCP_DOCUMENT_AI_* settings and uncomment to enable.

- **Dependencies**
  - Adds google-cloud-documentai and related gRPC dependencies.

<sup>Written for commit 380d763f59c5949b5456070c80c4d2e85bef9c93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

