### PR TITLE
Fix `vespa.QueryBuilder` test failure related to `presentation.summary` parameter

### DIFF
--- a/backend/tests/unit/platform/destinations/vespa/test_query_builder.py
+++ b/backend/tests/unit/platform/destinations/vespa/test_query_builder.py
@@ -154,8 +154,9 @@ class TestQueryBuilder:
         assert params["query"] == "test query"
         assert params["hits"] == 10
         assert params["offset"] == 0
-        assert params["presentation.summary"] == "full"
         assert params["ranking.softtimeout.enable"] == "true"
+        # We rely on Vespa's default summary (all fields with summary indexing)
+        assert "presentation.summary" not in params
 
     def test_build_params_ranking_profile_hybrid(self, query_builder, sample_dense_embeddings):
         """Test hybrid strategy selects hybrid ranking profile."""


### PR DESCRIPTION
ref: https://github.com/airweave-ai/airweave/blob/f205df418109ad5980b8cae19f07bed3a6171393/backend/airweave/platform/destinations/vespa/query_builder.py#L158-L159

(from the https://github.com/airweave-ai/airweave/pull/1372)

Since we don't explicitly set `presentation.summary` YQL query parameter anymore, it makes sense to test this behaviour instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Vespa QueryBuilder unit test to stop asserting presentation.summary=full and instead verify the parameter is unset, aligning with current behavior. This fixes the failing test and relies on Vespa’s default summary.

<sup>Written for commit 952081494695ba6d156ac3fd2b755771d1dc426a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

