### PR TITLE
Checkout `todoist` new API prefix

### DIFF
--- a/backend/airweave/platform/sources/todoist.py
+++ b/backend/airweave/platform/sources/todoist.py
@@ -99,9 +99,9 @@ class TodoistSource(BaseSource):
     ) -> AsyncGenerator[TodoistProjectEntity, None]:
         """Retrieve and yield Project entities.
 
-        GET https://api.todoist.com/rest/v2/projects
+        GET https://api.todoist.com/api/v1/projects
         """
-        url = "https://api.todoist.com/rest/v2/projects"
+        url = "https://api.todoist.com/api/v1/projects"
         projects = await self._get_with_auth(client, url)
         if not projects:
             return
@@ -144,9 +144,9 @@ class TodoistSource(BaseSource):
     ) -> AsyncGenerator[TodoistSectionEntity, None]:
         """Retrieve and yield Section entities for a given project.
 
-        GET https://api.todoist.com/rest/v2/sections?project_id={project_id}
+        GET https://api.todoist.com/api/v1/sections?project_id={project_id}
         """
-        url = f"https://api.todoist.com/rest/v2/sections?project_id={project_id}"
+        url = f"https://api.todoist.com/api/v1/sections?project_id={project_id}"
         sections = await self._get_with_auth(client, url)
         if not sections:
             return
@@ -172,11 +172,11 @@ class TodoistSource(BaseSource):
     ) -> List[Dict]:
         """Fetch all tasks for a given project.
 
-        GET https://api.todoist.com/rest/v2/tasks?project_id={project_id}
+        GET https://api.todoist.com/api/v1/tasks?project_id={project_id}
 
         Returns a list of task objects.
         """
-        url = f"https://api.todoist.com/rest/v2/tasks?project_id={project_id}"
+        url = f"https://api.todoist.com/api/v1/tasks?project_id={project_id}"
         tasks = await self._get_with_auth(client, url)
         return tasks if isinstance(tasks, list) else []
 
@@ -277,10 +277,10 @@ class TodoistSource(BaseSource):
     ) -> AsyncGenerator[TodoistCommentEntity, None]:
         """Retrieve and yield Comment entities for a given task.
 
-        GET https://api.todoist.com/rest/v2/comments?task_id={task_id}
+        GET https://api.todoist.com/api/v1/comments?task_id={task_id}
         """
         task_id = task_entity.entity_id
-        url = f"https://api.todoist.com/rest/v2/comments?task_id={task_id}"
+        url = f"https://api.todoist.com/api/v1/comments?task_id={task_id}"
         comments = await self._get_with_auth(client, url)
         if not isinstance(comments, list):
             return
@@ -348,7 +348,9 @@ class TodoistSource(BaseSource):
 
                 # Re-fetch sections in-memory to attach tasks to them,
                 # or reuse the info from above if desired
-                url_sections = f"https://api.todoist.com/rest/v2/sections?project_id={project_entity.entity_id}"
+                url_sections = (
+                    f"https://api.todoist.com/api/v1/sections?project_id={project_entity.entity_id}"
+                )
                 sections_data = await self._get_with_auth(client, url_sections)
                 sections = sections_data if isinstance(sections_data, list) else []
 
@@ -407,7 +409,7 @@ class TodoistSource(BaseSource):
     async def validate(self) -> bool:
         """Verify Todoist OAuth2 token by pinging a lightweight REST endpoint."""
         return await self._validate_oauth2(
-            ping_url="https://api.todoist.com/rest/v2/projects",
+            ping_url="https://api.todoist.com/api/v1/projects",
             headers={"Accept": "application/json"},
             timeout=10.0,
         )

--- a/monke/bongos/todoist.py
+++ b/monke/bongos/todoist.py
@@ -198,7 +198,7 @@ class TodoistBongo(BaseBongo):
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                "https://api.todoist.com/rest/v2/projects",
+                "https://api.todoist.com/api/v1/projects",
                 headers={
                     "Authorization": f"Bearer {self.access_token}",
                     "Content-Type": "application/json",
@@ -230,7 +230,7 @@ class TodoistBongo(BaseBongo):
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                "https://api.todoist.com/rest/v2/tasks",
+                "https://api.todoist.com/api/v1/tasks",
                 headers={
                     "Authorization": f"Bearer {self.access_token}",
                     "Content-Type": "application/json",
@@ -256,7 +256,7 @@ class TodoistBongo(BaseBongo):
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                f"https://api.todoist.com/rest/v2/tasks/{task_id}",
+                f"https://api.todoist.com/api/v1/tasks/{task_id}",
                 headers={
                     "Authorization": f"Bearer {self.access_token}",
                     "Content-Type": "application/json",
@@ -273,7 +273,7 @@ class TodoistBongo(BaseBongo):
 
         async with httpx.AsyncClient() as client:
             response = await client.delete(
-                f"https://api.todoist.com/rest/v2/tasks/{task_id}",
+                f"https://api.todoist.com/api/v1/tasks/{task_id}",
                 headers={"Authorization": f"Bearer {self.access_token}"},
             )
 
@@ -285,7 +285,7 @@ class TodoistBongo(BaseBongo):
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.get(
-                    f"https://api.todoist.com/rest/v2/tasks/{task_id}",
+                    f"https://api.todoist.com/api/v1/tasks/{task_id}",
                     headers={"Authorization": f"Bearer {self.access_token}"},
                 )
 
@@ -312,7 +312,7 @@ class TodoistBongo(BaseBongo):
 
         async with httpx.AsyncClient() as client:
             response = await client.delete(
-                f"https://api.todoist.com/rest/v2/projects/{project_id}",
+                f"https://api.todoist.com/api/v1/projects/{project_id}",
                 headers={"Authorization": f"Bearer {self.access_token}"},
             )
 


### PR DESCRIPTION
Exploring https://github.com/airweave-ai/airweave/pull/1399 CI failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched Todoist API calls from /rest/v2 to /api/v1 across the backend source and test helpers to fix failing CI requests. Updated projects, sections, tasks, comments, and the OAuth validation ping endpoints.

<sup>Written for commit 1d001b364cd8e82fbdaa1da51ed15a21d020d7d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

