### PR TITLE
fix(oauth): query param stripping in OAuth1 signature base string

### DIFF
--- a/backend/airweave/adapters/encryption/__init__.py
+++ b/backend/airweave/adapters/encryption/__init__.py
@@ -1,0 +1,9 @@
+"""Encryption adapters."""
+
+from airweave.adapters.encryption.fake import FakeCredentialEncryptor
+from airweave.adapters.encryption.fernet import FernetCredentialEncryptor
+
+__all__ = [
+    "FakeCredentialEncryptor",
+    "FernetCredentialEncryptor",
+]

--- a/backend/airweave/adapters/encryption/fake.py
+++ b/backend/airweave/adapters/encryption/fake.py
@@ -1,0 +1,42 @@
+"""Fake credential encryptor for testing.
+
+Round-trips dicts through a predictable transform without real crypto.
+Records calls for assertions.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class FakeCredentialEncryptor:
+    """Test implementation of CredentialEncryptor.
+
+    Usage::
+
+        fake = FakeCredentialEncryptor()
+        blob = fake.encrypt({"access_token": "tok"})
+        assert fake.decrypt(blob) == {}  # unless seeded
+
+        fake.seed_decrypt({"access_token": "tok"})
+        assert fake.decrypt(blob) == {"access_token": "tok"}
+    """
+
+    def __init__(self) -> None:
+        self._encrypt_calls: list[dict] = []
+        self._decrypt_calls: list[str] = []
+        self._decrypt_return: Optional[dict] = None
+
+    def seed_decrypt(self, result: dict) -> None:
+        """Set the dict that :meth:`decrypt` will return."""
+        self._decrypt_return = result
+
+    def encrypt(self, data: dict) -> str:
+        self._encrypt_calls.append(data)
+        return f"encrypted:{id(data)}"
+
+    def decrypt(self, encrypted: str) -> dict:
+        self._decrypt_calls.append(encrypted)
+        if self._decrypt_return is not None:
+            return dict(self._decrypt_return)
+        return {}

--- a/backend/airweave/adapters/encryption/fernet.py
+++ b/backend/airweave/adapters/encryption/fernet.py
@@ -1,0 +1,19 @@
+"""Fernet-based credential encryption adapter.
+
+Delegates to :mod:`airweave.core.credentials` which manages the
+``ENCRYPTION_KEY`` setting and the :class:`cryptography.fernet.Fernet` instance.
+"""
+
+from __future__ import annotations
+
+from airweave.core import credentials as _creds
+
+
+class FernetCredentialEncryptor:
+    """Encrypt/decrypt credential dicts using Fernet symmetric encryption."""
+
+    def encrypt(self, data: dict) -> str:
+        return _creds.encrypt(data)
+
+    def decrypt(self, encrypted: str) -> dict:
+        return _creds.decrypt(encrypted)

--- a/backend/airweave/adapters/encryption/fernet.py
+++ b/backend/airweave/adapters/encryption/fernet.py
@@ -1,19 +1,20 @@
-"""Fernet-based credential encryption adapter.
-
-Delegates to :mod:`airweave.core.credentials` which manages the
-``ENCRYPTION_KEY`` setting and the :class:`cryptography.fernet.Fernet` instance.
-"""
+"""Fernet-based credential encryption adapter."""
 
 from __future__ import annotations
 
-from airweave.core import credentials as _creds
+import json
+
+from cryptography.fernet import Fernet
 
 
 class FernetCredentialEncryptor:
     """Encrypt/decrypt credential dicts using Fernet symmetric encryption."""
 
+    def __init__(self, encryption_key: str) -> None:
+        self._fernet = Fernet(encryption_key.encode())
+
     def encrypt(self, data: dict) -> str:
-        return _creds.encrypt(data)
+        return self._fernet.encrypt(json.dumps(data).encode()).decode()
 
     def decrypt(self, encrypted: str) -> dict:
-        return _creds.decrypt(encrypted)
+        return json.loads(self._fernet.decrypt(encrypted).decode())

--- a/backend/airweave/core/container/container.py
+++ b/backend/airweave/core/container/container.py
@@ -25,7 +25,7 @@ from airweave.core.protocols import (
 from airweave.domains.auth_provider.protocols import AuthProviderRegistryProtocol
 from airweave.domains.connections.protocols import ConnectionRepositoryProtocol
 from airweave.domains.credentials.protocols import IntegrationCredentialRepositoryProtocol
-from airweave.domains.oauth.protocols import OAuth2ServiceProtocol
+from airweave.domains.oauth.protocols import OAuth1ServiceProtocol, OAuth2ServiceProtocol
 from airweave.domains.source_connections.protocols import SourceConnectionRepositoryProtocol
 from airweave.domains.sources.protocols import (
     SourceLifecycleServiceProtocol,
@@ -90,7 +90,8 @@ class Container:
     conn_repo: ConnectionRepositoryProtocol
     cred_repo: IntegrationCredentialRepositoryProtocol
 
-    # OAuth2 token operations
+    # OAuth services
+    oauth1_service: OAuth1ServiceProtocol
     oauth2_service: OAuth2ServiceProtocol
 
     # Source lifecycle — creates/validates configured source instances

--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from airweave.adapters.circuit_breaker import InMemoryCircuitBreaker
+from airweave.adapters.encryption.fernet import FernetCredentialEncryptor
 from airweave.adapters.event_bus.in_memory import InMemoryEventBus
 from airweave.adapters.ocr.docling import DoclingOcrAdapter
 from airweave.adapters.webhooks.endpoint_verifier import HttpEndpointVerifier
@@ -27,8 +28,8 @@ from airweave.domains.auth_provider.registry import AuthProviderRegistry
 from airweave.domains.connections.repository import ConnectionRepository
 from airweave.domains.credentials.repository import IntegrationCredentialRepository
 from airweave.domains.entities.registry import EntityDefinitionRegistry
+from airweave.domains.oauth.oauth1_service import OAuth1Service
 from airweave.domains.oauth.oauth2_service import OAuth2Service
-from airweave.adapters.encryption.fernet import FernetCredentialEncryptor
 from airweave.domains.oauth.repository import (
     OAuthConnectionRepository,
     OAuthCredentialRepository,
@@ -120,6 +121,7 @@ def create_container(settings: Settings) -> Container:
         sc_repo=source_deps["sc_repo"],
         conn_repo=source_deps["conn_repo"],
         cred_repo=source_deps["cred_repo"],
+        oauth1_service=source_deps["oauth1_service"],
         oauth2_service=source_deps["oauth2_service"],
         source_lifecycle_service=source_deps["source_lifecycle_service"],
         endpoint_verifier=endpoint_verifier,
@@ -224,11 +226,12 @@ def _create_source_services(settings: Settings) -> dict:
     sc_repo = SourceConnectionRepository()
     conn_repo = ConnectionRepository()
     cred_repo = IntegrationCredentialRepository()
+    oauth1_svc = OAuth1Service()
     oauth2_svc = OAuth2Service(
         settings=settings,
         conn_repo=OAuthConnectionRepository(),
         cred_repo=OAuthCredentialRepository(),
-        encryptor=FernetCredentialEncryptor(),
+        encryptor=FernetCredentialEncryptor(settings.ENCRYPTION_KEY),
         source_repo=OAuthSourceRepository(),
     )
 
@@ -252,6 +255,7 @@ def _create_source_services(settings: Settings) -> dict:
         "sc_repo": sc_repo,
         "conn_repo": conn_repo,
         "cred_repo": cred_repo,
+        "oauth1_service": oauth1_svc,
         "oauth2_service": oauth2_svc,
         "source_lifecycle_service": source_lifecycle_service,
     }

--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -28,8 +28,8 @@ from airweave.domains.connections.repository import ConnectionRepository
 from airweave.domains.credentials.repository import IntegrationCredentialRepository
 from airweave.domains.entities.registry import EntityDefinitionRegistry
 from airweave.domains.oauth.oauth2_service import OAuth2Service
+from airweave.adapters.encryption.fernet import FernetCredentialEncryptor
 from airweave.domains.oauth.repository import (
-    CredentialEncryptor,
     OAuthConnectionRepository,
     OAuthCredentialRepository,
     OAuthSourceRepository,
@@ -228,7 +228,7 @@ def _create_source_services(settings: Settings) -> dict:
         settings=settings,
         conn_repo=OAuthConnectionRepository(),
         cred_repo=OAuthCredentialRepository(),
-        encryptor=CredentialEncryptor(),
+        encryptor=FernetCredentialEncryptor(),
         source_repo=OAuthSourceRepository(),
     )
 

--- a/backend/airweave/core/protocols/__init__.py
+++ b/backend/airweave/core/protocols/__init__.py
@@ -6,6 +6,7 @@ infrastructure protocols only.
 """
 
 from airweave.core.protocols.circuit_breaker import CircuitBreaker
