### PR TITLE
fix: local embedder probe endpoint

### DIFF
--- a/backend/airweave/domains/embedders/config.py
+++ b/backend/airweave/domains/embedders/config.py
@@ -148,9 +148,9 @@ def _validate_credentials(
 def _validate_local_reachability(dense_spec: DenseEmbedderEntry) -> None:
     """Probe the text2vec inference service when using the local dense embedder.
 
-    Only runs for local_minilm. Performs a synchronous HTTP GET to the health
-    endpoint with a short timeout. Raises EmbeddingConfigError with actionable
-    instructions if the service is unreachable.
+    Only runs for local_minilm. Performs a synchronous HTTP POST to /vectors
+    with a short timeout. Raises EmbeddingConfigError with actionable instructions
+    if the service is unreachable.
     """
     from airweave.domains.embedders.dense.local import LocalDenseEmbedder
 
@@ -158,16 +158,16 @@ def _validate_local_reachability(dense_spec: DenseEmbedderEntry) -> None:
         return
 
     inference_url = settings.TEXT2VEC_INFERENCE_URL
-    health_url = f"{inference_url}/health"
+    probe_url = f"{inference_url}/vectors"
 
     try:
         with httpx.Client(timeout=httpx.Timeout(5.0)) as client:
-            response = client.get(health_url)
+            response = client.post(probe_url, json={"text": "airweave-local-embedder-probe"})
             response.raise_for_status()
     except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError) as exc:
         raise EmbeddingConfigError(
             f"Text2vec inference service is not reachable at {inference_url}\n"
-            f"  Health check failed: {exc}\n\n"
+            f"  Probe failed: {exc}\n\n"
             f"  DENSE_EMBEDDER=local_minilm requires the text2vec-transformers container.\n\n"
             f"  If using Docker Compose, start with the local-embeddings profile:\n"
             f"    docker compose -f docker/docker-compose.yml --profile local-embeddings up -d\n\n"

--- a/backend/airweave/domains/embedders/tests/test_local_reachability.py
+++ b/backend/airweave/domains/embedders/tests/test_local_reachability.py
@@ -37,11 +37,11 @@ def _mock_client(get_return=None, get_side_effect=None):
     """Create a mock httpx.Client context manager."""
     client = MagicMock()
     if get_side_effect:
-        client.get.side_effect = get_side_effect
+        client.post.side_effect = get_side_effect
     else:
         resp = MagicMock()
         resp.raise_for_status = MagicMock()
-        client.get.return_value = get_return or resp
+        client.post.return_value = get_return or resp
     client.__enter__ = MagicMock(return_value=client)
     client.__exit__ = MagicMock(return_value=False)
     return client
@@ -62,7 +62,7 @@ class TestValidateLocalReachability:
     @patch("airweave.domains.embedders.config.settings")
     @patch("airweave.domains.embedders.config.httpx")
     def test_passes_when_service_reachable(self, mock_httpx, mock_settings):
-        """Passes when the health endpoint returns 200."""
+        """Passes when the vectors probe endpoint returns 200."""
         mock_settings.TEXT2VEC_INFERENCE_URL = "http://localhost:9878"
         mock_httpx.Timeout = httpx.Timeout
         client = _mock_client()
@@ -71,7 +71,10 @@ class TestValidateLocalReachability:
         entry = _make_entry(LocalDenseEmbedder)
         _validate_local_reachability(entry)
 
-        client.get.assert_called_once_with("http://localhost:9878/health")
+        client.post.assert_called_once_with(
+            "http://localhost:9878/vectors",
+            json={"text": "airweave-local-embedder-probe"},
+        )
 
     @patch("airweave.domains.embedders.config.settings")
     @patch("airweave.domains.embedders.config.httpx")

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -40,7 +40,9 @@ services:
       ENABLE_CUDA: 0
       WORKERS_PER_NODE: 1
     healthcheck:
-      test: [ "CMD", "wget", "--spider", "-q", "http://localhost:8080/health" ]
+      # The inference image is reachable via POST /vectors; use Python stdlib
+      # because this image may not include `wget` or `curl`.
+      test: [ "CMD-SHELL", "python -c \"import urllib.request, json; req=urllib.request.Request('http://localhost:8080/vectors', data=json.dumps({'text':'health'}).encode(), headers={'Content-Type':'application/json'}); urllib.request.urlopen(req, timeout=5)\" >/dev/null 2>&1" ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -155,7 +155,9 @@ services:
       ENABLE_CUDA: 0
       WORKERS_PER_NODE: 1
     healthcheck:
-      test: [ "CMD", "wget", "--spider", "-q", "http://localhost:8080/health" ]
+      # The inference image is reachable via POST /vectors; use Python stdlib
+      # because this image may not include `wget` or `curl`.
+      test: [ "CMD-SHELL", "python -c \"import urllib.request, json; req=urllib.request.Request('http://localhost:8080/vectors', data=json.dumps({'text':'health'}).encode(), headers={'Content-Type':'application/json'}); urllib.request.urlopen(req, timeout=5)\" >/dev/null 2>&1" ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
- `semitechnologies/transformers-inference:sentence-transformers-all-*` do not expose `/health` endpoint. We can do a `POST /vectors` request with some data to process (should not be too consuming)
- the image does not include `curl` or `wget` so docker healthcheck uses cpython stdlib:

```shell
$ docker compose --profile local-embeddings exec text2vec-transformers which curl wget python
/usr/local/bin/python
````

Without the patch, the `backend` service is unable to start properly when using local embedder.