### PR TITLE
docs: improve examples README and fix grammar in intro notebook

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,34 @@ This folder contains educational materials and tutorials to help developers get 
 
 ## Contents
 
+### `intro_to_airweave.ipynb`
+An interactive Jupyter notebook that introduces the core Airweave workflow:
+
+1. **Client Setup** - Installing the SDK and initializing the client
+2. **Collections** - Creating a collection to organize data sources
+3. **Source Connections** - Connecting a data source (Stripe example)
+4. **Search** - Performing natural language searches across connected sources
+
+This is the best starting point for new users who prefer hands-on exploration.
+
+### `search_concepts.ipynb`
+A comprehensive Jupyter notebook with **14 practical examples** covering all major search features:
+
+1. **Basic Search** - Simple queries with default settings
+2. **Query Expansion** - AI-generated query variations for better recall
+3. **Search Methods** - Hybrid vs Neural search approaches
+4. **Filtering** - Structured filters by source, date range, and exclusions
+5. **Query Interpretation** - Natural language filtering (Beta)
+6. **Temporal Relevance** - Boosting recent content with recency bias
+7. **Pagination** - Handling large result sets with limit/offset
+8. **Score Filtering** - High-confidence results only
+9. **AI Reranking** - Improving result quality with AI reordering
+10. **AI Answer Generation** - Getting synthesized responses
+11. **Complete Example** - Combining all features together
+
+### `webhook-demo/`
+A minimal FastAPI app that receives Airweave webhook events and streams them to a browser UI in real time via WebSocket. See [webhook-demo/README.md](webhook-demo/README.md) for details.
+
 ### `quickstart_tutorial.py`
 A comprehensive Python script that walks through the complete Airweave quickstart process:
 

--- a/examples/intro_to_airweave.ipynb
+++ b/examples/intro_to_airweave.ipynb
@@ -109,7 +109,7 @@
     "that includes data from Stripe, HubSpot, and your internal Postgres database, or a \"Productivity Tools\" collection \n",
     "containing your Notion, Linear, and Microsoft Teams accounts.\n",
     "\n",
-    "You are free to add as many or as little sources to a collection as you like. The important thing to remember is that, in Airweave, a collection is what's being searched by an agent.\n",
+    "You are free to add as many or as few sources to a collection as you like. The important thing to remember is that, in Airweave, a collection is what's being searched by an agent.\n",
     "\n",
     "Let's create your first collection:"
    ]
@@ -124,7 +124,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ Created collection: my-first-collection-ezhgns\n",
+      "\u2705 Created collection: my-first-collection-ezhgns\n",
       "   Name: My First Collection\n",
       "   ID: YOUR_COLLECTION_ID\n"
      ]
@@ -136,7 +136,7 @@
     "    name=\"My First Collection\"  # Give your collection a descriptive name\n",
     ")\n",
     "\n",
-    "print(f\"✅ Created collection: {collection.readable_id}\")\n",
+    "print(f\"\u2705 Created collection: {collection.readable_id}\")\n",
     "print(f\"   Name: {collection.name}\")\n",
     "print(f\"   ID: {collection.id}\")"
    ]
@@ -182,7 +182,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ Created source connection: My Stripe Connection\n",
+      "\u2705 Created source connection: My Stripe Connection\n",
       "   Status: active\n",
       "   Type: stripe\n"
      ]
@@ -202,7 +202,7 @@
     "    }\n",
     ")\n",
     "\n",
-    "print(f\"✅ Created source connection: {source_connection.name}\")\n",
+    "print(f\"\u2705 Created source connection: {source_connection.name}\")\n",
     "print(f\"   Status: {source_connection.status}\")\n",
     "print(f\"   Type: {source_connection.short_name}\")"
    ]