+from airweave.core.protocols.encryption import CredentialEncryptor
 from airweave.core.protocols.event_bus import DomainEvent, EventBus, EventHandler
 from airweave.core.protocols.ocr import OcrProvider
 from airweave.core.protocols.webhooks import (
@@ -17,6 +18,7 @@ from airweave.core.protocols.webhooks import (
 
 __all__ = [
     "CircuitBreaker",
+    "CredentialEncryptor",
     "DomainEvent",
     "EndpointVerifier",
     "EventBus",

--- a/backend/airweave/core/protocols/encryption.py
+++ b/backend/airweave/core/protocols/encryption.py
@@ -1,0 +1,33 @@
+"""Credential encryption protocol.
+
+Defines the structural typing contract for encrypting/decrypting
+credential dicts. Uses :class:`typing.Protocol` so implementations
+don't need to inherit.
+
+Usage::
+
+    from airweave.core.protocols.encryption import CredentialEncryptor
+
+
+    def refresh_token(encryptor: CredentialEncryptor) -> ...:
+        creds = encryptor.decrypt(encrypted_blob)
+        creds["access_token"] = new_token
+        encrypted = encryptor.encrypt(creds)
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class CredentialEncryptor(Protocol):
+    """Encrypt/decrypt credential dicts to/from opaque strings."""
+
+    def encrypt(self, data: dict) -> str:
+        """Encrypt a credential dict to an opaque string."""
+        ...
+
+    def decrypt(self, encrypted: str) -> dict:
+        """Decrypt an opaque string back to a credential dict."""
+        ...

--- a/backend/airweave/domains/oauth/fakes/oauth2_service.py
+++ b/backend/airweave/domains/oauth/fakes/oauth2_service.py
@@ -1,33 +1,152 @@
 """Fake OAuth2 service for testing."""
 
-from typing import Optional
+from typing import Optional, Tuple
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave.api.context import ApiContext
-
-
-class FakeOAuth2TokenResponse:
-    """Minimal token response returned by FakeOAuth2Service."""
-
-    def __init__(self, access_token: str) -> None:
-        self.access_token = access_token
+from airweave.platform.auth.schemas import OAuth2Settings, OAuth2TokenResponse
 
 
 class FakeOAuth2Service:
-    """In-memory fake for OAuth2ServiceProtocol."""
+    """In-memory fake for OAuth2ServiceProtocol.
+
+    Covers all public methods of OAuth2Service. Seed responses per-integration
+    and inspect recorded calls for assertions.
+    """
 
     def __init__(self) -> None:
-        self._responses: dict[str, FakeOAuth2TokenResponse] = {}
+        self._refresh_responses: dict[str, OAuth2TokenResponse] = {}
+        self._exchange_responses: dict[str, OAuth2TokenResponse] = {}
+        self._auth_urls: dict[str, str] = {}
+        self._auth_url_with_redirect_responses: dict[str, Tuple[str, Optional[str]]] = {}
         self._calls: list[tuple] = []
         self._should_raise: Optional[Exception] = None
 
-    def seed(self, integration_short_name: str, access_token: str) -> None:
-        self._responses[integration_short_name] = FakeOAuth2TokenResponse(access_token)
+    # -- seeding helpers --
+
+    def seed_refresh(self, integration_short_name: str, access_token: str, **extra: str) -> None:
+        self._refresh_responses[integration_short_name] = OAuth2TokenResponse(
+            access_token=access_token, **extra
+        )
+
+    def seed_exchange(self, source_short_name: str, access_token: str, **extra: str) -> None:
+        self._exchange_responses[source_short_name] = OAuth2TokenResponse(
+            access_token=access_token, **extra
+        )
+
+    def seed_auth_url(self, integration_short_name: str, url: str) -> None:
+        self._auth_urls[integration_short_name] = url
+
+    def seed_auth_url_with_redirect(
+        self,
+        integration_short_name: str,
+        url: str,
+        code_verifier: Optional[str] = None,
+    ) -> None:
+        self._auth_url_with_redirect_responses[integration_short_name] = (url, code_verifier)
 
     def set_error(self, error: Exception) -> None:
         self._should_raise = error
+
+    def clear_error(self) -> None:
+        self._should_raise = None
+
+    @property
+    def calls(self) -> list[tuple]:
+        return list(self._calls)
+
+    def calls_for(self, method: str) -> list[tuple]:
+        return [c for c in self._calls if c[0] == method]
+
+    # -- public methods matching OAuth2ServiceProtocol + extras --
+
+    async def generate_auth_url(
+        self,
+        oauth2_settings: OAuth2Settings,
+        client_id: Optional[str] = None,
+        state: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+    ) -> str:
+        self._calls.append(("generate_auth_url", oauth2_settings, client_id, state))
+        if self._should_raise:
+            raise self._should_raise
+        url = self._auth_urls.get(oauth2_settings.integration_short_name)
+        if url is None:
+            raise ValueError(
+                f"No seeded auth_url for {oauth2_settings.integration_short_name}"
+            )
+        return url
+
+    async def exchange_authorization_code_for_token(
+        self,
+        ctx: ApiContext,
+        source_short_name: str,
+        code: str,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+    ) -> OAuth2TokenResponse:
+        self._calls.append((
+            "exchange_authorization_code_for_token",
+            ctx, source_short_name, code, client_id, client_secret, template_configs,
+        ))
+        if self._should_raise:
+            raise self._should_raise
+        resp = self._exchange_responses.get(source_short_name)
+        if not resp:
+            raise ValueError(f"No seeded exchange response for {source_short_name}")
+        return resp
+
+    async def generate_auth_url_with_redirect(
+        self,
+        oauth2_settings: OAuth2Settings,
+        *,
+        redirect_uri: str,
+        client_id: Optional[str] = None,
+        state: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+    ) -> Tuple[str, Optional[str]]:
+        self._calls.append((
+            "generate_auth_url_with_redirect",
+            oauth2_settings, redirect_uri, client_id, state,
+        ))
+        if self._should_raise:
+            raise self._should_raise
+        result = self._auth_url_with_redirect_responses.get(
+            oauth2_settings.integration_short_name
+        )
+        if result is None:
+            raise ValueError(
+                f"No seeded auth_url_with_redirect for "
+                f"{oauth2_settings.integration_short_name}"
+            )
+        return result
+
+    async def exchange_authorization_code_for_token_with_redirect(
+        self,
+        ctx: ApiContext,
+        *,
+        source_short_name: str,
+        code: str,
+        redirect_uri: str,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+        code_verifier: Optional[str] = None,
+    ) -> OAuth2TokenResponse:
+        self._calls.append((
+            "exchange_authorization_code_for_token_with_redirect",
+            ctx, source_short_name, code, redirect_uri,
+            client_id, client_secret, template_configs, code_verifier,
+        ))
+        if self._should_raise:
+            raise self._should_raise
+        resp = self._exchange_responses.get(source_short_name)
+        if not resp:
+            raise ValueError(f"No seeded exchange response for {source_short_name}")
+        return resp
 
     async def refresh_access_token(
         self,
@@ -37,21 +156,15 @@ class FakeOAuth2Service:
         connection_id: UUID,
         decrypted_credential: dict,
         config_fields: Optional[dict] = None,
-    ) -> FakeOAuth2TokenResponse:
-        self._calls.append(
-            (
-                "refresh_access_token",
-                db,
-                integration_short_name,
-                ctx,
-                connection_id,
-                decrypted_credential,
-                config_fields,
-            )
-        )
+    ) -> OAuth2TokenResponse:
+        self._calls.append((
+            "refresh_access_token",
+            db, integration_short_name, ctx, connection_id,
+            decrypted_credential, config_fields,
+        ))
         if self._should_raise:
             raise self._should_raise
-        response = self._responses.get(integration_short_name)
-        if not response:
-            raise ValueError(f"No seeded response for {integration_short_name}")
-        return response
+        resp = self._refresh_responses.get(integration_short_name)
+        if not resp:
+            raise ValueError(f"No seeded refresh response for {integration_short_name}")
+        return resp

--- a/backend/airweave/domains/oauth/fakes/oauth2_service.py
+++ b/backend/airweave/domains/oauth/fakes/oauth2_service.py
@@ -74,9 +74,7 @@ class FakeOAuth2Service:
             raise self._should_raise
         url = self._auth_urls.get(oauth2_settings.integration_short_name)
         if url is None:
-            raise ValueError(
-                f"No seeded auth_url for {oauth2_settings.integration_short_name}"
-            )
+            raise ValueError(f"No seeded auth_url for {oauth2_settings.integration_short_name}")
         return url
 
     async def exchange_authorization_code_for_token(
@@ -88,10 +86,17 @@ class FakeOAuth2Service:
         client_secret: Optional[str] = None,
         template_configs: Optional[dict] = None,
     ) -> OAuth2TokenResponse:
-        self._calls.append((
-            "exchange_authorization_code_for_token",
-            ctx, source_short_name, code, client_id, client_secret, template_configs,
-        ))
+        self._calls.append(
+            (
+                "exchange_authorization_code_for_token",
+                ctx,
+                source_short_name,
+                code,
+                client_id,
+                client_secret,
+                template_configs,
+            )
+        )
         if self._should_raise:
             raise self._should_raise
         resp = self._exchange_responses.get(source_short_name)
@@ -108,19 +113,21 @@ class FakeOAuth2Service:
         state: Optional[str] = None,
         template_configs: Optional[dict] = None,
     ) -> Tuple[str, Optional[str]]:
-        self._calls.append((
-            "generate_auth_url_with_redirect",
-            oauth2_settings, redirect_uri, client_id, state,
-        ))
+        self._calls.append(
+            (
+                "generate_auth_url_with_redirect",
+                oauth2_settings,
+                redirect_uri,
+                client_id,
+                state,
+            )
+        )
         if self._should_raise:
             raise self._should_raise
-        result = self._auth_url_with_redirect_responses.get(
-            oauth2_settings.integration_short_name
-        )
+        result = self._auth_url_with_redirect_responses.get(oauth2_settings.integration_short_name)
         if result is None:
             raise ValueError(
-                f"No seeded auth_url_with_redirect for "
-                f"{oauth2_settings.integration_short_name}"
+                f"No seeded auth_url_with_redirect for {oauth2_settings.integration_short_name}"
             )
         return result
 
@@ -136,11 +143,19 @@ class FakeOAuth2Service:
         template_configs: Optional[dict] = None,
         code_verifier: Optional[str] = None,
     ) -> OAuth2TokenResponse:
-        self._calls.append((
-            "exchange_authorization_code_for_token_with_redirect",
-            ctx, source_short_name, code, redirect_uri,
-            client_id, client_secret, template_configs, code_verifier,
-        ))
+        self._calls.append(
+            (
+                "exchange_authorization_code_for_token_with_redirect",
+                ctx,
+                source_short_name,
+                code,
+                redirect_uri,
+                client_id,
+                client_secret,
+                template_configs,
+                code_verifier,
+            )
+        )
         if self._should_raise:
             raise self._should_raise
         resp = self._exchange_responses.get(source_short_name)
@@ -157,11 +172,17 @@ class FakeOAuth2Service:
         decrypted_credential: dict,
         config_fields: Optional[dict] = None,
     ) -> OAuth2TokenResponse:
-        self._calls.append((
-            "refresh_access_token",
-            db, integration_short_name, ctx, connection_id,
-            decrypted_credential, config_fields,
-        ))
+        self._calls.append(
+            (
+                "refresh_access_token",
+                db,
+                integration_short_name,
+                ctx,
+                connection_id,
+                decrypted_credential,
+                config_fields,
+            )
+        )
         if self._should_raise:
             raise self._should_raise
         resp = self._refresh_responses.get(integration_short_name)

--- a/backend/airweave/domains/oauth/fakes/repository.py
+++ b/backend/airweave/domains/oauth/fakes/repository.py
@@ -23,9 +23,7 @@ class FakeOAuthConnectionRepository:
         self._calls.append(("get", db, id, ctx))
         return self._store.get(id)
 
-    async def create(
-        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
-    ) -> Any:
+    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
         self._calls.append(("create", db, obj_in, ctx, uow))
         self._created.append(obj_in)
         return obj_in
@@ -47,45 +45,15 @@ class FakeOAuthCredentialRepository:
         self._calls.append(("get", db, id, ctx))
         return self._store.get(id)
 
-    async def update(
-        self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext
-    ) -> Any:
+    async def update(self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext) -> Any:
         self._calls.append(("update", db, db_obj, obj_in, ctx))
         self._updated.append((db_obj, obj_in))
         return db_obj
 
-    async def create(
-        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
-    ) -> Any:
+    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
         self._calls.append(("create", db, obj_in, ctx, uow))
         self._created.append(obj_in)
         return obj_in
-
-
-class FakeCredentialEncryptor:
-    """In-memory fake for CredentialEncryptorProtocol.
-
-    Stores encrypt/decrypt calls. By default encrypt returns a predictable
-    string and decrypt returns the last-encrypted dict (round-trip).
-    """
-
-    def __init__(self) -> None:
-        self._encrypt_calls: list[dict] = []
-        self._decrypt_calls: list[str] = []
-        self._decrypt_return: Optional[dict] = None
-
-    def seed_decrypt(self, result: dict) -> None:
-        self._decrypt_return = result
-
-    def encrypt(self, data: dict) -> str:
-        self._encrypt_calls.append(data)
-        return f"encrypted:{id(data)}"
-
-    def decrypt(self, encrypted: str) -> dict:
-        self._decrypt_calls.append(encrypted)
-        if self._decrypt_return is not None:
-            return dict(self._decrypt_return)
-        return {}
 
 
 class FakeOAuthSourceRepository:

--- a/backend/airweave/domains/oauth/fakes/repository.py
+++ b/backend/airweave/domains/oauth/fakes/repository.py
@@ -1,4 +1,4 @@
-"""Fake repositories for OAuth2 domain testing."""
+"""Fake repositories for OAuth domain testing."""
 
 from typing import Any, Optional
 from uuid import UUID
@@ -6,6 +6,15 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave.api.context import ApiContext
+from airweave.db.unit_of_work import UnitOfWork
+from airweave.models.connection import Connection
+from airweave.models.integration_credential import IntegrationCredential
+from airweave.models.source import Source
+from airweave.schemas.connection import ConnectionCreate
+from airweave.schemas.integration_credential import (
+    IntegrationCredentialCreateEncrypted,
+    IntegrationCredentialUpdate,
+)
 
 
 class FakeOAuthConnectionRepository:
@@ -19,11 +28,18 @@ class FakeOAuthConnectionRepository:
     def seed(self, id: UUID, obj: Any) -> None:
         self._store[id] = obj
 
-    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Optional[Any]:
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Connection:
         self._calls.append(("get", db, id, ctx))
         return self._store.get(id)
 
-    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
+    async def create(
+        self,
+        db: AsyncSession,
+        *,
+        obj_in: ConnectionCreate,
+        ctx: ApiContext,
+        uow: UnitOfWork,
+    ) -> Connection:
         self._calls.append(("create", db, obj_in, ctx, uow))
         self._created.append(obj_in)
         return obj_in
@@ -41,16 +57,30 @@ class FakeOAuthCredentialRepository:
     def seed(self, id: UUID, obj: Any) -> None:
         self._store[id] = obj
 
-    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Optional[Any]:
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> IntegrationCredential:
         self._calls.append(("get", db, id, ctx))
         return self._store.get(id)
 
-    async def update(self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext) -> Any:
+    async def update(
+        self,
+        db: AsyncSession,
+        *,
+        db_obj: IntegrationCredential,
+        obj_in: IntegrationCredentialUpdate,
+        ctx: ApiContext,
+    ) -> IntegrationCredential:
         self._calls.append(("update", db, db_obj, obj_in, ctx))
         self._updated.append((db_obj, obj_in))
         return db_obj
 
-    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
+    async def create(
+        self,
+        db: AsyncSession,
+        *,
+        obj_in: IntegrationCredentialCreateEncrypted,
+        ctx: ApiContext,
+        uow: UnitOfWork,
+    ) -> IntegrationCredential:
         self._calls.append(("create", db, obj_in, ctx, uow))
         self._created.append(obj_in)
         return obj_in
@@ -66,6 +96,6 @@ class FakeOAuthSourceRepository:
     def seed(self, short_name: str, obj: Any) -> None:
         self._store[short_name] = obj
 
-    async def get_by_short_name(self, db: AsyncSession, short_name: str) -> Optional[Any]:
+    async def get_by_short_name(self, db: AsyncSession, short_name: str) -> Optional[Source]:
         self._calls.append(("get_by_short_name", db, short_name))
         return self._store.get(short_name)

--- a/backend/airweave/domains/oauth/fakes/repository.py
+++ b/backend/airweave/domains/oauth/fakes/repository.py
@@ -1,0 +1,103 @@
+"""Fake repositories for OAuth2 domain testing."""
+
+from typing import Any, Optional
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from airweave.api.context import ApiContext
+
+
+class FakeOAuthConnectionRepository:
+    """In-memory fake for OAuthConnectionRepositoryProtocol."""
+
+    def __init__(self) -> None:
+        self._store: dict[UUID, Any] = {}
+        self._calls: list[tuple] = []
+        self._created: list[Any] = []
+
+    def seed(self, id: UUID, obj: Any) -> None:
+        self._store[id] = obj
+
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Optional[Any]:
+        self._calls.append(("get", db, id, ctx))
+        return self._store.get(id)
+
+    async def create(
+        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
+    ) -> Any:
+        self._calls.append(("create", db, obj_in, ctx, uow))
+        self._created.append(obj_in)
+        return obj_in
+
+
+class FakeOAuthCredentialRepository:
+    """In-memory fake for OAuthCredentialRepositoryProtocol."""
+
+    def __init__(self) -> None:
+        self._store: dict[UUID, Any] = {}
+        self._calls: list[tuple] = []
+        self._created: list[Any] = []
+        self._updated: list[tuple] = []
+
+    def seed(self, id: UUID, obj: Any) -> None:
+        self._store[id] = obj
+
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Optional[Any]:
+        self._calls.append(("get", db, id, ctx))
+        return self._store.get(id)
+
+    async def update(
+        self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext
+    ) -> Any:
+        self._calls.append(("update", db, db_obj, obj_in, ctx))
+        self._updated.append((db_obj, obj_in))
+        return db_obj
+
+    async def create(
+        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
+    ) -> Any:
+        self._calls.append(("create", db, obj_in, ctx, uow))
+        self._created.append(obj_in)
+        return obj_in
+
+
+class FakeCredentialEncryptor:
+    """In-memory fake for CredentialEncryptorProtocol.
+
+    Stores encrypt/decrypt calls. By default encrypt returns a predictable
+    string and decrypt returns the last-encrypted dict (round-trip).
+    """
+
+    def __init__(self) -> None:
+        self._encrypt_calls: list[dict] = []
+        self._decrypt_calls: list[str] = []
+        self._decrypt_return: Optional[dict] = None
+
+    def seed_decrypt(self, result: dict) -> None:
+        self._decrypt_return = result
+
+    def encrypt(self, data: dict) -> str:
+        self._encrypt_calls.append(data)
+        return f"encrypted:{id(data)}"
+
+    def decrypt(self, encrypted: str) -> dict:
+        self._decrypt_calls.append(encrypted)
+        if self._decrypt_return is not None:
+            return dict(self._decrypt_return)
+        return {}
+
+
+class FakeOAuthSourceRepository:
+    """In-memory fake for OAuthSourceRepositoryProtocol."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, Any] = {}
+        self._calls: list[tuple] = []
+
+    def seed(self, short_name: str, obj: Any) -> None:
+        self._store[short_name] = obj
+
+    async def get_by_short_name(self, db: AsyncSession, short_name: str) -> Optional[Any]:
+        self._calls.append(("get_by_short_name", db, short_name))
+        return self._store.get(short_name)

--- a/backend/airweave/domains/oauth/oauth1_service.py
+++ b/backend/airweave/domains/oauth/oauth1_service.py
@@ -1,0 +1,298 @@
+"""OAuth1 authentication service for integrations that use OAuth 1.0 protocol.
+
+This service handles the 3-legged OAuth1 flow:
+1. Obtain temporary credentials (request token)
+2. Redirect user for authorization
+3. Exchange for access token
+
+Reference: RFC 5849 - The OAuth 1.0 Protocol
+"""
+
+import base64
+import hashlib
+import hmac
+import secrets
+import time
+from typing import Optional
+from urllib.parse import parse_qsl, quote, urlencode
+
+import httpx
+from fastapi import HTTPException
+
+from airweave.core.logging import ContextualLogger
+from airweave.domains.oauth.protocols import OAuth1ServiceProtocol
+from airweave.domains.oauth.types import OAuth1TokenResponse
+
+
+class OAuth1Service(OAuth1ServiceProtocol):
+    """Service for handling OAuth1 authentication flows."""
+
+    def _generate_nonce(self) -> str:
+        """Generate a cryptographically secure random nonce."""
+        return secrets.token_urlsafe(32)
+
+    def _get_timestamp(self) -> str:
+        """Get current Unix timestamp as string."""
+        return str(int(time.time()))
+
+    def _percent_encode(self, value: str) -> str:
+        """Percent-encode a value according to RFC 3986.
+
+        Encodes all characters except unreserved: A-Z, a-z, 0-9, -, ., _, ~
+        """
+        return quote(str(value), safe="~")
+
+    def _build_signature_base_string(self, method: str, url: str, params: dict) -> str:
+        """Build the signature base string per RFC 5849.
+
+        Format: HTTP_METHOD&URL&NORMALIZED_PARAMS
+        """
+        sorted_params = sorted(params.items())
+        param_str = "&".join(
+            f"{self._percent_encode(k)}={self._percent_encode(v)}" for k, v in sorted_params
+        )
+
+        parts = [
+            method.upper(),
+            self._percent_encode(url),
+            self._percent_encode(param_str),
+        ]
+        return "&".join(parts)
+
+    def _sign_hmac_sha1(
+        self, base_string: str, consumer_secret: str, token_secret: str = ""
+    ) -> str:
+        """Sign the base string using HMAC-SHA1.
+
+        Signing key: percent_encode(consumer_secret)&percent_encode(token_secret)
+        """
+        encoded_consumer = self._percent_encode(consumer_secret)
+        encoded_token = self._percent_encode(token_secret)
+        key = f"{encoded_consumer}&{encoded_token}"
+        key_bytes = key.encode("utf-8")
+        base_bytes = base_string.encode("utf-8")
+
+        signature_bytes = hmac.new(key_bytes, base_bytes, hashlib.sha1).digest()
+        return base64.b64encode(signature_bytes).decode("utf-8")
+
+    def _build_authorization_header(self, params: dict) -> str:
+        """Build OAuth1 Authorization header.
+
+        Format: OAuth oauth_consumer_key="...", oauth_nonce="...", ...
+        """
+        sorted_items = sorted(params.items())
+        param_strings = [
+            f'{self._percent_encode(k)}="{self._percent_encode(v)}"' for k, v in sorted_items
+        ]
+        return "OAuth " + ", ".join(param_strings)
+
+    async def get_request_token(
+        self,
+        *,
+        request_token_url: str,
+        consumer_key: str,
+        consumer_secret: str,
+        callback_url: str,
+        logger: ContextualLogger,
+    ) -> OAuth1TokenResponse:
+        """Obtain temporary credentials (request token) from OAuth1 provider.
+
+        Args:
+            request_token_url: Provider's request token endpoint
+            consumer_key: Client identifier (API key)
+            consumer_secret: Client secret
+            callback_url: Callback URL for OAuth flow
+            logger: Logger for debugging
+
+        Returns:
+            OAuth1TokenResponse with temporary credentials
+
+        Raises:
+            HTTPException: If request token retrieval fails
+        """
+        oauth_params = {
+            "oauth_consumer_key": consumer_key,
+            "oauth_signature_method": "HMAC-SHA1",
+            "oauth_timestamp": self._get_timestamp(),
+            "oauth_nonce": self._generate_nonce(),
+            "oauth_version": "1.0",
+            "oauth_callback": callback_url,
+        }
+
+        base_string = self._build_signature_base_string("POST", request_token_url, oauth_params)
+
+        signature = self._sign_hmac_sha1(base_string, consumer_secret, "")
+        oauth_params["oauth_signature"] = signature
+
+        auth_header = self._build_authorization_header(oauth_params)
+
+        logger.info(f"Requesting OAuth1 temporary credentials from {request_token_url}")
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    request_token_url,
+                    headers={
+                        "Authorization": auth_header,
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                )
+                response.raise_for_status()
+
+            response_params = dict(parse_qsl(response.text))
+
+            if "oauth_token" not in response_params or "oauth_token_secret" not in response_params:
+                logger.error(f"Invalid response from OAuth1 provider: {response.text}")
+                raise HTTPException(status_code=400, detail="Invalid response from OAuth1 provider")
+
+            logger.info("Successfully obtained OAuth1 temporary credentials")
+
+            return OAuth1TokenResponse(
+                oauth_token=response_params["oauth_token"],
+                oauth_token_secret=response_params["oauth_token_secret"],
+                **{
+                    k: v
+                    for k, v in response_params.items()
+                    if k not in ["oauth_token", "oauth_token_secret"]
+                },
+            )
+
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                f"HTTP error obtaining request token: {e.response.status_code} - {e.response.text}"
+            )
+            raise HTTPException(
+                status_code=400, detail=f"Failed to obtain request token: {e.response.text}"
+            ) from e
+        except Exception as e:
+            if isinstance(e, HTTPException):
+                raise
+            logger.error(f"Unexpected error obtaining request token: {str(e)}")
+            raise HTTPException(
+                status_code=400, detail=f"Failed to obtain request token: {str(e)}"
+            ) from e
+
+    async def exchange_token(
+        self,
+        *,
+        access_token_url: str,
+        consumer_key: str,
+        consumer_secret: str,
+        oauth_token: str,
+        oauth_token_secret: str,
+        oauth_verifier: str,
+        logger: ContextualLogger,
+    ) -> OAuth1TokenResponse:
+        """Exchange temporary credentials for access token credentials.
+
+        Args:
+            access_token_url: Provider's access token endpoint
+            consumer_key: Client identifier (API key)
+            consumer_secret: Client secret
+            oauth_token: Temporary token from step 1
+            oauth_token_secret: Temporary token secret from step 1
+            oauth_verifier: Verification code from user authorization
+            logger: Logger for debugging
+
+        Returns:
+            OAuth1TokenResponse with access token credentials
+
+        Raises:
+            HTTPException: If token exchange fails
+        """
+        oauth_params = {
+            "oauth_consumer_key": consumer_key,
+            "oauth_token": oauth_token,
+            "oauth_signature_method": "HMAC-SHA1",
+            "oauth_timestamp": self._get_timestamp(),
+            "oauth_nonce": self._generate_nonce(),
+            "oauth_version": "1.0",
+            "oauth_verifier": oauth_verifier,
+        }
+
+        base_string = self._build_signature_base_string("POST", access_token_url, oauth_params)
+
+        signature = self._sign_hmac_sha1(base_string, consumer_secret, oauth_token_secret)
+        oauth_params["oauth_signature"] = signature
+
+        auth_header = self._build_authorization_header(oauth_params)
+
+        logger.info(
+            f"Exchanging OAuth1 temporary credentials for access token at {access_token_url}"
+        )
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    access_token_url,
+                    headers={
+                        "Authorization": auth_header,
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                )
+                response.raise_for_status()
+
+            response_params = dict(parse_qsl(response.text))
+
+            if "oauth_token" not in response_params or "oauth_token_secret" not in response_params:
+                logger.error(f"Invalid access token response: {response.text}")
+                raise HTTPException(status_code=400, detail="Invalid access token response")
+
+            logger.info("Successfully obtained OAuth1 access token")
+
+            return OAuth1TokenResponse(
+                oauth_token=response_params["oauth_token"],
+                oauth_token_secret=response_params["oauth_token_secret"],
+                **{
+                    k: v
+                    for k, v in response_params.items()
+                    if k not in ["oauth_token", "oauth_token_secret"]
+                },
+            )
+
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                f"HTTP error exchanging token: {e.response.status_code} - {e.response.text}"
+            )
+            raise HTTPException(
+                status_code=400, detail=f"Failed to exchange OAuth1 token: {e.response.text}"
+            ) from e
+        except Exception as e:
+            if isinstance(e, HTTPException):
+                raise
+            logger.error(f"Unexpected error exchanging token: {str(e)}")
+            raise HTTPException(
+                status_code=400, detail=f"Failed to exchange OAuth1 token: {str(e)}"
+            ) from e
+
+    def build_authorization_url(
+        self,
+        *,
+        authorization_url: str,
+        oauth_token: str,
+        app_name: Optional[str] = None,
+        scope: Optional[str] = None,
+        expiration: Optional[str] = None,
+    ) -> str:
+        """Build the authorization URL for user consent (step 2 of OAuth1 flow).
+
+        Args:
+            authorization_url: Provider's authorization endpoint
+            oauth_token: Temporary token from step 1
+            app_name: Optional app name to display
+            scope: Optional scope (read, write, account, etc.)
+            expiration: Optional expiration (1hour, 1day, 30days, never)
+
+        Returns:
+            Complete authorization URL for user redirect
+        """
+        params = {"oauth_token": oauth_token}
+
+        if app_name:
+            params["name"] = app_name
+        if scope:
+            params["scope"] = scope
+        if expiration:
+            params["expiration"] = expiration
+
+        return f"{authorization_url}?{urlencode(params)}"

--- a/backend/airweave/domains/oauth/oauth2_service.py
+++ b/backend/airweave/domains/oauth/oauth2_service.py
@@ -150,8 +150,9 @@ class OAuth2Service(OAuth2ServiceProtocol):
             oauth2_settings, source_short_name, template_configs
         )
 
