### PR TITLE
[code blue] collections repo

### DIFF
--- a/backend/airweave/domains/collections/fakes/__init__.py
+++ b/backend/airweave/domains/collections/fakes/__init__.py
@@ -1,0 +1,1 @@
+"""Fakes for the collections domain — used in unit tests."""

--- a/backend/airweave/domains/collections/fakes/repository.py
+++ b/backend/airweave/domains/collections/fakes/repository.py
@@ -1,0 +1,34 @@
+"""Fake collection repository for testing."""
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from airweave.api.context import ApiContext
+from airweave.models.collection import Collection
+
+
+class FakeCollectionRepository:
+    """In-memory fake for CollectionRepositoryProtocol."""
+
+    def __init__(self) -> None:
+        self._store: dict[UUID, Collection] = {}
+        self._readable_store: dict[str, Collection] = {}
+        self._calls: list[tuple] = []
+
+    def seed(self, id: UUID, obj: Collection) -> None:
+        self._store[id] = obj
+
+    def seed_readable(self, readable_id: str, obj: Collection) -> None:
+        self._readable_store[readable_id] = obj
+
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Optional[Collection]:
+        self._calls.append(("get", db, id, ctx))
+        return self._store.get(id)
+
+    async def get_by_readable_id(
+        self, db: AsyncSession, readable_id: str, ctx: ApiContext
+    ) -> Optional[Collection]:
+        self._calls.append(("get_by_readable_id", db, readable_id, ctx))
+        return self._readable_store.get(readable_id)

--- a/backend/airweave/domains/collections/protocols.py
+++ b/backend/airweave/domains/collections/protocols.py
@@ -1,0 +1,23 @@
+"""Protocols for collection repository."""
+
+from typing import Optional, Protocol
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from airweave.api.context import ApiContext
+from airweave.models.collection import Collection
+
+
+class CollectionRepositoryProtocol(Protocol):
+    """Read-only access to collection records."""
+
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Optional[Collection]:
+        """Get a collection by ID within an organization."""
+        ...
+
+    async def get_by_readable_id(
+        self, db: AsyncSession, readable_id: str, ctx: ApiContext
+    ) -> Optional[Collection]:
+        """Get a collection by human-readable ID within an organization."""
+        ...

--- a/backend/airweave/domains/collections/repository.py
+++ b/backend/airweave/domains/collections/repository.py
@@ -1,0 +1,23 @@
+"""Collection repository wrapping crud.collection."""
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from airweave import crud
+from airweave.api.context import ApiContext
+from airweave.domains.collections.protocols import CollectionRepositoryProtocol
+from airweave.models.collection import Collection
+
+
+class CollectionRepository(CollectionRepositoryProtocol):
+    """Delegates to the crud.collection singleton."""
+
+    async def get(self, db: AsyncSession, id: UUID, ctx: ApiContext) -> Optional[Collection]:
+        return await crud.collection.get(db, id, ctx)
+
+    async def get_by_readable_id(
+        self, db: AsyncSession, readable_id: str, ctx: ApiContext
+    ) -> Optional[Collection]:
+        return await crud.collection.get_by_readable_id(db, readable_id=readable_id, ctx=ctx)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a read-only Collections repository with a protocol and an in-memory fake for tests.

- **New Features**
  - CollectionRepository implementing get and get_by_readable_id, delegating to crud.collection.
  - In-memory FakeCollectionRepository for tests with seed and seed_readable helpers.

<sup>Written for commit 4d61fbae7e89e2008292abe3cdd4be7ffbe78695. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