@@ -212,7 +212,7 @@
    "id": "7275c86a",
    "metadata": {},
    "source": [
-    "Once source connection is established, Airweave will automatically:\n",
+    "Once the source connection is established, Airweave will automatically:\n",
     "1. Validate the credentials\n",
     "2. Begin syncing data from Stripe\n",
     "3. Extract and index relevant entities (customers, payments, invoices, etc.)\n",
@@ -256,9 +256,9 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "🔍 Searching for customer payment information...\n",
+      "\ud83d\udd0d Searching for customer payment information...\n",
       "\n",
-      "📍 Result 1 (Score: 88.83%)\n",
+      "\ud83d\udccd Result 1 (Score: 88.83%)\n",
       "   Source: stripe | Type: StripePaymentIntentEntity\n",
       "   ID: pi_3Q13xgGm1FpXlyE50uRm1zO2\n",
       "   Amount: 1008\n",
@@ -269,7 +269,7 @@
       "   Customer Id: cus_QpEel2ZOt74xmy\n",
       "------------------------------------------------------------\n",
       "\n",
-      "📍 Result 2 (Score: 51.82%)\n",
+      "\ud83d\udccd Result 2 (Score: 51.82%)\n",
       "   Source: stripe | Type: StripePaymentIntentEntity\n",
       "   ID: pi_3Q17MZGm1FpXlyE51ZMPa9cr\n",
       "   Amount: 1008\n",
@@ -280,7 +280,7 @@
       "   Customer Id: cus_QpEel2ZOt74xmy\n",
       "------------------------------------------------------------\n",
       "\n",
-      "📍 Result 3 (Score: 47.38%)\n",
+      "\ud83d\udccd Result 3 (Score: 47.38%)\n",
       "   Source: stripe | Type: StripePaymentIntentEntity\n",
       "   ID: pi_3Q1373Gm1FpXlyE5195Woh3n\n",
       "   Amount: 1008\n",
@@ -291,7 +291,7 @@
       "   Customer Id: cus_QpEel2ZOt74xmy\n",
       "------------------------------------------------------------\n",
       "\n",
-      "📍 Result 4 (Score: 39.98%)\n",
+      "\ud83d\udccd Result 4 (Score: 39.98%)\n",
       "   Source: stripe | Type: StripePaymentIntentEntity\n",
       "   ID: pi_3Q17TsGm1FpXlyE51wWVduuC\n",
       "   Amount: 1008\n",
@@ -302,7 +302,7 @@
       "   Customer Id: cus_QpEel2ZOt74xmy\n",
       "------------------------------------------------------------\n",
       "\n",
-      "📍 Result 5 (Score: 16.77%)\n",
+      "\ud83d\udccd Result 5 (Score: 16.77%)\n",
       "   Source: stripe | Type: StripePaymentIntentEntity\n",
       "   ID: pi_3PxrxGGm1FpXlyE50SnwWx4E\n",
       "   Amount: 1005\n",
@@ -313,7 +313,7 @@
       "   Customer Id: cus_QpEel2ZOt74xmy\n",
       "------------------------------------------------------------\n",
       "\n",
-      "📍 Result 6 (Score: 14.32%)\n",
+      "\ud83d\udccd Result 6 (Score: 14.32%)\n",
       "   Source: stripe | Type: StripePaymentIntentEntity\n",
       "   ID: pi_3PxsZsGm1FpXlyE51G6Hk74K\n",
       "   Amount: 1008\n",
@@ -327,7 +327,7 @@
     }
    ],
    "source": [
-    "print(\"\\n🔍 Searching for customer payment information...\")\n",
+    "print(\"\\n\ud83d\udd0d Searching for customer payment information...\")\n",
     "results = client.collections.search(\n",
     "    readable_id=collection.readable_id, query=\"Payment attempts for concert tickets\"\n",
     ")\n",
@@ -342,7 +342,7 @@
     "    source = payload.get('airweave_system_metadata', {}).get('source_name', 'Unknown')\n",
     "    entity_type = payload.get('airweave_system_metadata', {}).get('entity_type', 'Unknown')\n",
     "    \n",
-    "    print(f\"\\n📍 Result {i} (Score: {score:.2%})\")\n",
+    "    print(f\"\\n\ud83d\udccd Result {i} (Score: {score:.2%})\")\n",
     "    print(f\"   Source: {source} | Type: {entity_type}\")\n",
     "    print(f\"   ID: {entity_id}\")\n",
     "    \n",
@@ -372,13 +372,13 @@
    "id": "f7fcaa93",
    "metadata": {},
    "source": [
-    "## Congratulations! 🎉\n",
+    "## Congratulations! \ud83c\udf89\n",
     "\n",
     "You've successfully:\n",
-    "- ✅ Set up the Airweave Python client\n",
-    "- ✅ Created a collection\n",
-    "- ✅ Connected data sources\n",
-    "- ✅ Performed searches across your data\n",
+    "- \u2705 Set up the Airweave Python client\n",
+    "- \u2705 Created a collection\n",
+    "- \u2705 Connected data sources\n",
+    "- \u2705 Performed searches across your data\n",
     "\n",
     "### What's Next?\n",
     "\n",


### PR DESCRIPTION
## Summary

This PR improves the developer enablement materials in the `examples/` directory:

### Examples README (`examples/README.md`)

The README previously only documented `quickstart_tutorial.py`, but the directory also contains two Jupyter notebooks and a webhook demo subdirectory. This PR adds documentation for:

- **`intro_to_airweave.ipynb`** — Description and overview of what new users will learn
- **`search_concepts.ipynb`** — Summary of all 14 search examples covered in the notebook
- **`webhook-demo/`** — Cross-reference to the webhook demo subdirectory

### Intro Notebook (`examples/intro_to_airweave.ipynb`)

Fixed several grammar and formatting issues:

- `is an open-source platform enables` → `is an open-source platform that enables`
- `as many or as little sources` → `as many or as few sources` (countable noun)
- `Once source connection is established` → `Once the source connection is established`
- Improved formatting of the setup instructions cell (added markdown link and blockquote for the local deployment note)

## Changes

- Modified `examples/README.md`
- Modified `examples/intro_to_airweave.ipynb`

No code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the examples README to document the intro and search notebooks plus the webhook demo, and cleans up grammar/formatting in the intro notebook. No code changes.

- **Docs**
  - Update examples/README.md to include intro_to_airweave.ipynb, search_concepts.ipynb (14 search examples), and webhook-demo/.
  - Fix phrasing in intro_to_airweave.ipynb (“…that enables”, “as many or as few…”, “Once the source connection…”), and tidy setup/output formatting for clarity.

<sup>Written for commit d11ea7aa2bdda11c162fdf9d5d51b8470f2caf3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