-        if not client_id and not client_secret:
+        if not client_id:
             client_id = oauth2_settings.client_id
+        if not client_secret:
             client_secret = oauth2_settings.client_secret
 
         return await self._exchange_code(

--- a/backend/airweave/domains/oauth/oauth2_service.py
+++ b/backend/airweave/domains/oauth/oauth2_service.py
@@ -18,10 +18,10 @@ from airweave.api.context import ApiContext
 from airweave.core.config.settings import Settings
 from airweave.core.exceptions import NotFoundException, TokenRefreshError
 from airweave.core.logging import ContextualLogger
+from airweave.core.protocols.encryption import CredentialEncryptor
 from airweave.core.shared_models import ConnectionStatus
 from airweave.db.unit_of_work import UnitOfWork
 from airweave.domains.oauth.protocols import (
-    CredentialEncryptorProtocol,
     OAuth2ServiceProtocol,
     OAuthConnectionRepositoryProtocol,
     OAuthCredentialRepositoryProtocol,
@@ -44,7 +44,7 @@ class OAuth2Service(OAuth2ServiceProtocol):
         settings: Settings,
         conn_repo: OAuthConnectionRepositoryProtocol,
         cred_repo: OAuthCredentialRepositoryProtocol,
-        encryptor: CredentialEncryptorProtocol,
+        encryptor: CredentialEncryptor,
         source_repo: OAuthSourceRepositoryProtocol,
     ):
         """Initialize with injected dependencies."""
@@ -331,9 +331,7 @@ class OAuth2Service(OAuth2ServiceProtocol):
                     )
 
                 try:
-                    source = await self.source_repo.get_by_short_name(
-                        db, integration_short_name
-                    )
+                    source = await self.source_repo.get_by_short_name(db, integration_short_name)
                     if source and source.config_class:
                         from airweave.platform.locator import resource_locator
 
@@ -362,9 +360,7 @@ class OAuth2Service(OAuth2ServiceProtocol):
                 ctx.logger, integration_config, refresh_token, client_id, client_secret
             )
 
-            response = await self._make_token_request(
-                ctx.logger, backend_url, headers, payload
-            )
+            response = await self._make_token_request(ctx.logger, backend_url, headers, payload)
 
             oauth2_token_response = await self._handle_token_response(
                 db, response, integration_config, ctx, connection_id
@@ -421,9 +417,7 @@ class OAuth2Service(OAuth2ServiceProtocol):
                 ) from e
         return oauth2_settings.backend_url
 
-    async def _get_refresh_token(
-        self, logger: ContextualLogger, decrypted_credential: dict
-    ) -> str:
+    async def _get_refresh_token(self, logger: ContextualLogger, decrypted_credential: dict) -> str:
         """Get refresh token from decrypted credentials.
 
         Raises:

--- a/backend/airweave/domains/oauth/oauth2_service.py
+++ b/backend/airweave/domains/oauth/oauth2_service.py
@@ -1,18 +1,317 @@
-"""OAuth2 service wrapping the platform oauth2_service singleton."""
+"""OAuth2 service for handling authentication and token exchange for integrations."""
 
-from typing import Optional
+import asyncio
+import base64
+import hashlib
+import random
+import secrets
+from typing import Optional, Tuple
+from urllib.parse import urlencode
 from uuid import UUID
 
+import httpx
+from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from airweave import schemas
 from airweave.api.context import ApiContext
-from airweave.domains.oauth.protocols import OAuth2ServiceProtocol
-from airweave.platform.auth.oauth2_service import oauth2_service
-from airweave.platform.auth.schemas import OAuth2TokenResponse
+from airweave.core.config.settings import Settings
+from airweave.core.exceptions import NotFoundException, TokenRefreshError
+from airweave.core.logging import ContextualLogger
+from airweave.core.shared_models import ConnectionStatus
+from airweave.db.unit_of_work import UnitOfWork
+from airweave.domains.oauth.protocols import (
+    CredentialEncryptorProtocol,
+    OAuth2ServiceProtocol,
+    OAuthConnectionRepositoryProtocol,
+    OAuthCredentialRepositoryProtocol,
+    OAuthSourceRepositoryProtocol,
+)
+from airweave.models.integration_credential import IntegrationType
+from airweave.platform.auth.schemas import (
+    BaseAuthSettings,
+    OAuth2Settings,
+    OAuth2TokenResponse,
+)
+from airweave.platform.auth.settings import integration_settings
 
 
 class OAuth2Service(OAuth2ServiceProtocol):
-    """Delegates to the oauth2_service module-level singleton."""
+    """Service for handling OAuth2 authentication and token exchange."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        conn_repo: OAuthConnectionRepositoryProtocol,
+        cred_repo: OAuthCredentialRepositoryProtocol,
+        encryptor: CredentialEncryptorProtocol,
+        source_repo: OAuthSourceRepositoryProtocol,
+    ):
+        """Initialize with injected dependencies."""
+        self.settings = settings
+        self.conn_repo = conn_repo
+        self.cred_repo = cred_repo
+        self.encryptor = encryptor
+        self.source_repo = source_repo
+
+    async def generate_auth_url(
+        self,
+        oauth2_settings: OAuth2Settings,
+        client_id: Optional[str] = None,
+        state: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+    ) -> str:
+        """Generate the OAuth2 authorization URL for an integration.
+
+        Args:
+            oauth2_settings: The OAuth2 settings for the integration
+            client_id: Optional client ID to override the default one
+            state: Optional state token to round-trip through the OAuth flow
+            template_configs: Optional config fields for URL templates (e.g., instance_url)
+
+        Returns:
+            The authorization URL for the OAuth2 flow
+
+        Raises:
+            HTTPException: If there's an error generating the authorization URL
+            ValueError: If template URL requires template_configs but it's missing
+        """
+        redirect_uri = self._get_redirect_url(oauth2_settings.integration_short_name)
+
+        if not client_id:
+            client_id = oauth2_settings.client_id
+
+        if oauth2_settings.url_template:
+            if not template_configs:
+                raise ValueError(
+                    f"template_configs needed for templated OAuth URLs "
+                    f"({oauth2_settings.integration_short_name})"
+                )
+            try:
+                auth_url_base = oauth2_settings.render_url(**template_configs)
+            except KeyError as e:
+                raise ValueError(
+                    f"Missing template variable {e} for {oauth2_settings.integration_short_name}. "
+                    f"Available in template_configs: {list(template_configs.keys())}"
+                ) from e
+        else:
+            auth_url_base = oauth2_settings.url
+
+        params = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            **(oauth2_settings.additional_frontend_params or {}),
+        }
+
+        if oauth2_settings.scope:
+            params["scope"] = oauth2_settings.scope
+
+        if oauth2_settings.user_scope:
+            params["user_scope"] = oauth2_settings.user_scope
+
+        if state is not None:
+            params["state"] = state
+
+        auth_url = f"{auth_url_base}?{urlencode(params)}"
+
+        return auth_url
+
+    async def exchange_authorization_code_for_token(
+        self,
+        ctx: ApiContext,
+        source_short_name: str,
+        code: str,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+    ) -> OAuth2TokenResponse:
+        """Exchange an authorization code for an OAuth2 token.
+
+        Args:
+            ctx: The API context.
+            source_short_name: The short name of the integration source.
+            code: The authorization code to exchange.
+            client_id: Optional client ID to override the default.
+            client_secret: Optional client secret to override the default.
+            template_configs: Optional config fields for URL templates.
+
+        Returns:
+            OAuth2TokenResponse: The response containing the access token and other details.
+
+        Raises:
+            HTTPException: If settings are not found for the source or token exchange fails.
+        """
+        oauth2_settings = await integration_settings.get_by_short_name(source_short_name)
+        if not oauth2_settings:
+            raise HTTPException(
+                status_code=404, detail=f"Settings not found for source: {source_short_name}"
+            )
+
+        redirect_uri = self._get_redirect_url(source_short_name)
+
+        if getattr(oauth2_settings, "backend_url_template", False):
+            if not template_configs:
+                raise ValueError(f"template_configs needed for {source_short_name}")
+            try:
+                backend_url = oauth2_settings.render_backend_url(**template_configs)
+            except KeyError as e:
+                raise ValueError(
+                    f"Missing template variable {e} in template_configs for token exchange"
+                ) from e
+        else:
+            backend_url = oauth2_settings.backend_url
+
+        if not client_id and not client_secret:
+            client_id = oauth2_settings.client_id
+            client_secret = oauth2_settings.client_secret
+
+        return await self._exchange_code(
+            logger=ctx.logger,
+            code=code,
+            redirect_uri=redirect_uri,
+            client_id=client_id,
+            client_secret=client_secret,
+            backend_url=backend_url,
+            integration_config=oauth2_settings,
+        )
+
+    async def generate_auth_url_with_redirect(
+        self,
+        oauth2_settings: OAuth2Settings,
+        *,
+        redirect_uri: str,
+        client_id: Optional[str] = None,
+        state: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+    ) -> Tuple[str, Optional[str]]:
+        """Generate an OAuth2 authorization URL with PKCE support if required.
+
+        For providers that require PKCE (e.g., Airtable), this method generates
+        a code_verifier and includes the corresponding code_challenge in the
+        authorization URL. The code_verifier must be stored and sent during
+        token exchange.
+
+        Args:
+            oauth2_settings: The OAuth2 settings for the integration
+            redirect_uri: The redirect URI for the OAuth callback
+            client_id: Optional client ID to override the default
+            state: Optional state token for CSRF protection
+            template_configs: Optional config fields for URL templates (e.g., instance_url)
+
+        Returns:
+            Tuple[str, Optional[str]]: (authorization_url, code_verifier)
+                - authorization_url: The complete URL to redirect the user to
+                - code_verifier: The PKCE code verifier if PKCE is required, None otherwise
+
+        Raises:
+            ValueError: If template URL requires template_configs but it's missing
+        """
+        if not client_id:
+            client_id = oauth2_settings.client_id
+
+        if oauth2_settings.url_template:
+            if not template_configs:
+                raise ValueError(
+                    f"template_configs needed for templated OAuth URLs "
+                    f"({oauth2_settings.integration_short_name})"
+                )
+            try:
+                auth_url_base = oauth2_settings.render_url(**template_configs)
+            except KeyError as e:
+                raise ValueError(
+                    f"Missing template variable {e} for {oauth2_settings.integration_short_name}"
+                ) from e
+        else:
+            auth_url_base = oauth2_settings.url
+
+        params = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            **(oauth2_settings.additional_frontend_params or {}),
+        }
+        if state:
+            params["state"] = state
+        if oauth2_settings.scope:
+            params["scope"] = oauth2_settings.scope
+        if oauth2_settings.user_scope:
+            params["user_scope"] = oauth2_settings.user_scope
+
+        code_verifier = None
+        if oauth2_settings.requires_pkce:
+            code_verifier, code_challenge = self._generate_pkce_challenge_pair()
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
+
+        auth_url = f"{auth_url_base}?{urlencode(params)}"
+        return auth_url, code_verifier
+
+    async def exchange_authorization_code_for_token_with_redirect(
+        self,
+        ctx: ApiContext,
+        *,
+        source_short_name: str,
+        code: str,
+        redirect_uri: str,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+        code_verifier: Optional[str] = None,
+    ) -> OAuth2TokenResponse:
+        """Exchange an OAuth2 code using an explicit redirect_uri.
+
+        Args:
+            ctx: The API context
+            source_short_name: The short name of the integration
+            code: The authorization code from the OAuth provider
+            redirect_uri: Must match the one used in authorization request
+            client_id: Optional client ID override
+            client_secret: Optional client secret override
+            template_configs: Optional config fields for URL templates
+            code_verifier: PKCE code verifier (required if provider uses PKCE)
+
+        Returns:
+            OAuth2TokenResponse: The response containing the access token and other details
+
+        Raises:
+            HTTPException: If settings not found or token exchange fails
+            ValueError: If template URL requires template_configs but it's missing
+        """
+        try:
+            oauth2_settings = await integration_settings.get_by_short_name(source_short_name)
+        except KeyError as e:
+            raise HTTPException(
+                status_code=404, detail=f"Settings not found for source: {source_short_name}"
+            ) from e
+
+        if getattr(oauth2_settings, "backend_url_template", False):
+            if not template_configs:
+                raise ValueError(f"template_configs needed for {source_short_name}")
+            try:
+                backend_url = oauth2_settings.render_backend_url(**template_configs)
+            except KeyError as e:
+                raise ValueError(
+                    f"Missing template variable {e} in template_configs for token exchange"
+                ) from e
+        else:
+            backend_url = oauth2_settings.backend_url
+
+        if not client_id:
+            client_id = oauth2_settings.client_id
+        if not client_secret:
+            client_secret = oauth2_settings.client_secret
+
+        return await self._exchange_code(
+            logger=ctx.logger,
+            code=code,
+            redirect_uri=redirect_uri,
+            client_id=client_id,
+            client_secret=client_secret,
+            backend_url=backend_url,
+            integration_config=oauth2_settings,
+            code_verifier=code_verifier,
+        )
 
     async def refresh_access_token(
         self,
@@ -23,11 +322,501 @@ class OAuth2Service(OAuth2ServiceProtocol):
         decrypted_credential: dict,
         config_fields: Optional[dict] = None,
     ) -> OAuth2TokenResponse:
