### PR TITLE
fix(embedding-model): wrong model choice

### DIFF
--- a/backend/airweave/search/agentic_search/config.py
+++ b/backend/airweave/search/agentic_search/config.py
@@ -123,7 +123,7 @@ class AgenticSearchConfig:
     # here produces query embeddings in a different vector space than
     # the stored document embeddings, making semantic search useless.
     DENSE_EMBEDDER_PROVIDER = DenseEmbedderProvider.OPENAI
-    DENSE_EMBEDDER_MODEL = DenseEmbedderModel.TEXT_EMBEDDING_3_SMALL
+    DENSE_EMBEDDER_MODEL = DenseEmbedderModel.TEXT_EMBEDDING_3_LARGE
 
     # Sparse embedder
     SPARSE_EMBEDDER_PROVIDER = SparseEmbedderProvider.FASTEMBED


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the dense embedder model to TEXT_EMBEDDING_3_LARGE so query embeddings share the same vector space as stored document embeddings, restoring accurate semantic search.

<sup>Written for commit 2f5082efb95030f928c5db56b17f3a4c05833fec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