-        return await oauth2_service.refresh_access_token(
-            db,
-            integration_short_name,
-            ctx,
-            connection_id,
-            decrypted_credential,
-            config_fields,
+        """Refresh an access token using a refresh token.
+
+        Rotates the refresh token if the integration is configured to do so.
+
+        Args:
+            db: The database session.
+            integration_short_name: The short name of the integration.
+            ctx: The API context.
+            connection_id: The ID of the connection to refresh the token for.
+            decrypted_credential: The token and optional config fields.
+            config_fields: Config fields for template rendering.
+
+        Returns:
+            OAuth2TokenResponse: The response containing the new access token and other details.
+
+        Raises:
+            TokenRefreshError: If token refresh fails.
+            NotFoundException: If the integration is not found.
+        """
+        try:
+            refresh_token = await self._get_refresh_token(ctx.logger, decrypted_credential)
+
+            integration_config = await self._get_integration_config(
+                ctx.logger, integration_short_name
+            )
+
+            backend_url = integration_config.backend_url
+            if getattr(integration_config, "backend_url_template", False):
+                if not config_fields:
+                    raise ValueError(
+                        f"config_fields required for token refresh of {integration_short_name}"
+                    )
+
+                try:
+                    source = await self.source_repo.get_by_short_name(
+                        db, integration_short_name
+                    )
+                    if source and source.config_class:
+                        from airweave.platform.locator import resource_locator
+
+                        config_class = resource_locator.get_config(source.config_class)
+                        template_config_values = config_class.extract_template_configs(
+                            config_fields
+                        )
+                    else:
+                        template_config_values = config_fields
+                except Exception:
+                    template_config_values = config_fields
+
+                try:
+                    backend_url = integration_config.backend_url.format(**template_config_values)
+                    ctx.logger.debug(f"Rendered backend URL for token refresh: {backend_url}")
+                except KeyError as e:
+                    raise ValueError(
+                        f"Missing template variable {e} in config_fields for token refresh"
+                    ) from e
+
+            client_id, client_secret = await self._get_client_credentials(
+                ctx.logger, integration_config, None, decrypted_credential
+            )
+
+            headers, payload = self._prepare_token_request(
+                ctx.logger, integration_config, refresh_token, client_id, client_secret
+            )
+
+            response = await self._make_token_request(
+                ctx.logger, backend_url, headers, payload
+            )
+
+            oauth2_token_response = await self._handle_token_response(
+                db, response, integration_config, ctx, connection_id
+            )
+
+            return oauth2_token_response
+
+        except Exception as e:
+            ctx.logger.error(
+                f"Token refresh failed for organization {ctx.organization.id} and "
+                f"integration {integration_short_name}: {str(e)}"
+            )
+            raise
+
+    async def _get_refresh_token(
+        self, logger: ContextualLogger, decrypted_credential: dict
+    ) -> str:
+        """Get refresh token from decrypted credentials.
+
+        Raises:
+            TokenRefreshError: If no refresh token is found.
+        """
+        refresh_token = decrypted_credential.get("refresh_token", None)
+        if not refresh_token:
+            error_message = "No refresh token found"
+            logger.error(error_message)
+            raise TokenRefreshError(error_message)
+        return refresh_token
+
+    async def _get_integration_config(
+        self,
+        logger: ContextualLogger,
+        integration_short_name: str,
+    ) -> schemas.Source | schemas.Destination | schemas.EmbeddingModel:
+        """Get and validate integration configuration exists.
+
+        Raises:
+            NotFoundException: If integration configuration is not found.
+        """
+        integration_config = await integration_settings.get_by_short_name(integration_short_name)
+        if not integration_config:
+            error_message = f"Configuration for {integration_short_name} not found"
+            logger.error(error_message)
+            raise NotFoundException(error_message)
+        return integration_config
+
+    async def _get_client_credentials(
+        self,
+        logger: ContextualLogger,
+        integration_config: schemas.Source | schemas.Destination | schemas.EmbeddingModel,
+        auth_fields: Optional[dict] = None,
+        decrypted_credential: Optional[dict] = None,
+    ) -> tuple[str, str]:
+        """Get client credentials based on priority ordering.
+
+        Priority order:
+        1. From decrypted_credential (if available)
+        2. From auth_fields (if available)
+        3. From integration_config (as fallback)
+        """
+        client_id = integration_config.client_id
+        client_secret = integration_config.client_secret
+
+        if decrypted_credential:
+            client_id = decrypted_credential.get("client_id", client_id)
+            client_secret = decrypted_credential.get("client_secret", client_secret)
+
+        if auth_fields:
+            client_id = auth_fields.get("client_id", client_id)
+            client_secret = auth_fields.get("client_secret", client_secret)
+
+        return client_id, client_secret
+
+    def _prepare_token_request(
+        self,
+        logger: ContextualLogger,
+        integration_config: schemas.Source | schemas.Destination | schemas.EmbeddingModel,
+        refresh_token: str,
+        client_id: str,
+        client_secret: str,
+    ) -> tuple[dict, dict]:
+        """Prepare headers and payload for token refresh request."""
+        headers = {
+            "Content-Type": integration_config.content_type,
+        }
+
+        payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+
+        # IMPORTANT: For WITH_ROTATING_REFRESH OAuth (Jira, Confluence, Microsoft),
+        # do NOT include scope parameter - Atlassian/Microsoft reject it with 403
+        # For WITH_REFRESH OAuth (Google, Slack), scope should be included
+        # EXCEPTION: Salesforce is with_refresh but does NOT support scope parameter during refresh
+        # See: https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/#refresh-a-token
+        oauth_type = getattr(integration_config, "oauth_type", None)
+        integration_short_name = getattr(integration_config, "integration_short_name", None)
+
+        if oauth_type == "with_rotating_refresh" or integration_short_name == "salesforce":
+            logger.debug(
+                f"Skipping scope in token refresh "
+                f"(oauth_type={oauth_type}, integration={integration_short_name})"
+            )
+        elif (
+            oauth_type == "with_refresh"
+            and hasattr(integration_config, "scope")
+            and integration_config.scope
+        ):
+            payload["scope"] = integration_config.scope
+            logger.debug(
+                f"Including scope in token refresh (oauth_type=with_refresh): "
+                f"{integration_config.scope}"
+            )
+
+        if integration_config.client_credential_location == "header":
+            encoded_credentials = self._encode_client_credentials(client_id, client_secret)
+            headers["Authorization"] = f"Basic {encoded_credentials}"
+        else:
+            payload["client_id"] = client_id
+            payload["client_secret"] = client_secret
+
+        logger.info(
+            f"OAuth2 code exchange request - "
+            f"URL: {integration_config.backend_url}, "
+            f"Redirect URI: {integration_config.backend_url}, "
+            f"Client ID: {client_id}, "
+            f"Code length: {len(refresh_token)}, "
+            f"Grant type: {payload['grant_type']}, "
+            f"Credential location: {integration_config.client_credential_location}"
         )
+
+        return headers, payload
+
+    def _is_oauth_rate_limit_error(self, response: httpx.Response) -> bool:
+        """Check if response is an OAuth rate limit error.
+
+        Some providers (like Zoho) return 400 instead of 429 for rate limits:
+        {"error_description": "You have made too many requests...", "error": "Access Denied"}
+        """
+        if response.status_code == 429:
+            return True
+        if response.status_code == 400:
+            try:
+                data = response.json()
+                error_desc = data.get("error_description", "").lower()
+                error_type = data.get("error", "").lower()
+                if "too many requests" in error_desc and error_type == "access denied":
+                    return True
+            except Exception:
+                pass
+        return False
+
+    async def _make_token_request(
+        self, logger: ContextualLogger, url: str, headers: dict, payload: dict
+    ) -> httpx.Response:
+        """Make the token refresh request with retry on rate limit."""
+        logger.info(f"Making token request to: {url}")
+
+        max_retries = 5
+        base_delay = 5.0
+
+        for attempt in range(max_retries):
+            try:
+                async with httpx.AsyncClient() as client:
+                    logger.info(f"Sending request to {url}")
+                    response = await client.post(url, headers=headers, data=payload)
+
+                    logger.info(f"Received response: Status {response.status_code}, ")
+
+                    if self._is_oauth_rate_limit_error(response):
+                        delay = base_delay * (2**attempt) + random.uniform(0, 2)
+                        logger.warning(
+                            f"OAuth rate limit hit, waiting {delay:.1f}s before retry "
+                            f"(attempt {attempt + 1}/{max_retries})"
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+
+                    response.raise_for_status()
+                    return response
+
+            except httpx.HTTPStatusError as e:
+                if self._is_oauth_rate_limit_error(e.response):
+                    delay = base_delay * (2**attempt) + random.uniform(0, 2)
+                    logger.warning(
+                        f"OAuth rate limit hit (exception), waiting {delay:.1f}s before retry "
+                        f"(attempt {attempt + 1}/{max_retries})"
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+
+                logger.error(
+                    f"HTTP error during token request: {e.response.status_code} "
+                    f"{e.response.reason_phrase}"
+                )
+
+                try:
+                    error_content = e.response.json()
+                    logger.error(f"Error response body: {error_content}")
+                except Exception:
+                    logger.error(f"Error response text: {e.response.text}")
+
+                raise
+            except Exception as e:
+                logger.error(f"Unexpected error during token request: {str(e)}")
+                raise
+
+        raise httpx.HTTPStatusError(
+            f"OAuth token request failed after {max_retries} retries (rate limited)",
+            request=httpx.Request("POST", url),
+            response=httpx.Response(429),
+        )
+
+    async def _handle_token_response(
+        self,
+        db: AsyncSession,
+        response: httpx.Response,
+        integration_config: schemas.Source | schemas.Destination | schemas.EmbeddingModel,
+        ctx: ApiContext,
+        connection_id: UUID,
+    ) -> OAuth2TokenResponse:
+        """Handle the token response and update refresh token if needed."""
+        oauth2_token_response = OAuth2TokenResponse(**response.json())
+
+        if (
+            hasattr(integration_config, "oauth_type")
+            and integration_config.oauth_type == "with_rotating_refresh"
+        ):
+            connection = await self.conn_repo.get(db=db, id=connection_id, ctx=ctx)
+            integration_credential = await self.cred_repo.get(
+                db=db, id=connection.integration_credential_id, ctx=ctx
+            )
+
+            current_credentials = self.encryptor.decrypt(
+                integration_credential.encrypted_credentials
+            )
+            current_credentials["refresh_token"] = oauth2_token_response.refresh_token
+
+            encrypted_credentials = self.encryptor.encrypt(current_credentials)
+            await self.cred_repo.update(
+                db=db,
+                db_obj=integration_credential,
+                obj_in={"encrypted_credentials": encrypted_credentials},
+                ctx=ctx,
+            )
+
+        return oauth2_token_response
+
+    def _encode_client_credentials(self, client_id: str, client_secret: str) -> str:
+        """Encodes the client ID and client secret in Base64."""
+        creds = f"{client_id}:{client_secret}"
+        creds_bytes = creds.encode("ascii")
+        base64_bytes = base64.b64encode(creds_bytes)
+        base64_credentials = base64_bytes.decode("ascii")
+        return base64_credentials
+
+    def _generate_pkce_challenge_pair(self) -> Tuple[str, str]:
+        """Generate PKCE code verifier and code challenge.
+
+        Returns:
+            Tuple[str, str]: (code_verifier, code_challenge)
+                - code_verifier: Random string to be sent during token exchange
+                - code_challenge: SHA256 hash to be sent during authorization
+
+        References:
+            RFC 7636: https://tools.ietf.org/html/rfc7636
+        """
+        code_verifier = secrets.token_urlsafe(64)
+
+        verifier_bytes = code_verifier.encode("ascii")
+        sha256_hash = hashlib.sha256(verifier_bytes).digest()
+
+        code_challenge = base64.urlsafe_b64encode(sha256_hash).decode("ascii").rstrip("=")
+
+        return code_verifier, code_challenge
+
+    def _normalize_token_response(
+        self, response_data: dict, integration_short_name: str, logger: ContextualLogger
+    ) -> dict:
+        """Normalize non-standard OAuth2 token responses to standard format.
+
+        Some OAuth providers return tokens in non-standard nested structures.
+        This method detects and normalizes them to the standard OAuth2 format.
+        """
+        if "authed_user" in response_data and isinstance(response_data.get("authed_user"), dict):
+            authed_user = response_data["authed_user"]
+            if "access_token" in authed_user and "access_token" not in response_data:
+                logger.debug(
+                    f"Normalized nested authed_user token format for {integration_short_name}"
+                )
+                return {
+                    "access_token": authed_user.get("access_token"),
+                    "token_type": authed_user.get("token_type", "Bearer"),
+                    "scope": authed_user.get("scope", response_data.get("scope")),
+                    "refresh_token": authed_user.get("refresh_token"),
+                }
+
+        return response_data
+
+    def _get_redirect_url(self, integration_short_name: str) -> str:
+        """Generate the appropriate redirect URI based on environment."""
+        return f"{self.settings.app_url}/auth/callback"
+
+    async def _exchange_code(
+        self,
+        *,
+        logger: ContextualLogger,
+        code: str,
+        redirect_uri: str,
+        client_id: str,
+        client_secret: str,
+        backend_url: str,
+        integration_config: schemas.Source | schemas.Destination | schemas.EmbeddingModel,
+        code_verifier: Optional[str] = None,
+    ) -> OAuth2TokenResponse:
+        """Core method to exchange an authorization code for tokens.
+
+        Supports both standard OAuth 2.0 and PKCE (Proof Key for Code Exchange).
+        """
+        headers = {
+            "Content-Type": integration_config.content_type,
+        }
+
+        payload = {
+            "grant_type": integration_config.grant_type,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+
+        if code_verifier:
+            payload["code_verifier"] = code_verifier
+            logger.debug("Including PKCE code_verifier in token exchange request")
+
+        if integration_config.client_credential_location == "header":
+            encoded_credentials = self._encode_client_credentials(client_id, client_secret)
+            headers["Authorization"] = f"Basic {encoded_credentials}"
+        else:
+            payload["client_id"] = client_id
+            payload["client_secret"] = client_secret
+
+        logger.info(
+            f"OAuth2 code exchange request - "
+            f"URL: {backend_url}, "
+            f"Redirect URI: {redirect_uri}, "
+            f"Client ID: {client_id}, "
+            f"Code length: {len(code)}, "
+            f"Grant type: {integration_config.grant_type}, "
+            f"Credential location: {integration_config.client_credential_location}"
+        )
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(backend_url, headers=headers, data=payload)
+                response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                f"OAuth2 token exchange failed - Status: {e.response.status_code}, "
+                f"Response text: {e.response.text}"
+            )
+            raise HTTPException(status_code=400, detail=e.response.text) from e
+        except Exception as e:
+            logger.error(f"Failed to exchange authorization code: {str(e)}")
+            raise HTTPException(
+                status_code=400, detail="Failed to exchange authorization code"
+            ) from e
+
+        response_data = response.json()
+
+        normalized_data = self._normalize_token_response(
+            response_data, integration_config.integration_short_name, logger
+        )
+
+        return OAuth2TokenResponse(**normalized_data)
+
+    def _supports_oauth2(self, oauth_type: Optional[str]) -> bool:
+        """Check if the integration supports OAuth2 based on oauth_type."""
+        return oauth_type is not None
+
+    async def _create_connection(
+        self,
+        db: AsyncSession,
+        source: schemas.Source,
+        auth_settings: BaseAuthSettings,
+        oauth2_response: OAuth2TokenResponse,
+        ctx: ApiContext,
+    ) -> schemas.Connection:
+        """Create a new connection with OAuth2 credentials."""
+        decrypted_credentials = (
+            {"access_token": oauth2_response.access_token}
+            if (hasattr(auth_settings, "oauth_type") and auth_settings.oauth_type == "access_only")
+            else {
+                "refresh_token": oauth2_response.refresh_token,
+                "access_token": oauth2_response.access_token,
+            }
+        )
+
+        encrypted_credentials = self.encryptor.encrypt(decrypted_credentials)
+
+        async with UnitOfWork(db) as uow:
+            integration_credential_in = schemas.IntegrationCredentialCreate(
+                name=f"{source.name} - {ctx.organization.id}",
+                description=(f"OAuth2 credentials for {source.name} - {ctx.organization.id}"),
+                integration_short_name=source.short_name,
+                integration_type=IntegrationType.SOURCE,
+                encrypted_credentials=encrypted_credentials,
+            )
+
+            integration_credential = await self.cred_repo.create(
+                uow.session, obj_in=integration_credential_in, ctx=ctx, uow=uow
+            )
+
+            await uow.session.flush()
+
+            connection_in = schemas.ConnectionCreate(
+                name=f"Connection to {source.name}",
+                integration_type=IntegrationType.SOURCE,
+                status=ConnectionStatus.ACTIVE,
+                integration_credential_id=integration_credential.id,
+                short_name=source.short_name,
+            )
+
+            connection = await self.conn_repo.create(
+                uow.session, obj_in=connection_in, ctx=ctx, uow=uow
+            )
+
+            await uow.commit()
+            await uow.session.refresh(connection)
+
+        return connection

--- a/backend/airweave/domains/oauth/protocols.py
+++ b/backend/airweave/domains/oauth/protocols.py
@@ -1,16 +1,121 @@
-"""Protocols for OAuth2 domain dependencies."""
+"""Protocols for OAuth domain dependencies."""
 
-from typing import Any, Optional, Protocol
+from typing import Optional, Protocol, Tuple
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave.api.context import ApiContext
-from airweave.platform.auth.schemas import OAuth2TokenResponse
+from airweave.core.logging import ContextualLogger
+from airweave.db.unit_of_work import UnitOfWork
+from airweave.domains.oauth.types import OAuth1TokenResponse
+from airweave.models.connection import Connection
+from airweave.models.integration_credential import IntegrationCredential
+from airweave.models.source import Source
+from airweave.platform.auth.schemas import OAuth2Settings, OAuth2TokenResponse
+from airweave.schemas.connection import ConnectionCreate
+from airweave.schemas.integration_credential import (
+    IntegrationCredentialCreateEncrypted,
+    IntegrationCredentialUpdate,
+)
+
+
+class OAuth1ServiceProtocol(Protocol):
+    """OAuth1 authentication flow capability."""
+
+    async def get_request_token(
+        self,
+        *,
+        request_token_url: str,
+        consumer_key: str,
+        consumer_secret: str,
+        callback_url: str,
+        logger: ContextualLogger,
+    ) -> OAuth1TokenResponse:
+        """Obtain temporary credentials (request token)."""
+        ...
+
+    async def exchange_token(
+        self,
+        *,
+        access_token_url: str,
+        consumer_key: str,
+        consumer_secret: str,
+        oauth_token: str,
+        oauth_token_secret: str,
+        oauth_verifier: str,
+        logger: ContextualLogger,
+    ) -> OAuth1TokenResponse:
+        """Exchange temporary credentials for access token credentials."""
+        ...
+
+    def build_authorization_url(
+        self,
+        *,
+        authorization_url: str,
+        oauth_token: str,
+        app_name: Optional[str] = None,
+        scope: Optional[str] = None,
+        expiration: Optional[str] = None,
+    ) -> str:
+        """Build the authorization URL for user consent."""
+        ...
 
 
 class OAuth2ServiceProtocol(Protocol):
-    """OAuth2 token refresh capability."""
+    """OAuth2 authentication and token management capability."""
+
+    async def generate_auth_url(
+        self,
+        oauth2_settings: OAuth2Settings,
+        client_id: Optional[str] = None,
+        state: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+    ) -> str:
+        """Generate the OAuth2 authorization URL for an integration."""
+        ...
+
+    async def exchange_authorization_code_for_token(
+        self,
+        ctx: ApiContext,
+        source_short_name: str,
+        code: str,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+    ) -> OAuth2TokenResponse:
+        """Exchange an authorization code for an OAuth2 token."""
+        ...
+
+    async def generate_auth_url_with_redirect(
+        self,
+        oauth2_settings: OAuth2Settings,
+        *,
+        redirect_uri: str,
+        client_id: Optional[str] = None,
+        state: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+    ) -> Tuple[str, Optional[str]]:
+        """Generate an OAuth2 authorization URL with PKCE support if required.
+
+        Returns (authorization_url, code_verifier).
+        """
+        ...
+
+    async def exchange_authorization_code_for_token_with_redirect(
+        self,
+        ctx: ApiContext,
+        *,
+        source_short_name: str,
+        code: str,
+        redirect_uri: str,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        template_configs: Optional[dict] = None,
+        code_verifier: Optional[str] = None,
+    ) -> OAuth2TokenResponse:
+        """Exchange an OAuth2 code using an explicit redirect_uri."""
+        ...
 
     async def refresh_access_token(
         self,
@@ -21,37 +126,55 @@ class OAuth2ServiceProtocol(Protocol):
         decrypted_credential: dict,
         config_fields: Optional[dict] = None,
     ) -> OAuth2TokenResponse:
-        """Refresh an OAuth2 access token.
-
-        Returns an OAuth2TokenResponse with an `access_token` attribute.
-        """
+        """Refresh an OAuth2 access token."""
         ...
 
 
 class OAuthConnectionRepositoryProtocol(Protocol):
-    """Connection data access needed by OAuth2 flows."""
+    """Connection data access needed by OAuth flows."""
 
-    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Any:
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Connection:
         """Get a connection by ID."""
         ...
 
-    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
+    async def create(
+        self,
+        db: AsyncSession,
+        *,
+        obj_in: ConnectionCreate,
+        ctx: ApiContext,
+        uow: UnitOfWork,
+    ) -> Connection:
         """Create a connection within a unit of work."""
         ...
 
 
 class OAuthCredentialRepositoryProtocol(Protocol):
-    """Integration credential data access needed by OAuth2 flows."""
+    """Integration credential data access needed by OAuth flows."""
 
-    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Any:
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> IntegrationCredential:
         """Get an integration credential by ID."""
         ...
 
-    async def update(self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext) -> Any:
+    async def update(
+        self,
+        db: AsyncSession,
+        *,
+        db_obj: IntegrationCredential,
+        obj_in: IntegrationCredentialUpdate,
+        ctx: ApiContext,
+    ) -> IntegrationCredential:
         """Update an integration credential."""
         ...
 
-    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
+    async def create(
+        self,
+        db: AsyncSession,
+        *,
+        obj_in: IntegrationCredentialCreateEncrypted,
+        ctx: ApiContext,
+        uow: UnitOfWork,
+    ) -> IntegrationCredential:
         """Create an integration credential within a unit of work."""
         ...
 
@@ -59,6 +182,6 @@ class OAuthCredentialRepositoryProtocol(Protocol):
 class OAuthSourceRepositoryProtocol(Protocol):
     """Source lookup needed for template URL rendering during token refresh."""
 
-    async def get_by_short_name(self, db: AsyncSession, short_name: str) -> Any:
+    async def get_by_short_name(self, db: AsyncSession, short_name: str) -> Optional[Source]:
         """Get a source by short_name. Returns None if not found."""
         ...

--- a/backend/airweave/domains/oauth/protocols.py
+++ b/backend/airweave/domains/oauth/protocols.py
@@ -1,6 +1,6 @@
-"""Protocols for OAuth2 token operations."""
+"""Protocols for OAuth2 domain dependencies."""
 
-from typing import Optional, Protocol
+from typing import Any, Optional, Protocol
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,4 +25,58 @@ class OAuth2ServiceProtocol(Protocol):
 
         Returns an OAuth2TokenResponse with an `access_token` attribute.
         """
+        ...
+
+
+class OAuthConnectionRepositoryProtocol(Protocol):
+    """Connection data access needed by OAuth2 flows."""
+
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Any:
+        """Get a connection by ID."""
+        ...
+
+    async def create(
+        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
+    ) -> Any:
+        """Create a connection within a unit of work."""
+        ...
+
+
+class OAuthCredentialRepositoryProtocol(Protocol):
+    """Integration credential data access needed by OAuth2 flows."""
+
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Any:
+        """Get an integration credential by ID."""
+        ...
+
+    async def update(
+        self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext
+    ) -> Any:
+        """Update an integration credential."""
+        ...
+
+    async def create(
+        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
+    ) -> Any:
+        """Create an integration credential within a unit of work."""
+        ...
+
+
+class CredentialEncryptorProtocol(Protocol):
+    """Encrypt/decrypt credential dicts."""
+
+    def encrypt(self, data: dict) -> str:
+        """Encrypt a credential dict → encrypted string."""
+        ...
+
+    def decrypt(self, encrypted: str) -> dict:
+        """Decrypt an encrypted string → credential dict."""
+        ...
+
+
+class OAuthSourceRepositoryProtocol(Protocol):
+    """Source lookup needed for template URL rendering during token refresh."""
+
+    async def get_by_short_name(self, db: AsyncSession, short_name: str) -> Any:
+        """Get a source by short_name. Returns None if not found."""
         ...

--- a/backend/airweave/domains/oauth/protocols.py
+++ b/backend/airweave/domains/oauth/protocols.py
@@ -35,9 +35,7 @@ class OAuthConnectionRepositoryProtocol(Protocol):
         """Get a connection by ID."""
         ...
 
-    async def create(
-        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
-    ) -> Any:
+    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
         """Create a connection within a unit of work."""
         ...
 
@@ -49,28 +47,12 @@ class OAuthCredentialRepositoryProtocol(Protocol):
         """Get an integration credential by ID."""
         ...
 
-    async def update(
-        self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext
-    ) -> Any:
+    async def update(self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext) -> Any:
         """Update an integration credential."""
         ...
 
-    async def create(
-        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
-    ) -> Any:
+    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
         """Create an integration credential within a unit of work."""
-        ...
-
-
-class CredentialEncryptorProtocol(Protocol):
-    """Encrypt/decrypt credential dicts."""
-
-    def encrypt(self, data: dict) -> str:
-        """Encrypt a credential dict → encrypted string."""
-        ...
-
-    def decrypt(self, encrypted: str) -> dict:
-        """Decrypt an encrypted string → credential dict."""
         ...
 
 

--- a/backend/airweave/domains/oauth/repository.py
+++ b/backend/airweave/domains/oauth/repository.py
@@ -1,15 +1,13 @@
 """Repository implementations for OAuth2 domain, wrapping crud singletons."""
 
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave import crud
 from airweave.api.context import ApiContext
-from airweave.core import credentials as credentials_module
 from airweave.domains.oauth.protocols import (
-    CredentialEncryptorProtocol,
     OAuthConnectionRepositoryProtocol,
     OAuthCredentialRepositoryProtocol,
     OAuthSourceRepositoryProtocol,
@@ -22,9 +20,7 @@ class OAuthConnectionRepository(OAuthConnectionRepositoryProtocol):
     async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Any:
         return await crud.connection.get(db, id, ctx)
 
-    async def create(
-        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
-    ) -> Any:
+    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
         return await crud.connection.create(db, obj_in=obj_in, ctx=ctx, uow=uow)
 
 
@@ -34,27 +30,13 @@ class OAuthCredentialRepository(OAuthCredentialRepositoryProtocol):
     async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Any:
         return await crud.integration_credential.get(db, id, ctx)
 
-    async def update(
-        self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext
-    ) -> Any:
+    async def update(self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext) -> Any:
         return await crud.integration_credential.update(
             db=db, db_obj=db_obj, obj_in=obj_in, ctx=ctx
         )
 
-    async def create(
-        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
-    ) -> Any:
+    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
         return await crud.integration_credential.create(db, obj_in=obj_in, ctx=ctx, uow=uow)
-
-
-class CredentialEncryptor(CredentialEncryptorProtocol):
-    """Delegates to airweave.core.credentials."""
-
-    def encrypt(self, data: dict) -> str:
-        return credentials_module.encrypt(data)
-
-    def decrypt(self, encrypted: str) -> dict:
-        return credentials_module.decrypt(encrypted)
 
 
 class OAuthSourceRepository(OAuthSourceRepositoryProtocol):

--- a/backend/airweave/domains/oauth/repository.py
+++ b/backend/airweave/domains/oauth/repository.py
@@ -1,0 +1,64 @@
+"""Repository implementations for OAuth2 domain, wrapping crud singletons."""
+
+from typing import Any, Optional
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from airweave import crud
+from airweave.api.context import ApiContext
+from airweave.core import credentials as credentials_module
+from airweave.domains.oauth.protocols import (
+    CredentialEncryptorProtocol,
+    OAuthConnectionRepositoryProtocol,
+    OAuthCredentialRepositoryProtocol,
+    OAuthSourceRepositoryProtocol,
+)
+
+
+class OAuthConnectionRepository(OAuthConnectionRepositoryProtocol):
+    """Delegates to crud.connection."""
+
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Any:
+        return await crud.connection.get(db, id, ctx)
+
+    async def create(
+        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
+    ) -> Any:
+        return await crud.connection.create(db, obj_in=obj_in, ctx=ctx, uow=uow)
+
+
+class OAuthCredentialRepository(OAuthCredentialRepositoryProtocol):
+    """Delegates to crud.integration_credential."""
+
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Any:
+        return await crud.integration_credential.get(db, id, ctx)
+
+    async def update(
+        self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext
+    ) -> Any:
+        return await crud.integration_credential.update(
+            db=db, db_obj=db_obj, obj_in=obj_in, ctx=ctx
+        )
+
+    async def create(
+        self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any
+    ) -> Any:
+        return await crud.integration_credential.create(db, obj_in=obj_in, ctx=ctx, uow=uow)
+
+
+class CredentialEncryptor(CredentialEncryptorProtocol):
+    """Delegates to airweave.core.credentials."""
+
+    def encrypt(self, data: dict) -> str:
+        return credentials_module.encrypt(data)
+
+    def decrypt(self, encrypted: str) -> dict:
+        return credentials_module.decrypt(encrypted)
+
+
+class OAuthSourceRepository(OAuthSourceRepositoryProtocol):
+    """Delegates to crud.source for config_class lookups."""
+
+    async def get_by_short_name(self, db: AsyncSession, short_name: str) -> Any:
+        return await crud.source.get_by_short_name(db, short_name)

--- a/backend/airweave/domains/oauth/repository.py
+++ b/backend/airweave/domains/oauth/repository.py
@@ -1,46 +1,71 @@
-"""Repository implementations for OAuth2 domain, wrapping crud singletons."""
+"""Repository implementations for OAuth domain, wrapping crud singletons."""
 
-from typing import Any
+from typing import Optional
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave import crud
 from airweave.api.context import ApiContext
-from airweave.domains.oauth.protocols import (
-    OAuthConnectionRepositoryProtocol,
-    OAuthCredentialRepositoryProtocol,
-    OAuthSourceRepositoryProtocol,
+from airweave.db.unit_of_work import UnitOfWork
+from airweave.models.connection import Connection
+from airweave.models.integration_credential import IntegrationCredential
+from airweave.models.source import Source
+from airweave.schemas.connection import ConnectionCreate
+from airweave.schemas.integration_credential import (
+    IntegrationCredentialCreateEncrypted,
+    IntegrationCredentialUpdate,
 )
 
 
-class OAuthConnectionRepository(OAuthConnectionRepositoryProtocol):
+class OAuthConnectionRepository:
     """Delegates to crud.connection."""
 
-    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Any:
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Connection:
         return await crud.connection.get(db, id, ctx)
 
-    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
+    async def create(
+        self,
+        db: AsyncSession,
+        *,
+        obj_in: ConnectionCreate,
+        ctx: ApiContext,
+        uow: UnitOfWork,
+    ) -> Connection:
         return await crud.connection.create(db, obj_in=obj_in, ctx=ctx, uow=uow)
 
 
-class OAuthCredentialRepository(OAuthCredentialRepositoryProtocol):
+class OAuthCredentialRepository:
     """Delegates to crud.integration_credential."""
 
-    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Any:
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> IntegrationCredential:
         return await crud.integration_credential.get(db, id, ctx)
 
-    async def update(self, db: AsyncSession, *, db_obj: Any, obj_in: Any, ctx: ApiContext) -> Any:
+    async def update(
+        self,
+        db: AsyncSession,
+        *,
+        db_obj: IntegrationCredential,
+        obj_in: IntegrationCredentialUpdate,
+        ctx: ApiContext,
+    ) -> IntegrationCredential:
         return await crud.integration_credential.update(
             db=db, db_obj=db_obj, obj_in=obj_in, ctx=ctx
         )
 
-    async def create(self, db: AsyncSession, *, obj_in: Any, ctx: ApiContext, uow: Any) -> Any:
+    async def create(
+        self,
+        db: AsyncSession,
+        *,
+        obj_in: IntegrationCredentialCreateEncrypted,
+        ctx: ApiContext,
+        uow: UnitOfWork,
+    ) -> IntegrationCredential:
         return await crud.integration_credential.create(db, obj_in=obj_in, ctx=ctx, uow=uow)
 
 
-class OAuthSourceRepository(OAuthSourceRepositoryProtocol):
+class OAuthSourceRepository:
     """Delegates to crud.source for config_class lookups."""
 
-    async def get_by_short_name(self, db: AsyncSession, short_name: str) -> Any:
+    async def get_by_short_name(self, db: AsyncSession, short_name: str) -> Optional[Source]:
         return await crud.source.get_by_short_name(db, short_name)

--- a/backend/airweave/domains/oauth/tests/test_oauth1_service.py
+++ b/backend/airweave/domains/oauth/tests/test_oauth1_service.py
@@ -1,0 +1,482 @@
+"""Unit tests for OAuth1Service.
+
+Covers:
+- _generate_nonce (length, uniqueness)
+- _percent_encode (RFC 3986 compliance)
+- _build_signature_base_string (known vectors)
+- _sign_hmac_sha1 (known vectors)
+- _build_authorization_header (format)
+- get_request_token (happy path with mocked httpx, error cases)
+- exchange_token (happy path with mocked httpx, error cases)
+- build_authorization_url (with/without optional params)
+
+Uses table-driven @dataclass cases wherever possible.
+"""
+
+import base64
+import hashlib
+import hmac
+from dataclasses import dataclass, field
+from typing import Optional
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from airweave.core.logging import logger
+from airweave.domains.oauth.oauth1_service import OAuth1Service
+from airweave.domains.oauth.types import OAuth1TokenResponse
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _svc() -> OAuth1Service:
+    return OAuth1Service()
+
+
+def _logger():
+    return logger.with_context(request_id="test-oauth1")
+
+
+def _mock_httpx(response: httpx.Response):
+    """Context manager that patches httpx.AsyncClient to return `response`."""
+    patcher = patch("airweave.domains.oauth.oauth1_service.httpx.AsyncClient")
+
+    class _Ctx:
+        def __enter__(self):
+            mock_cls = patcher.start()
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+            return mock_client
+
+        def __exit__(self, *args):
+            patcher.stop()
+
+    return _Ctx()
+
+
+# ===========================================================================
+# _generate_nonce
+# ===========================================================================
+
+
+def test_nonce_length_is_nonzero():
+    assert len(_svc()._generate_nonce()) > 0
+
+
+def test_nonce_uniqueness():
+    nonces = {_svc()._generate_nonce() for _ in range(100)}
+    assert len(nonces) == 100
+
+
+# ===========================================================================
+# _percent_encode — RFC 3986 (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class PercentEncodeCase:
+    desc: str
+    input_val: str
+    expected: str
+
+
+PERCENT_ENCODE_CASES = [
+    PercentEncodeCase("plain ascii", "abc", "abc"),
+    PercentEncodeCase("space", "hello world", "hello%20world"),
+    PercentEncodeCase("tilde unreserved", "~", "~"),
+    PercentEncodeCase("plus sign", "a+b", "a%2Bb"),
+    PercentEncodeCase("percent literal", "100%", "100%25"),
+    PercentEncodeCase("slash", "foo/bar", "foo%2Fbar"),
+    PercentEncodeCase("ampersand and equals", "a=1&b=2", "a%3D1%26b%3D2"),
+    PercentEncodeCase("unicode", "naïve", "na%C3%AFve"),
+    PercentEncodeCase("empty string", "", ""),
+]
+
+
+@pytest.mark.parametrize("case", PERCENT_ENCODE_CASES, ids=lambda c: c.desc)
+def test_percent_encode(case: PercentEncodeCase):
+    assert _svc()._percent_encode(case.input_val) == case.expected
+
+
+# ===========================================================================
+# _build_signature_base_string (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class SigBaseCase:
+    desc: str
+    method: str
+    url: str
+    params: dict
+    expect_prefix: str
+    expect_params_sorted: bool = False
+
+
+SIG_BASE_CASES = [
+    SigBaseCase(
+        "POST uppercase preserved",
+        "POST",
+        "https://api.example.com/oauth/request_token",
+        {"oauth_consumer_key": "key1", "oauth_nonce": "nonce1"},
+        "POST&",
+    ),
+    SigBaseCase(
+        "get normalised to GET",
+        "get",
+        "https://api.example.com/resource",
+        {"a": "1", "b": "2"},
+        "GET&",
+    ),
+    SigBaseCase(
+        "params sorted alphabetically",
+        "POST",
+        "https://example.com",
+        {"z_param": "z_val", "a_param": "a_val"},
+        "POST&",
+        expect_params_sorted=True,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", SIG_BASE_CASES, ids=lambda c: c.desc)
+def test_build_signature_base_string(case: SigBaseCase):
+    svc = _svc()
+    result = svc._build_signature_base_string(case.method, case.url, case.params)
+    assert result.startswith(case.expect_prefix)
+    if case.expect_params_sorted:
+        parts = result.split("&", 2)
+        expected_param_str = svc._percent_encode("a_param=a_val&z_param=z_val")
+        assert parts[2] == expected_param_str
+
+
+# ===========================================================================
+# _sign_hmac_sha1 (table-driven)
+# ===========================================================================
+
+
+def _expected_hmac(base: str, consumer_secret: str, token_secret: str) -> str:
+    svc = _svc()
+    key = f"{svc._percent_encode(consumer_secret)}&{svc._percent_encode(token_secret)}"
+    sig = hmac.new(key.encode("utf-8"), base.encode("utf-8"), hashlib.sha1).digest()
+    return base64.b64encode(sig).decode("utf-8")
+
+
+@dataclass
+class HmacCase:
+    desc: str
+    base_string: str
+    consumer_secret: str
+    token_secret: str
+
+
+HMAC_CASES = [
+    HmacCase(
+        "with token secret",
+        "POST&https%3A%2F%2Fexample.com&oauth_consumer_key%3Dkey",
+        "secret",
+        "token_secret",
+    ),
+    HmacCase(
+        "empty token secret (request-token step)",
+        "GET&https%3A%2F%2Fexample.com&param%3Dval",
+        "consumer",
+        "",
+    ),
+    HmacCase(
+        "special chars in secrets",
+        "POST&https%3A%2F%2Fexample.com&p%3D1",
+        "sec&ret",
+        "tok/sec",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", HMAC_CASES, ids=lambda c: c.desc)
+def test_sign_hmac_sha1(case: HmacCase):
+    expected = _expected_hmac(case.base_string, case.consumer_secret, case.token_secret)
+    assert _svc()._sign_hmac_sha1(
+        case.base_string, case.consumer_secret, case.token_secret
+    ) == expected
+
+
+# ===========================================================================
+# _build_authorization_header (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class AuthHeaderCase:
+    desc: str
+    params: dict
+    expect_contains: list = field(default_factory=list)
+    expect_sorted: bool = False
+
+
+AUTH_HEADER_CASES = [
+    AuthHeaderCase(
+        "standard OAuth params",
+        {"oauth_consumer_key": "mykey", "oauth_nonce": "mynonce"},
+        ['oauth_consumer_key="mykey"', 'oauth_nonce="mynonce"'],
+    ),
+    AuthHeaderCase(
+        "params sorted alphabetically",
+        {"z_key": "z_val", "a_key": "a_val"},
+        [],
+        expect_sorted=True,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", AUTH_HEADER_CASES, ids=lambda c: c.desc)
+def test_build_authorization_header(case: AuthHeaderCase):
+    header = _svc()._build_authorization_header(case.params)
+    assert header.startswith("OAuth ")
+    for fragment in case.expect_contains:
+        assert fragment in header
+    if case.expect_sorted:
+        a_pos = header.index("a_key")
+        z_pos = header.index("z_key")
+        assert a_pos < z_pos
+
+
+# ===========================================================================
+# get_request_token (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class GetRequestTokenCase:
+    desc: str
+    response_status: int
+    response_body: str
+    expect_success: bool
+    expect_token: Optional[str] = None
+    expect_secret: Optional[str] = None
+    expect_extra: Optional[dict] = None
+
+
+GET_REQUEST_TOKEN_CASES = [
+    GetRequestTokenCase(
+        "happy path — valid response",
+        200,
+        "oauth_token=req_tok&oauth_token_secret=req_sec&extra=val",
+        True,
+        expect_token="req_tok",
+        expect_secret="req_sec",
+        expect_extra={"extra": "val"},
+    ),
+    GetRequestTokenCase(
+        "200 but missing oauth_token — error",
+        200,
+        "some_other_param=value",
+        False,
+    ),
+    GetRequestTokenCase(
+        "401 HTTP error",
+        401,
+        "Unauthorized",
+        False,
+    ),
+    GetRequestTokenCase(
+        "500 server error",
+        500,
+        "Internal Server Error",
+        False,
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", GET_REQUEST_TOKEN_CASES, ids=lambda c: c.desc)
+async def test_get_request_token(case: GetRequestTokenCase):
+    resp = httpx.Response(
+        case.response_status,
+        text=case.response_body,
+        request=httpx.Request("POST", "https://provider.com/oauth/request_token"),
+    )
+
+    with _mock_httpx(resp):
+        if case.expect_success:
+            result = await _svc().get_request_token(
+                request_token_url="https://provider.com/oauth/request_token",
+                consumer_key="ck",
+                consumer_secret="cs",
+                callback_url="https://app.com/callback",
+                logger=_logger(),
+            )
+            assert isinstance(result, OAuth1TokenResponse)
+            assert result.oauth_token == case.expect_token
+            assert result.oauth_token_secret == case.expect_secret
+            if case.expect_extra is not None:
+                assert result.additional_params == case.expect_extra
+        else:
+            with pytest.raises(Exception) as exc_info:
+                await _svc().get_request_token(
+                    request_token_url="https://provider.com/oauth/request_token",
+                    consumer_key="ck",
+                    consumer_secret="cs",
+                    callback_url="https://app.com/callback",
+                    logger=_logger(),
+                )
+            assert exc_info.value.status_code == 400
+
+
+# ===========================================================================
+# exchange_token (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class ExchangeTokenCase:
+    desc: str
+    response_status: int
+    response_body: str
+    expect_success: bool
+    expect_token: Optional[str] = None
+    expect_secret: Optional[str] = None
+    expect_extra: Optional[dict] = None
+
+
+EXCHANGE_TOKEN_CASES = [
+    ExchangeTokenCase(
+        "happy path — valid access token",
+        200,
+        "oauth_token=access_tok&oauth_token_secret=access_sec&user_id=123",
+        True,
+        expect_token="access_tok",
+        expect_secret="access_sec",
+        expect_extra={"user_id": "123"},
+    ),
+    ExchangeTokenCase(
+        "200 but missing tokens — error",
+        200,
+        "user_id=123",
+        False,
+    ),
+    ExchangeTokenCase(
+        "403 forbidden",
+        403,
+        "Forbidden",
+        False,
+    ),
+    ExchangeTokenCase(
+        "502 bad gateway",
+        502,
+        "Bad Gateway",
+        False,
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", EXCHANGE_TOKEN_CASES, ids=lambda c: c.desc)
+async def test_exchange_token(case: ExchangeTokenCase):
+    resp = httpx.Response(
+        case.response_status,
+        text=case.response_body,
+        request=httpx.Request("POST", "https://provider.com/oauth/access_token"),
+    )
+
+    with _mock_httpx(resp):
+        if case.expect_success:
+            result = await _svc().exchange_token(
+                access_token_url="https://provider.com/oauth/access_token",
+                consumer_key="ck",
+                consumer_secret="cs",
+                oauth_token="req_tok",
+                oauth_token_secret="req_sec",
+                oauth_verifier="verifier123",
+                logger=_logger(),
+            )
+            assert isinstance(result, OAuth1TokenResponse)
+            assert result.oauth_token == case.expect_token
+            assert result.oauth_token_secret == case.expect_secret
+            if case.expect_extra is not None:
+                assert result.additional_params == case.expect_extra
+        else:
+            with pytest.raises(Exception) as exc_info:
+                await _svc().exchange_token(
+                    access_token_url="https://provider.com/oauth/access_token",
+                    consumer_key="ck",
+                    consumer_secret="cs",
+                    oauth_token="req_tok",
+                    oauth_token_secret="req_sec",
+                    oauth_verifier="verifier123",
+                    logger=_logger(),
+                )
+            assert exc_info.value.status_code == 400
+
+
+# ===========================================================================
+# build_authorization_url (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class AuthUrlCase:
+    desc: str
+    kwargs: dict
+    expect_contains: list = field(default_factory=list)
+    expect_not_contains: list = field(default_factory=list)
+
+
+AUTH_URL_CASES = [
+    AuthUrlCase(
+        "minimal — token only",
+        {
+            "authorization_url": "https://provider.com/authorize",
+            "oauth_token": "tok123",
+        },
+        ["oauth_token=tok123"],
+        ["name=", "scope=", "expiration="],
+    ),
+    AuthUrlCase(
+        "all optional params",
+        {
+            "authorization_url": "https://provider.com/authorize",
+            "oauth_token": "tok123",
+            "app_name": "MyApp",
+            "scope": "read,write",
+            "expiration": "never",
+        },
+        ["oauth_token=tok123", "name=MyApp", "scope=read", "expiration=never"],
+    ),
+    AuthUrlCase(
+        "partial — scope only",
+        {
+            "authorization_url": "https://provider.com/authorize",
+            "oauth_token": "tok123",
+            "scope": "read",
+        },
+        ["oauth_token=tok123", "scope=read"],
+        ["name=", "expiration="],
+    ),
+    AuthUrlCase(
+        "partial — app_name only",
+        {
+            "authorization_url": "https://provider.com/authorize",
+            "oauth_token": "tok123",
+            "app_name": "TestApp",
+        },
+        ["oauth_token=tok123", "name=TestApp"],
+        ["scope=", "expiration="],
+    ),
+]
+
+
+@pytest.mark.parametrize("case", AUTH_URL_CASES, ids=lambda c: c.desc)
+def test_build_authorization_url(case: AuthUrlCase):
+    url = _svc().build_authorization_url(**case.kwargs)
+    assert url.startswith(case.kwargs["authorization_url"])
+    for fragment in case.expect_contains:
+        assert fragment in url
+    for fragment in case.expect_not_contains:
+        assert fragment not in url

--- a/backend/airweave/domains/oauth/tests/test_oauth2_service.py
+++ b/backend/airweave/domains/oauth/tests/test_oauth2_service.py
@@ -1,0 +1,1382 @@
+"""Unit tests for OAuth2Service.
+
+Covers:
+- _encode_client_credentials (base64 encoding)
+- _generate_pkce_challenge_pair (RFC 7636 compliance)
+- _normalize_token_response (standard + non-standard formats)
+- _is_oauth_rate_limit_error (429, Zoho-style 400, normal errors)
+- _prepare_token_request (scope rules, credential location)
+- _get_client_credentials (priority ordering)
+- _supports_oauth2 (trivial)
+- generate_auth_url (URL construction, templates, scopes, state)
+- generate_auth_url_with_redirect (PKCE toggle, redirect_uri)
+- exchange_authorization_code_for_token (happy path, missing settings, template URLs)
+- exchange_authorization_code_for_token_with_redirect (same + PKCE)
+- refresh_access_token (full flow, rotating refresh, missing token, missing config)
+- _exchange_code (HTTP errors, PKCE, credential location)
+- _make_token_request (rate limit retries)
+- _handle_token_response (rotating vs non-rotating credential update)
+
+Uses table-driven tests wherever possible.
+"""
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from airweave.api.context import ApiContext
+from airweave.core.exceptions import NotFoundException, TokenRefreshError
+from airweave.core.logging import logger
+from airweave.core.shared_models import AuthMethod
+from airweave.domains.oauth.fakes.repository import (
+    FakeCredentialEncryptor,
+    FakeOAuthConnectionRepository,
+    FakeOAuthCredentialRepository,
+    FakeOAuthSourceRepository,
+)
+from airweave.domains.oauth.oauth2_service import OAuth2Service
+from airweave.platform.auth.schemas import OAuth2Settings, OAuth2TokenResponse
+from airweave.schemas.organization import Organization
+
+NOW = datetime.now(timezone.utc)
+ORG_ID = uuid4()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx() -> ApiContext:
+    org = Organization(
+        id=str(ORG_ID),
+        name="Test Org",
+        created_at=NOW,
+        modified_at=NOW,
+        enabled_features=[],
+    )
+    return ApiContext(
+        request_id="test-req-001",
+        organization=org,
+        auth_method=AuthMethod.SYSTEM,
+        auth_metadata={},
+        logger=logger.with_context(request_id="test-req-001"),
+    )
+
+
+def _make_settings(**overrides) -> SimpleNamespace:
+    defaults = dict(app_url="https://app.airweave.ai")
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_oauth2_settings(
+    *,
+    short_name: str = "slack",
+    url: str = "https://slack.com/oauth/v2/authorize",
+    backend_url: str = "https://slack.com/api/oauth.v2.access",
+    client_id: str = "test-client-id",
+    client_secret: str = "test-client-secret",
+    grant_type: str = "authorization_code",
+    content_type: str = "application/x-www-form-urlencoded",
+    client_credential_location: str = "body",
+    scope: Optional[str] = None,
+    user_scope: Optional[str] = None,
+    additional_frontend_params: Optional[dict] = None,
+    url_template: bool = False,
+    backend_url_template: bool = False,
+    requires_pkce: bool = False,
+    oauth_type: Optional[str] = None,
+) -> OAuth2Settings:
+    return OAuth2Settings(
+        integration_short_name=short_name,
+        url=url,
+        backend_url=backend_url,
+        client_id=client_id,
+        client_secret=client_secret,
+        grant_type=grant_type,
+        content_type=content_type,
+        client_credential_location=client_credential_location,
+        scope=scope,
+        user_scope=user_scope,
+        additional_frontend_params=additional_frontend_params,
+        url_template=url_template,
+        backend_url_template=backend_url_template,
+        requires_pkce=requires_pkce,
+        oauth_type=oauth_type,
+    )
+
+
+def _make_integration_config(**overrides) -> SimpleNamespace:
+    """Build a lightweight integration config stand-in."""
+    defaults = dict(
+        integration_short_name="google_drive",
+        backend_url="https://oauth2.googleapis.com/token",
+        backend_url_template=False,
+        content_type="application/x-www-form-urlencoded",
+        grant_type="authorization_code",
+        client_id="cfg-client-id",
+        client_secret="cfg-client-secret",
+        client_credential_location="body",
+        scope="https://www.googleapis.com/auth/drive.readonly",
+        oauth_type="with_refresh",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_httpx_response(
+    status_code: int = 200,
+    json_body: Optional[dict] = None,
+    text: str = "",
+) -> httpx.Response:
+    """Build an httpx.Response with controllable body."""
+    return httpx.Response(
+        status_code=status_code,
+        content=json.dumps(json_body).encode() if json_body else text.encode(),
+        headers={"content-type": "application/json"} if json_body else {},
+        request=httpx.Request("POST", "https://example.com/token"),
+    )
+
+
+class Deps:
+    """Bundles fakes for OAuth2Service constructor."""
+
+    def __init__(self, **settings_overrides):
+        self.settings = _make_settings(**settings_overrides)
+        self.conn_repo = FakeOAuthConnectionRepository()
+        self.cred_repo = FakeOAuthCredentialRepository()
+        self.encryptor = FakeCredentialEncryptor()
+        self.source_repo = FakeOAuthSourceRepository()
+
+    def build(self) -> OAuth2Service:
+        return OAuth2Service(
+            settings=self.settings,
+            conn_repo=self.conn_repo,
+            cred_repo=self.cred_repo,
+            encryptor=self.encryptor,
+            source_repo=self.source_repo,
+        )
+
+
+def _svc(**settings_overrides) -> OAuth2Service:
+    return Deps(**settings_overrides).build()
+
+
+# ===========================================================================
+# _encode_client_credentials (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class EncodeCredCase:
+    desc: str
+    client_id: str
+    client_secret: str
+    expected: str
+
+
+ENCODE_CRED_CASES = [
+    EncodeCredCase(
+        "standard credentials",
+        "my-id",
+        "my-secret",
+        base64.b64encode(b"my-id:my-secret").decode("ascii"),
+    ),
+    EncodeCredCase(
+        "empty secret",
+        "my-id",
+        "",
+        base64.b64encode(b"my-id:").decode("ascii"),
+    ),
+    EncodeCredCase(
+        "special characters in secret",
+        "id",
+        "s3cr3t+/=!@#",
+        base64.b64encode(b"id:s3cr3t+/=!@#").decode("ascii"),
+    ),
+    EncodeCredCase(
+        "both empty",
+        "",
+        "",
+        base64.b64encode(b":").decode("ascii"),
+    ),
+]
+
+
+@pytest.mark.parametrize("case", ENCODE_CRED_CASES, ids=lambda c: c.desc)
+def test_encode_client_credentials(case: EncodeCredCase):
+    result = _svc()._encode_client_credentials(case.client_id, case.client_secret)
+    assert result == case.expected
+
+
+# ===========================================================================
+# _generate_pkce_challenge_pair
+# ===========================================================================
+
+
+def test_pkce_pair_format_and_length():
+    verifier, challenge = _svc()._generate_pkce_challenge_pair()
+    assert 43 <= len(verifier) <= 128
+    assert len(challenge) > 0
+    assert "=" not in challenge  # no padding per spec
+
+
+def test_pkce_pair_verifier_matches_challenge():
+    """SHA256(verifier) base64url-encoded == challenge (RFC 7636)."""
+    verifier, challenge = _svc()._generate_pkce_challenge_pair()
+    sha = hashlib.sha256(verifier.encode("ascii")).digest()
+    expected = base64.urlsafe_b64encode(sha).decode("ascii").rstrip("=")
+    assert challenge == expected
+
+
+def test_pkce_pair_uniqueness():
+    pairs = [_svc()._generate_pkce_challenge_pair() for _ in range(10)]
+    verifiers = [v for v, _ in pairs]
+    assert len(set(verifiers)) == 10
+
+
+# ===========================================================================
+# _normalize_token_response (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class NormalizeCase:
+    desc: str
+    response_data: dict
+    expected_access_token: str
+    expected_token_type: Optional[str] = None
+
+
+NORMALIZE_CASES = [
+    NormalizeCase(
+        "standard format — passthrough",
+        {"access_token": "tok-123", "token_type": "Bearer", "scope": "read"},
+        "tok-123",
+        "Bearer",
+    ),
+    NormalizeCase(
+        "slack nested authed_user",
+        {
+            "ok": True,
+            "authed_user": {
+                "access_token": "xoxp-slack-user",
+                "token_type": "user",
+                "scope": "channels:read",
+            },
+        },
+        "xoxp-slack-user",
+        "user",
+    ),
+    NormalizeCase(
+        "authed_user present but access_token also at top level — no normalization",
+        {
+            "access_token": "top-level-tok",
+            "authed_user": {"access_token": "nested-tok"},
+        },
+        "top-level-tok",
+        None,
+    ),
+    NormalizeCase(
+        "authed_user is not a dict — ignored",
+        {"access_token": "tok-abc", "authed_user": "not-a-dict"},
+        "tok-abc",
+        None,
+    ),
+    NormalizeCase(
+        "empty authed_user dict without access_token — passthrough",
+        {"access_token": "tok-xyz", "authed_user": {}},
+        "tok-xyz",
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", NORMALIZE_CASES, ids=lambda c: c.desc)
+def test_normalize_token_response(case: NormalizeCase):
+    svc = _svc()
+    log = logger.with_context(test="normalize")
+    result = svc._normalize_token_response(case.response_data, "test_source", log)
+    assert result["access_token"] == case.expected_access_token
+    if case.expected_token_type:
+        assert result.get("token_type") == case.expected_token_type
+
+
+# ===========================================================================
+# _is_oauth_rate_limit_error (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class RateLimitCase:
+    desc: str
+    status_code: int
+    json_body: Optional[dict]
+    expected: bool
+
+
+RATE_LIMIT_CASES = [
+    RateLimitCase("429 → True", 429, None, True),
+    RateLimitCase("200 → False", 200, None, False),
+    RateLimitCase("500 → False", 500, None, False),
+    RateLimitCase(
+        "400 Zoho-style rate limit → True",
+        400,
+        {"error_description": "You have made too many requests recently", "error": "Access Denied"},
+        True,
+    ),
+    RateLimitCase(
+        "400 but different error → False",
+        400,
+        {"error_description": "Invalid grant", "error": "invalid_grant"},
+        False,
+    ),
+    RateLimitCase(
+        "400 with non-JSON body → False",
+        400,
+        None,
+        False,
+    ),
+    RateLimitCase(
+        "400 error_description without 'too many requests' → False",
+        400,
+        {"error_description": "Something went wrong", "error": "Access Denied"},
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", RATE_LIMIT_CASES, ids=lambda c: c.desc)
+def test_is_oauth_rate_limit_error(case: RateLimitCase):
+    resp = _make_httpx_response(status_code=case.status_code, json_body=case.json_body)
+    result = _svc()._is_oauth_rate_limit_error(resp)
+    assert result is case.expected
+
+
+# ===========================================================================
+# _get_client_credentials (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class ClientCredCase:
+    desc: str
+    config_id: str
+    config_secret: str
+    auth_fields: Optional[dict]
+    decrypted_credential: Optional[dict]
+    expect_id: str
+    expect_secret: str
+
+
+CLIENT_CRED_CASES = [
+    ClientCredCase(
+        "config only — fallback to integration_config",
+        "cfg-id", "cfg-secret", None, None, "cfg-id", "cfg-secret",
+    ),
+    ClientCredCase(
+        "decrypted_credential overrides config",
+        "cfg-id", "cfg-secret", None,
+        {"client_id": "cred-id", "client_secret": "cred-secret"},
+        "cred-id", "cred-secret",
+    ),
+    ClientCredCase(
+        "auth_fields overrides decrypted_credential",
+        "cfg-id", "cfg-secret",
+        {"client_id": "auth-id", "client_secret": "auth-secret"},
+        {"client_id": "cred-id", "client_secret": "cred-secret"},
+        "auth-id", "auth-secret",
+    ),
+    ClientCredCase(
+        "partial override — decrypted_credential overrides only id",
+        "cfg-id", "cfg-secret", None,
+        {"client_id": "new-id"},
+        "new-id", "cfg-secret",
+    ),
+    ClientCredCase(
+        "partial override — auth_fields overrides only secret",
+        "cfg-id", "cfg-secret",
+        {"client_secret": "new-secret"}, None,
+        "cfg-id", "new-secret",
+    ),
+    ClientCredCase(
+        "all three — auth_fields wins",
+        "cfg-id", "cfg-secret",
+        {"client_id": "auth-id"},
+        {"client_id": "cred-id"},
+        "auth-id", "cfg-secret",
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", CLIENT_CRED_CASES, ids=lambda c: c.desc)
+async def test_get_client_credentials(case: ClientCredCase):
+    config = _make_integration_config(client_id=case.config_id, client_secret=case.config_secret)
+    log = logger.with_context(test="creds")
+    cid, csecret = await _svc()._get_client_credentials(
+        log, config, case.auth_fields, case.decrypted_credential
+    )
+    assert cid == case.expect_id
+    assert csecret == case.expect_secret
+
+
+# ===========================================================================
+# _prepare_token_request — scope rules (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class PrepareRequestCase:
+    desc: str
+    oauth_type: Optional[str]
+    integration_short_name: str
+    scope: Optional[str]
+    cred_location: str  # "header" or "body"
+    expect_scope_in_payload: bool
+    expect_auth_header: bool
+
+
+PREPARE_REQUEST_CASES = [
+    PrepareRequestCase(
+        "with_refresh + scope → scope included",
+        "with_refresh", "google_drive", "drive.readonly", "body",
+        True, False,
+    ),
+    PrepareRequestCase(
+        "with_rotating_refresh → scope excluded",
+        "with_rotating_refresh", "jira", "read:jira-work", "body",
+        False, False,
+    ),
+    PrepareRequestCase(
+        "salesforce → scope excluded (special case)",
+        "with_refresh", "salesforce", "full", "body",
+        False, False,
+    ),
+    PrepareRequestCase(
+        "no oauth_type → scope excluded",
+        None, "generic", "some-scope", "body",
+        False, False,
+    ),
+    PrepareRequestCase(
+        "with_refresh but no scope → no scope key",
+        "with_refresh", "hubspot", None, "body",
+        False, False,
+    ),
+    PrepareRequestCase(
+        "header location → Basic auth in header, no client_id/secret in body",
+        "with_refresh", "zoom", "meeting:read", "header",
+        True, True,
+    ),
+    PrepareRequestCase(
+        "body location → client_id/secret in payload",
+        "with_refresh", "google_drive", "drive", "body",
+        True, False,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", PREPARE_REQUEST_CASES, ids=lambda c: c.desc)
+def test_prepare_token_request(case: PrepareRequestCase):
+    config = _make_integration_config(
+        oauth_type=case.oauth_type,
+        integration_short_name=case.integration_short_name,
+        scope=case.scope,
+        client_credential_location=case.cred_location,
+    )
+    log = logger.with_context(test="prepare")
+    headers, payload = _svc()._prepare_token_request(
+        log, config, "refresh-tok-xyz", "cid", "csecret"
+    )
+
+    assert payload["grant_type"] == "refresh_token"
+    assert payload["refresh_token"] == "refresh-tok-xyz"
+
+    if case.expect_scope_in_payload:
+        assert "scope" in payload
+    else:
+        assert "scope" not in payload
+
+    if case.expect_auth_header:
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("Basic ")
+        assert "client_id" not in payload
+        assert "client_secret" not in payload
+    else:
+        if case.cred_location == "body":
+            assert payload["client_id"] == "cid"
+            assert payload["client_secret"] == "csecret"
+
+
+# ===========================================================================
+# _supports_oauth2
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "oauth_type,expected",
+    [("with_refresh", True), ("access_only", True), (None, False)],
+    ids=["with_refresh", "access_only", "none"],
+)
+def test_supports_oauth2(oauth_type, expected):
+    assert _svc()._supports_oauth2(oauth_type) is expected
+
+
+# ===========================================================================
+# generate_auth_url (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class AuthUrlCase:
+    desc: str
+    scope: Optional[str]
+    user_scope: Optional[str]
+    state: Optional[str]
+    client_id_override: Optional[str]
+    additional_frontend_params: Optional[dict]
+    url_template: bool
+    template_configs: Optional[dict]
+    url: str
+    expect_in_url: list[str] = field(default_factory=list)
+    expect_not_in_url: list[str] = field(default_factory=list)
+    expect_error: bool = False
+
+
+AUTH_URL_CASES = [
+    AuthUrlCase(
+        "basic — no scope, no state",
+        None, None, None, None, None, False, None,
+        "https://provider.com/auth",
+        ["response_type=code", "client_id=test-client-id", "redirect_uri="],
+        ["scope=", "state=", "user_scope="],
+    ),
+    AuthUrlCase(
+        "with scope and user_scope",
+        "read write", "channels:read", None, None, None, False, None,
+        "https://provider.com/auth",
+        ["scope=read+write", "user_scope=channels"],
+    ),
+    AuthUrlCase(
+        "with state",
+        None, None, "csrf-tok-abc", None, None, False, None,
+        "https://provider.com/auth",
+        ["state=csrf-tok-abc"],
+    ),
+    AuthUrlCase(
+        "client_id override",
+        None, None, None, "override-id", None, False, None,
+        "https://provider.com/auth",
+        ["client_id=override-id"],
+        ["client_id=test-client-id"],
+    ),
+    AuthUrlCase(
+        "additional_frontend_params",
+        None, None, None, None, {"prompt": "consent"}, False, None,
+        "https://provider.com/auth",
+        ["prompt=consent"],
+    ),
+    AuthUrlCase(
+        "template URL — rendered",
+        None, None, None, None, None, True,
+        {"instance_url": "mycompany.example.com"},
+        "https://{instance_url}/oauth/authorize",
+        ["mycompany.example.com"],
+    ),
+    AuthUrlCase(
+        "template URL — missing configs → error",
+        None, None, None, None, None, True, None,
+        "https://{instance_url}/oauth/authorize",
+        expect_error=True,
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", AUTH_URL_CASES, ids=lambda c: c.desc)
+async def test_generate_auth_url(case: AuthUrlCase):
+    settings_obj = _make_oauth2_settings(
+        url=case.url,
+        scope=case.scope,
+        user_scope=case.user_scope,
+        additional_frontend_params=case.additional_frontend_params,
+        url_template=case.url_template,
+    )
+    svc = _svc()
+
+    if case.expect_error:
+        with pytest.raises(ValueError):
+            await svc.generate_auth_url(
+                settings_obj,
+                client_id=case.client_id_override,
+                state=case.state,
+                template_configs=case.template_configs,
+            )
+        return
+
+    url = await svc.generate_auth_url(
+        settings_obj,
+        client_id=case.client_id_override,
+        state=case.state,
+        template_configs=case.template_configs,
+    )
+
+    for expected in case.expect_in_url:
+        assert expected in url, f"expected '{expected}' in URL: {url}"
+    for unexpected in case.expect_not_in_url:
+        assert unexpected not in url, f"did not expect '{unexpected}' in URL: {url}"
+
+
+# ===========================================================================
+# generate_auth_url_with_redirect — PKCE (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class AuthUrlRedirectCase:
+    desc: str
+    requires_pkce: bool
+    state: Optional[str]
+    expect_code_verifier: bool
+    expect_in_url: list[str] = field(default_factory=list)
+
+
+AUTH_URL_REDIRECT_CASES = [
+    AuthUrlRedirectCase(
+        "no PKCE → verifier is None",
+        False, None, False,
+        ["redirect_uri=https%3A%2F%2Fcustom.app%2Fcallback"],
+    ),
+    AuthUrlRedirectCase(
+        "PKCE required → verifier returned, challenge in URL",
+        True, None, True,
+        ["code_challenge=", "code_challenge_method=S256"],
+    ),
+    AuthUrlRedirectCase(
+        "with state → state in URL",
+        False, "my-state", False,
+        ["state=my-state"],
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", AUTH_URL_REDIRECT_CASES, ids=lambda c: c.desc)
+async def test_generate_auth_url_with_redirect(case: AuthUrlRedirectCase):
+    settings_obj = _make_oauth2_settings(requires_pkce=case.requires_pkce)
+    svc = _svc()
+
+    url, verifier = await svc.generate_auth_url_with_redirect(
+        settings_obj,
+        redirect_uri="https://custom.app/callback",
+        state=case.state,
+    )
+
+    if case.expect_code_verifier:
+        assert verifier is not None
+        assert len(verifier) >= 43
+    else:
+        assert verifier is None
+
+    for expected in case.expect_in_url:
+        assert expected in url, f"expected '{expected}' in URL: {url}"
+
+
+# ===========================================================================
+# _exchange_code (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class ExchangeCodeCase:
+    desc: str
+    cred_location: str
+    code_verifier: Optional[str]
+    http_status: int
+    response_body: dict
+    expect_error: bool
+    expect_pkce_in_payload: bool
+
+
+EXCHANGE_CODE_CASES = [
+    ExchangeCodeCase(
+        "happy path — body credentials",
+        "body", None, 200,
+        {"access_token": "new-tok", "token_type": "Bearer"},
+        False, False,
+    ),
+    ExchangeCodeCase(
+        "happy path — header credentials",
+        "header", None, 200,
+        {"access_token": "new-tok"},
+        False, False,
+    ),
+    ExchangeCodeCase(
+        "with PKCE verifier",
+        "body", "verifier-abc", 200,
+        {"access_token": "pkce-tok"},
+        False, True,
+    ),
+    ExchangeCodeCase(
+        "HTTP 401 error → HTTPException",
+        "body", None, 401,
+        {"error": "invalid_client"},
+        True, False,
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", EXCHANGE_CODE_CASES, ids=lambda c: c.desc)
+async def test_exchange_code(case: ExchangeCodeCase):
+    config = _make_integration_config(client_credential_location=case.cred_location)
+    log = logger.with_context(test="exchange_code")
+    svc = _svc()
+
+    mock_response = _make_httpx_response(case.http_status, case.response_body)
+
+    async def fake_post(url, headers=None, data=None):
+        if case.expect_pkce_in_payload:
+            assert "code_verifier" in data
+        if case.http_status >= 400:
+            raise httpx.HTTPStatusError(
+                "error", request=mock_response.request, response=mock_response
+            )
+        return mock_response
+
+    mock_client = AsyncMock()
+    mock_client.post = fake_post
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("airweave.domains.oauth.oauth2_service.httpx.AsyncClient", return_value=mock_client):
+        if case.expect_error:
+            with pytest.raises(Exception):
+                await svc._exchange_code(
+                    logger=log,
+                    code="auth-code-xyz",
+                    redirect_uri="https://app.test/callback",
+                    client_id="cid",
+                    client_secret="csecret",
+                    backend_url="https://provider.com/token",
+                    integration_config=config,
+                    code_verifier=case.code_verifier,
+                )
+        else:
+            result = await svc._exchange_code(
+                logger=log,
+                code="auth-code-xyz",
+                redirect_uri="https://app.test/callback",
+                client_id="cid",
+                client_secret="csecret",
+                backend_url="https://provider.com/token",
+                integration_config=config,
+                code_verifier=case.code_verifier,
+            )
+            assert result.access_token == case.response_body["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_normalizes_slack_response():
+    """Slack-style nested authed_user response is normalized."""
+    config = _make_integration_config()
+    log = logger.with_context(test="exchange_slack")
+    svc = _svc()
+
+    slack_body = {
+        "ok": True,
+        "authed_user": {
+            "access_token": "xoxp-user-tok",
+            "token_type": "user",
+            "scope": "channels:read",
+        },
+    }
+    mock_response = _make_httpx_response(200, slack_body)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("airweave.domains.oauth.oauth2_service.httpx.AsyncClient", return_value=mock_client):
+        result = await svc._exchange_code(
+            logger=log,
+            code="slack-code",
+            redirect_uri="https://app.test/callback",
+            client_id="cid",
+            client_secret="csecret",
+            backend_url="https://slack.com/api/oauth.v2.access",
+            integration_config=config,
+        )
+    assert result.access_token == "xoxp-user-tok"
+
+
+# ===========================================================================
+# exchange_authorization_code_for_token (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class ExchangeTokenCase:
+    desc: str
+    settings_found: bool
+    backend_url_template: bool
+    template_configs: Optional[dict]
+    client_id_override: Optional[str]
+    client_secret_override: Optional[str]
+    expect_error: bool
+    expect_error_type: type = Exception
+
+
+EXCHANGE_TOKEN_CASES = [
+    ExchangeTokenCase("happy path", True, False, None, None, None, False),
+    ExchangeTokenCase("settings not found → HTTPException", False, False, None, None, None, True),
+    ExchangeTokenCase(
+        "template URL without configs → ValueError",
+        True, True, None, None, None, True, ValueError,
+    ),
+    ExchangeTokenCase(
+        "template URL with configs → rendered",
+        True, True, {"instance_url": "acme.example.com"}, None, None, False,
+    ),
+    ExchangeTokenCase("client_id + secret override", True, False, None, "custom-id", "custom-secret", False),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", EXCHANGE_TOKEN_CASES, ids=lambda c: c.desc)
+async def test_exchange_authorization_code_for_token(case: ExchangeTokenCase):
+    svc = _svc()
+    ctx = _make_ctx()
+
+    oauth_settings = _make_oauth2_settings(
+        backend_url=(
+            "https://{instance_url}/oauth/token" if case.backend_url_template
+            else "https://provider.com/token"
+        ),
+        backend_url_template=case.backend_url_template,
+    )
+
+    async def fake_get_by_short_name(name):
+        if not case.settings_found:
+            return None
+        return oauth_settings
+
+    token_response = OAuth2TokenResponse(access_token="exchanged-tok")
+
+    with (
+        patch(
+            "airweave.domains.oauth.oauth2_service.integration_settings"
+        ) as mock_int_settings,
+        patch.object(svc, "_exchange_code", new_callable=AsyncMock, return_value=token_response),
+    ):
+        mock_int_settings.get_by_short_name = AsyncMock(side_effect=fake_get_by_short_name)
+
+        if case.expect_error:
+            with pytest.raises(Exception):
+                await svc.exchange_authorization_code_for_token(
+                    ctx, "test_source", "auth-code",
+                    client_id=case.client_id_override,
+                    client_secret=case.client_secret_override,
+                    template_configs=case.template_configs,
+                )
+        else:
+            result = await svc.exchange_authorization_code_for_token(
+                ctx, "test_source", "auth-code",
+                client_id=case.client_id_override,
+                client_secret=case.client_secret_override,
+                template_configs=case.template_configs,
+            )
+            assert result.access_token == "exchanged-tok"
+
+
+# ===========================================================================
+# exchange_authorization_code_for_token_with_redirect (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class ExchangeWithRedirectCase:
+    desc: str
+    settings_raises: bool
+    backend_url_template: bool
+    template_configs: Optional[dict]
+    code_verifier: Optional[str]
+    expect_error: bool
+
+
+EXCHANGE_WITH_REDIRECT_CASES = [
+    ExchangeWithRedirectCase("happy path", False, False, None, None, False),
+    ExchangeWithRedirectCase("settings KeyError → HTTPException", True, False, None, None, True),
+    ExchangeWithRedirectCase(
+        "template URL with configs", False, True,
+        {"instance_url": "acme.example.com"}, None, False,
+    ),
+    ExchangeWithRedirectCase("with PKCE verifier", False, False, None, "pkce-verifier", False),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", EXCHANGE_WITH_REDIRECT_CASES, ids=lambda c: c.desc)
+async def test_exchange_token_with_redirect(case: ExchangeWithRedirectCase):
+    svc = _svc()
+    ctx = _make_ctx()
+
+    oauth_settings = _make_oauth2_settings(
+        backend_url=(
+            "https://{instance_url}/oauth/token" if case.backend_url_template
+            else "https://provider.com/token"
+        ),
+        backend_url_template=case.backend_url_template,
+    )
+
+    async def fake_get_by_short_name(name):
+        if case.settings_raises:
+            raise KeyError(f"No settings for {name}")
+        return oauth_settings
+
+    token_response = OAuth2TokenResponse(access_token="redirect-tok")
+
+    with (
+        patch(
+            "airweave.domains.oauth.oauth2_service.integration_settings"
+        ) as mock_int_settings,
+        patch.object(svc, "_exchange_code", new_callable=AsyncMock, return_value=token_response),
+    ):
+        mock_int_settings.get_by_short_name = AsyncMock(side_effect=fake_get_by_short_name)
+
+        if case.expect_error:
+            with pytest.raises(Exception):
+                await svc.exchange_authorization_code_for_token_with_redirect(
+                    ctx,
+                    source_short_name="test_source",
+                    code="auth-code",
+                    redirect_uri="https://custom.app/cb",
+                    template_configs=case.template_configs,
+                    code_verifier=case.code_verifier,
+                )
+        else:
+            result = await svc.exchange_authorization_code_for_token_with_redirect(
+                ctx,
+                source_short_name="test_source",
+                code="auth-code",
+                redirect_uri="https://custom.app/cb",
+                template_configs=case.template_configs,
+                code_verifier=case.code_verifier,
+            )
+            assert result.access_token == "redirect-tok"
+
+
+# ===========================================================================
+# refresh_access_token (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class RefreshCase:
+    desc: str
+    decrypted_credential: dict
+    config_found: bool
+    oauth_type: str
+    http_status: int
+    http_body: dict
+    expect_error: bool
+    expect_error_type: type = Exception
+    expect_access_token: Optional[str] = None
+
+
+REFRESH_CASES = [
+    RefreshCase(
+        "happy path — with_refresh",
+        {"refresh_token": "rt-123", "access_token": "old-at"},
+        True, "with_refresh", 200,
+        {"access_token": "new-at", "token_type": "Bearer"},
+        False,
+        expect_access_token="new-at",
+    ),
+    RefreshCase(
+        "no refresh token → TokenRefreshError",
+        {"access_token": "only-at"},
+        True, "with_refresh", 200, {},
+        True, TokenRefreshError,
+    ),
+    RefreshCase(
+        "integration config not found → NotFoundException",
+        {"refresh_token": "rt-123"},
+        False, "with_refresh", 200, {},
+        True, NotFoundException,
+    ),
+    RefreshCase(
+        "rotating refresh — new refresh_token stored",
+        {"refresh_token": "old-rt", "access_token": "old-at"},
+        True, "with_rotating_refresh", 200,
+        {"access_token": "fresh-at", "refresh_token": "fresh-rt"},
+        False,
+        expect_access_token="fresh-at",
+    ),
+    RefreshCase(
+        "HTTP 401 from provider → error bubbles",
+        {"refresh_token": "rt-expired"},
+        True, "with_refresh", 401,
+        {"error": "invalid_grant"},
+        True,
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", REFRESH_CASES, ids=lambda c: c.desc)
+async def test_refresh_access_token(case: RefreshCase):
+    deps = Deps()
+    svc = deps.build()
+    ctx = _make_ctx()
+    connection_id = uuid4()
+    cred_id = uuid4()
+
+    integration_config = _make_integration_config(oauth_type=case.oauth_type)
+
+    async def fake_get_by_short_name(name):
+        if not case.config_found:
+            return None
+        return integration_config
+
+    # Seed repos for rotating refresh path
+    deps.conn_repo.seed(
+        connection_id, SimpleNamespace(id=connection_id, integration_credential_id=cred_id)
+    )
+    deps.cred_repo.seed(
+        cred_id, SimpleNamespace(id=cred_id, encrypted_credentials="enc-blob")
+    )
+    deps.encryptor.seed_decrypt(dict(case.decrypted_credential))
+
+    mock_http_response = _make_httpx_response(case.http_status, case.http_body)
+
+    async def fake_post(url, headers=None, data=None):
+        if case.http_status >= 400:
+            raise httpx.HTTPStatusError(
+                "err", request=mock_http_response.request, response=mock_http_response
+            )
+        return mock_http_response
+
+    mock_client = AsyncMock()
+    mock_client.post = fake_post
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch(
+            "airweave.domains.oauth.oauth2_service.integration_settings"
+        ) as mock_int_settings,
+        patch(
+            "airweave.domains.oauth.oauth2_service.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+    ):
+        mock_int_settings.get_by_short_name = AsyncMock(side_effect=fake_get_by_short_name)
+
+        if case.expect_error:
+            with pytest.raises(case.expect_error_type):
+                await svc.refresh_access_token(
+                    MagicMock(), "google_drive", ctx, connection_id,
+                    case.decrypted_credential,
+                )
+        else:
+            result = await svc.refresh_access_token(
+                MagicMock(), "google_drive", ctx, connection_id,
+                case.decrypted_credential,
+            )
+            assert result.access_token == case.expect_access_token
+
+
+# ===========================================================================
+# _handle_token_response — rotating vs non-rotating (table-driven)
+# ===========================================================================
+
+
+@dataclass
+class HandleResponseCase:
+    desc: str
+    oauth_type: Optional[str]
+    response_body: dict
+    expect_credential_update: bool
+
+
+HANDLE_RESPONSE_CASES = [
+    HandleResponseCase(
+        "with_refresh — no credential update",
+        "with_refresh",
+        {"access_token": "at-1", "refresh_token": "rt-1"},
+        False,
+    ),
+    HandleResponseCase(
+        "with_rotating_refresh — credential updated with new refresh_token",
+        "with_rotating_refresh",
+        {"access_token": "at-2", "refresh_token": "rt-new"},
+        True,
+    ),
+    HandleResponseCase(
+        "no oauth_type — no credential update",
+        None,
+        {"access_token": "at-3"},
+        False,
+    ),
+    HandleResponseCase(
+        "access_only — no credential update",
+        "access_only",
+        {"access_token": "at-4"},
+        False,
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", HANDLE_RESPONSE_CASES, ids=lambda c: c.desc)
+async def test_handle_token_response(case: HandleResponseCase):
+    deps = Deps()
+    svc = deps.build()
+    ctx = _make_ctx()
+    connection_id = uuid4()
+    cred_id = uuid4()
+    config = _make_integration_config(oauth_type=case.oauth_type)
+
+    http_response = _make_httpx_response(200, case.response_body)
+
+    deps.conn_repo.seed(
+        connection_id, SimpleNamespace(id=connection_id, integration_credential_id=cred_id)
+    )
+    deps.cred_repo.seed(
+        cred_id, SimpleNamespace(id=cred_id, encrypted_credentials="enc-blob")
+    )
+    deps.encryptor.seed_decrypt({"refresh_token": "old-rt", "access_token": "old-at"})
+
+    result = await svc._handle_token_response(
+        MagicMock(), http_response, config, ctx, connection_id
+    )
+
+    assert result.access_token == case.response_body["access_token"]
+
+    if case.expect_credential_update:
+        assert len(deps.cred_repo._updated) == 1
+        assert len(deps.encryptor._encrypt_calls) == 1
+        encrypted_input = deps.encryptor._encrypt_calls[0]
+        assert encrypted_input["refresh_token"] == case.response_body["refresh_token"]
+    else:
+        assert len(deps.cred_repo._updated) == 0
+        assert len(deps.encryptor._encrypt_calls) == 0
+
+
+# ===========================================================================
+# _make_token_request — rate limit retry (integration-ish)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_make_token_request_retries_on_429():
+    """First call 429, second call 200 → succeeds after retry."""
+    svc = _svc()
+    log = logger.with_context(test="retry")
+
+    call_count = 0
+
+    async def fake_post(url, headers=None, data=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _make_httpx_response(429)
+        return _make_httpx_response(200, {"access_token": "retry-tok"})
+
+    mock_client = AsyncMock()
+    mock_client.post = fake_post
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch(
+            "airweave.domains.oauth.oauth2_service.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+        patch("airweave.domains.oauth.oauth2_service.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        result = await svc._make_token_request(log, "https://p.com/token", {}, {})
+
+    assert result.status_code == 200
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_make_token_request_zoho_style_rate_limit():
+    """Zoho returns 400 with 'too many requests' — detected as rate limit."""
+    svc = _svc()
+    log = logger.with_context(test="zoho")
+
+    call_count = 0
+    zoho_body = {
+        "error_description": "You have made too many requests recently",
+        "error": "Access Denied",
+    }
+
+    async def fake_post(url, headers=None, data=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _make_httpx_response(400, zoho_body)
+        return _make_httpx_response(200, {"access_token": "zoho-tok"})
+
+    mock_client = AsyncMock()
+    mock_client.post = fake_post
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch(
+            "airweave.domains.oauth.oauth2_service.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+        patch("airweave.domains.oauth.oauth2_service.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        result = await svc._make_token_request(log, "https://p.com/token", {}, {})
+
+    assert result.status_code == 200
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_make_token_request_non_retryable_error_raises():
+    """500 error (not rate limit) → raises immediately."""
+    svc = _svc()
+    log = logger.with_context(test="non_retry")
+
+    async def fake_post(url, headers=None, data=None):
+        resp = _make_httpx_response(500, {"error": "server_error"})
+        raise httpx.HTTPStatusError("err", request=resp.request, response=resp)
+
+    mock_client = AsyncMock()
+    mock_client.post = fake_post
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "airweave.domains.oauth.oauth2_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        with pytest.raises(httpx.HTTPStatusError):
+            await svc._make_token_request(log, "https://p.com/token", {}, {})
+
+
+# ===========================================================================
+# _get_redirect_url — uses injected settings
+# ===========================================================================
+
+
+def test_get_redirect_url_uses_injected_settings():
+    svc = _svc(app_url="https://myapp.com")
+    assert svc._get_redirect_url("slack") == "https://myapp.com/auth/callback"
+
+
+def test_get_redirect_url_different_env():
+    svc = _svc(app_url="http://localhost:3000")
+    assert svc._get_redirect_url("jira") == "http://localhost:3000/auth/callback"
+
+
+# ===========================================================================
+# FakeOAuth2Service (verify fake contract matches real service)
+# ===========================================================================
+
+
+class TestFakeOAuth2Service:
+    """Verify the fake records calls and returns seeded data."""
+
+    def _make_fake(self):
+        from airweave.domains.oauth.fakes.oauth2_service import FakeOAuth2Service
+        return FakeOAuth2Service()
+
+    @pytest.mark.asyncio
+    async def test_refresh_happy_path(self):
+        fake = self._make_fake()
+        fake.seed_refresh("slack", "fresh-tok")
+        ctx = _make_ctx()
+        result = await fake.refresh_access_token(
+            MagicMock(), "slack", ctx, uuid4(), {"refresh_token": "rt"},
+        )
+        assert result.access_token == "fresh-tok"
+        assert len(fake.calls_for("refresh_access_token")) == 1
+
+    @pytest.mark.asyncio
+    async def test_refresh_unseeded_raises(self):
+        fake = self._make_fake()
+        with pytest.raises(ValueError, match="No seeded"):
+            await fake.refresh_access_token(
+                MagicMock(), "unknown", _make_ctx(), uuid4(), {},
+            )
+
+    @pytest.mark.asyncio
+    async def test_set_error_propagates(self):
+        fake = self._make_fake()
+        fake.seed_refresh("slack", "tok")
+        fake.set_error(TokenRefreshError("forced"))
+        with pytest.raises(TokenRefreshError):
+            await fake.refresh_access_token(
+                MagicMock(), "slack", _make_ctx(), uuid4(), {},
+            )
+
+    @pytest.mark.asyncio
+    async def test_exchange_happy_path(self):
+        fake = self._make_fake()
+        fake.seed_exchange("github", "gh-tok")
+        result = await fake.exchange_authorization_code_for_token(
+            _make_ctx(), "github", "code-abc",
+        )
+        assert result.access_token == "gh-tok"
+        assert len(fake.calls_for("exchange_authorization_code_for_token")) == 1
+
+    @pytest.mark.asyncio
+    async def test_generate_auth_url_happy_path(self):
+        fake = self._make_fake()
+        fake.seed_auth_url("slack", "https://slack.com/oauth?client_id=x")
+        settings_obj = _make_oauth2_settings()
+        url = await fake.generate_auth_url(settings_obj)
+        assert url == "https://slack.com/oauth?client_id=x"
+
+    @pytest.mark.asyncio
+    async def test_exchange_with_redirect_happy_path(self):
+        fake = self._make_fake()
+        fake.seed_exchange("jira", "jira-tok")
+        result = await fake.exchange_authorization_code_for_token_with_redirect(
+            _make_ctx(),
+            source_short_name="jira",
+            code="code-xyz",
+            redirect_uri="https://app.test/cb",
+        )
+        assert result.access_token == "jira-tok"
+
+    @pytest.mark.asyncio
+    async def test_auth_url_with_redirect_happy_path(self):
+        fake = self._make_fake()
+        fake.seed_auth_url_with_redirect("airtable", "https://airtable.com/oauth", "v123")
+        settings_obj = _make_oauth2_settings(short_name="airtable")
+        url, verifier = await fake.generate_auth_url_with_redirect(
+            settings_obj, redirect_uri="https://app.test/cb",
+        )
+        assert url == "https://airtable.com/oauth"
+        assert verifier == "v123"
+
+    @pytest.mark.asyncio
+    async def test_clear_error(self):
+        fake = self._make_fake()
+        fake.seed_refresh("slack", "tok")
+        fake.set_error(RuntimeError("boom"))
+        fake.clear_error()
+        result = await fake.refresh_access_token(
+            MagicMock(), "slack", _make_ctx(), uuid4(), {},
+        )
+        assert result.access_token == "tok"

--- a/backend/airweave/domains/oauth/tests/test_oauth2_service.py
+++ b/backend/airweave/domains/oauth/tests/test_oauth2_service.py
@@ -37,8 +37,8 @@ from airweave.api.context import ApiContext
 from airweave.core.exceptions import NotFoundException, TokenRefreshError
 from airweave.core.logging import logger
 from airweave.core.shared_models import AuthMethod
+from airweave.adapters.encryption.fake import FakeCredentialEncryptor
 from airweave.domains.oauth.fakes.repository import (
-    FakeCredentialEncryptor,
     FakeOAuthConnectionRepository,
     FakeOAuthCredentialRepository,
     FakeOAuthSourceRepository,

--- a/backend/airweave/domains/oauth/types.py
+++ b/backend/airweave/domains/oauth/types.py
@@ -1,0 +1,15 @@
+"""Value types for the OAuth domain.
+
+These live in a separate module to avoid circular imports between
+service implementations and protocol definitions.
+"""
+
+
+class OAuth1TokenResponse:
+    """Response from OAuth1 token exchange."""
+
+    def __init__(self, oauth_token: str, oauth_token_secret: str, **kwargs):
+        """Initialize with token, secret, and any additional provider params."""
+        self.oauth_token = oauth_token
+        self.oauth_token_secret = oauth_token_secret
+        self.additional_params = kwargs

--- a/backend/airweave/domains/sources/tests/test_lifecycle.py
+++ b/backend/airweave/domains/sources/tests/test_lifecycle.py
@@ -579,7 +579,7 @@ async def test_handle_auth_config_credentials(case: HandleAuthConfigCase):
 
     oauth2_fake = FakeOAuth2Service()
     if case.has_refresh_token:
-        oauth2_fake.seed("src", "new-access-tok")
+        oauth2_fake.seed_refresh("src", "new-access-tok")
 
     service = _make_service(source_entries=[entry], oauth2_service=oauth2_fake)
     decrypted = {"access_token": "old", "refresh_token": case.refresh_token_value}

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -166,6 +166,14 @@ def fake_oauth2_service():
 
 
 @pytest.fixture
+def fake_oauth1_service():
+    """Real OAuth1Service (no injected deps, safe for unit tests)."""
+    from airweave.domains.oauth.oauth1_service import OAuth1Service
+
+    return OAuth1Service()
+
+
+@pytest.fixture
 def test_container(
     fake_event_bus,
     fake_webhook_publisher,
@@ -180,6 +188,7 @@ def test_container(
     fake_sc_repo,
     fake_conn_repo,
     fake_cred_repo,
+    fake_oauth1_service,
     fake_oauth2_service,
     fake_source_lifecycle_service,
 ):
@@ -207,6 +216,7 @@ def test_container(
         sc_repo=fake_sc_repo,
         conn_repo=fake_conn_repo,
         cred_repo=fake_cred_repo,
+        oauth1_service=fake_oauth1_service,
         oauth2_service=fake_oauth2_service,
         source_lifecycle_service=fake_source_lifecycle_service,
     )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an RFC‑compliant OAuth1 authentication service and wires it into the app. Also fixes OAuth1 signature generation, improves OAuth2 credential defaults, and injects the encryption key properly.

- **New Features**
  - Added OAuth1Service (request token, access token exchange, authorization URL).
  - Exposed oauth1_service in the container for use by sources.
  - Comprehensive unit tests for OAuth1 flow and signing.

- **Bug Fixes**
  - OAuth1 signature base string now strips URL query params per RFC 5849 §3.4.1.2.
  - OAuth2 code exchange now falls back client_id and client_secret independently.
  - Fernet encryptor now uses Settings.ENCRYPTION_KEY (no global dependency).

<sup>Written for commit 8d97aa277f9b15ec2d50f83fd58e4aa8afe06ac7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

