### PR TITLE
feat: add pause_reason to Sync + auto-unpause on billing cycle reset

### DIFF
--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -313,6 +313,8 @@ def create_container(settings: Settings) -> Container:
 
     billing_unpause = BillingUnpauseSubscriber(
         sync_state_machine=sync_deps["sync_state_machine"],
+        sync_repo=source_deps["sync_repo"],
+        org_repo=billing_repos["org_repo"],
     )
     for pattern in billing_unpause.EVENT_PATTERNS:
         event_bus.subscribe(pattern, billing_unpause.handle)

--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -1028,6 +1028,7 @@ def _create_sync_services(
         source_registry=source_registry,
         entity_count_repo=entity_count_repo,
         sync_job_repo=sync_job_repo,
+        sync_repo=sync_repo,
         auth_provider_registry=auth_provider_registry,
     )
 

--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -132,6 +132,7 @@ from airweave.domains.syncs.jobs.state_machine import SyncJobStateMachine
 from airweave.domains.syncs.repository import SyncRepository
 from airweave.domains.syncs.service import SyncService
 from airweave.domains.syncs.state_machine import SyncStateMachine
+from airweave.domains.syncs.subscribers.billing_unpause import BillingUnpauseSubscriber
 from airweave.domains.temporal.client import get_cached_client as get_cached_temporal_client
 from airweave.domains.temporal.schedule_service import TemporalScheduleService
 from airweave.domains.temporal.service import TemporalWorkflowService
@@ -308,17 +309,6 @@ def create_container(settings: Settings) -> Container:
         auth_provider_registry=source_deps["auth_provider_registry"],
     )
 
-    # BillingUnpauseSubscriber — unpauses usage-exhausted syncs on new billing period
-    from airweave.domains.syncs.subscribers.billing_unpause import BillingUnpauseSubscriber
-
-    billing_unpause = BillingUnpauseSubscriber(
-        sync_state_machine=sync_deps["sync_state_machine"],
-        sync_repo=source_deps["sync_repo"],
-        org_repo=billing_repos["org_repo"],
-    )
-    for pattern in billing_unpause.EVENT_PATTERNS:
-        event_bus.subscribe(pattern, billing_unpause.handle)
-
     # -----------------------------------------------------------------
     # Shared services (needed by both sync and source_connection domains)
     # Built here, before embedders, to keep deps available below.
@@ -424,6 +414,14 @@ def create_container(settings: Settings) -> Container:
         temporal_schedule_service=sync_deps["temporal_schedule_service"],
         sync_factory=sync_factory,
     )
+
+    # BillingUnpauseSubscriber — unpauses usage-exhausted syncs on new billing period
+    billing_unpause = BillingUnpauseSubscriber(
+        sync_service=sync_service,
+        org_repo=billing_repos["org_repo"],
+    )
+    for pattern in billing_unpause.EVENT_PATTERNS:
+        event_bus.subscribe(pattern, billing_unpause.handle)
 
     # -----------------------------------------------------------------
     # Source connection sub-services (need sync_service)

--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -189,9 +189,9 @@ def create_container(settings: Settings) -> Container:
     endpoint_verifier = HttpEndpointVerifier()
 
     # -----------------------------------------------------------------
-    # Billing services
+    # Billing repos (created early; services created after event_bus)
     # -----------------------------------------------------------------
-    billing_services = _create_billing_services(settings)
+    billing_repos = _create_billing_repos(settings)
 
     # -----------------------------------------------------------------
     # Identity provider (Auth0 / Null)
@@ -213,8 +213,8 @@ def create_container(settings: Settings) -> Container:
     # -----------------------------------------------------------------
     # Usage domain — checker (read) + ledger (write), both singletons
     # -----------------------------------------------------------------
-    usage_checker = _create_usage_checker(settings, billing_services, source_deps, user_org_repo)
-    usage_ledger = _create_usage_ledger(settings, billing_services)
+    usage_checker = _create_usage_checker(settings, billing_repos, source_deps, user_org_repo)
+    usage_ledger = _create_usage_ledger(settings, billing_repos)
     # -----------------------------------------------------------------
     # Webhook service (composes admin + verifier for API layer)
     # -----------------------------------------------------------------
@@ -256,6 +256,11 @@ def create_container(settings: Settings) -> Container:
         usage_ledger=usage_ledger,
         context_cache=context_cache,
     )
+
+    # -----------------------------------------------------------------
+    # Billing services (created after event_bus for event publishing)
+    # -----------------------------------------------------------------
+    billing_services = _create_billing_services(billing_repos, event_bus)
 
     # -----------------------------------------------------------------
     # Organization domain service
@@ -302,6 +307,15 @@ def create_container(settings: Settings) -> Container:
         sync_job_repo=source_deps["sync_job_repo"],
         auth_provider_registry=source_deps["auth_provider_registry"],
     )
+
+    # BillingUnpauseSubscriber — unpauses usage-exhausted syncs on new billing period
+    from airweave.domains.syncs.subscribers.billing_unpause import BillingUnpauseSubscriber
+
+    billing_unpause = BillingUnpauseSubscriber(
+        sync_state_machine=sync_deps["sync_state_machine"],
+    )
+    for pattern in billing_unpause.EVENT_PATTERNS:
+        event_bus.subscribe(pattern, billing_unpause.handle)
 
     # -----------------------------------------------------------------
     # Shared services (needed by both sync and source_connection domains)
@@ -914,55 +928,62 @@ def _create_payment_gateway(settings: Settings) -> PaymentGatewayProtocol:
     return NullPaymentGateway()
 
 
-def _create_billing_services(settings: Settings) -> dict:
-    """Create billing service and webhook processor with shared dependencies."""
-    from airweave.domains.billing.operations import BillingOperations
+def _create_billing_repos(settings: Settings) -> dict:
+    """Create billing repositories and payment gateway (no event_bus needed)."""
     from airweave.domains.billing.repository import (
         BillingPeriodRepository,
         OrganizationBillingRepository,
         WebhookEventRepository,
     )
-    from airweave.domains.billing.service import BillingService
-    from airweave.domains.billing.webhook_processor import BillingWebhookProcessor
     from airweave.domains.organizations.repository import OrganizationRepository
     from airweave.domains.usage.repository import UsageRepository
 
     payment_gateway = _create_payment_gateway(settings)
-    billing_repo = OrganizationBillingRepository()
-    period_repo = BillingPeriodRepository()
-    org_repo = OrganizationRepository()
-    usage_repo = UsageRepository()
+    return {
+        "payment_gateway": payment_gateway,
+        "billing_repo": OrganizationBillingRepository(),
+        "period_repo": BillingPeriodRepository(),
+        "org_repo": OrganizationRepository(),
+        "usage_repo": UsageRepository(),
+        "webhook_event_repo": WebhookEventRepository(),
+    }
+
+
+def _create_billing_services(billing_repos: dict, event_bus: EventBus) -> dict:
+    """Create billing service and webhook processor (requires event_bus)."""
+    from airweave.domains.billing.operations import BillingOperations
+    from airweave.domains.billing.service import BillingService
+    from airweave.domains.billing.webhook_processor import BillingWebhookProcessor
+
     billing_ops = BillingOperations(
-        billing_repo=billing_repo,
-        period_repo=period_repo,
-        usage_repo=usage_repo,
-        payment_gateway=payment_gateway,
+        billing_repo=billing_repos["billing_repo"],
+        period_repo=billing_repos["period_repo"],
+        usage_repo=billing_repos["usage_repo"],
+        payment_gateway=billing_repos["payment_gateway"],
+        event_bus=event_bus,
     )
 
     billing_service = BillingService(
-        payment_gateway=payment_gateway,
-        billing_repo=billing_repo,
-        period_repo=period_repo,
+        payment_gateway=billing_repos["payment_gateway"],
+        billing_repo=billing_repos["billing_repo"],
+        period_repo=billing_repos["period_repo"],
         billing_ops=billing_ops,
-        org_repo=org_repo,
+        org_repo=billing_repos["org_repo"],
     )
-    webhook_event_repo = WebhookEventRepository()
     billing_webhook = BillingWebhookProcessor(
-        payment_gateway=payment_gateway,
-        billing_repo=billing_repo,
-        period_repo=period_repo,
+        payment_gateway=billing_repos["payment_gateway"],
+        billing_repo=billing_repos["billing_repo"],
+        period_repo=billing_repos["period_repo"],
         billing_ops=billing_ops,
-        org_repo=org_repo,
-        webhook_event_repo=webhook_event_repo,
+        org_repo=billing_repos["org_repo"],
+        webhook_event_repo=billing_repos["webhook_event_repo"],
     )
 
     return {
         "billing_service": billing_service,
         "billing_webhook": billing_webhook,
         "billing_ops": billing_ops,
-        "payment_gateway": payment_gateway,
-        "billing_repo": billing_repo,
-        "period_repo": period_repo,
+        **billing_repos,
     }
 
 

--- a/backend/airweave/core/events/__init__.py
+++ b/backend/airweave/core/events/__init__.py
@@ -1,9 +1,11 @@
 """Domain events for the event bus."""
 
 from airweave.core.events.base import DomainEvent
+from airweave.core.events.billing import BillingPeriodCreatedEvent
 from airweave.core.events.collection import CollectionLifecycleEvent
 from airweave.core.events.enums import (
     AccessControlEventType,
+    BillingEventType,
     CollectionEventType,
     EntityEventType,
     EventType,
@@ -30,6 +32,8 @@ from airweave.core.events.sync import (
 __all__ = [
     "AccessControlEventType",
     "AccessControlMembershipBatchProcessedEvent",
+    "BillingEventType",
+    "BillingPeriodCreatedEvent",
     "CollectionEventType",
     "CollectionLifecycleEvent",
     "DomainEvent",

--- a/backend/airweave/core/events/billing.py
+++ b/backend/airweave/core/events/billing.py
@@ -1,0 +1,16 @@
+"""Billing domain events."""
+
+from uuid import UUID
+
+from airweave.core.events.base import DomainEvent
+from airweave.core.events.enums import BillingEventType
+
+
+class BillingPeriodCreatedEvent(DomainEvent):
+    """Emitted when a new billing period is created (renewal, upgrade, initial signup)."""
+
+    event_type: BillingEventType = BillingEventType.PERIOD_CREATED
+    billing_period_id: UUID
+    plan: str
+    status: str
+    transition: str

--- a/backend/airweave/core/events/enums.py
+++ b/backend/airweave/core/events/enums.py
@@ -66,6 +66,12 @@ class OrganizationEventType(str, Enum):
     MEMBER_REMOVED = "organization.member_removed"
 
 
+class BillingEventType(str, Enum):
+    """Billing lifecycle event types."""
+
+    PERIOD_CREATED = "billing.period_created"
+
+
 class SearchEventType(str, Enum):
     """Search event types (all tiers: instant, classic, agentic)."""
 
@@ -84,6 +90,7 @@ EventType = (
     | EntityEventType
     | QueryEventType
     | AccessControlEventType
+    | BillingEventType
     | CollectionEventType
     | SourceConnectionEventType
     | OrganizationEventType
@@ -97,6 +104,7 @@ ALL_EVENT_TYPE_ENUMS: tuple[type[Enum], ...] = (
     EntityEventType,
     QueryEventType,
     AccessControlEventType,
+    BillingEventType,
     CollectionEventType,
     SourceConnectionEventType,
     OrganizationEventType,

--- a/backend/airweave/core/shared_models.py
+++ b/backend/airweave/core/shared_models.py
@@ -55,6 +55,15 @@ class SyncStatus(str, Enum):
     ERROR = "error"
 
 
+class SyncPauseReason(str, Enum):
+    """Why a sync was paused."""
+
+    CREDENTIAL_ERROR = "credential_error"
+    USAGE_EXHAUSTED = "usage_exhausted"
+    PAYMENT_REQUIRED = "payment_required"
+    MANUAL = "manual"
+
+
 class SourceConnectionStatus(str, Enum):
     """Source connection status enum - represents overall connection state."""
 

--- a/backend/airweave/domains/billing/operations.py
+++ b/backend/airweave/domains/billing/operations.py
@@ -13,7 +13,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave import schemas
 from airweave.core.context import BaseContext
+from airweave.core.events.billing import BillingPeriodCreatedEvent
 from airweave.core.logging import logger
+from airweave.core.protocols.event_bus import EventBus
 from airweave.core.protocols.payment import PaymentGatewayProtocol
 from airweave.db.unit_of_work import UnitOfWork
 from airweave.domains.billing.exceptions import BillingStateError
@@ -87,12 +89,14 @@ class BillingOperations(BillingOperationsProtocol):
         period_repo: BillingPeriodRepositoryProtocol,
         usage_repo: UsageRepositoryProtocol,
         payment_gateway: PaymentGatewayProtocol,
+        event_bus: EventBus,
     ) -> None:
         """Initialize with required repository and payment dependencies."""
         self._billing_repo = billing_repo
         self._period_repo = period_repo
         self._usage_repo = usage_repo
         self._payment_gateway = payment_gateway
+        self._event_bus = event_bus
 
     async def create_billing_record(
         self,
@@ -274,5 +278,15 @@ class BillingOperations(BillingOperationsProtocol):
         created_period = await self._period_repo.get(db, id=period_id, ctx=ctx)
         if not created_period:
             raise BillingStateError("Failed to create billing period")
+
+        await self._event_bus.publish(
+            BillingPeriodCreatedEvent(
+                organization_id=organization_id,
+                billing_period_id=period_id,
+                plan=plan.value,
+                status=status.value,
+                transition=transition.value,
+            )
+        )
 
         return schemas.BillingPeriod.model_validate(created_period, from_attributes=True)

--- a/backend/airweave/domains/billing/tests/test_idempotency.py
+++ b/backend/airweave/domains/billing/tests/test_idempotency.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from airweave.adapters.event_bus.fake import FakeEventBus
 from airweave.adapters.payment.fake import FakePaymentGateway, _obj
 from airweave.domains.billing.fakes.operations import FakeBillingOperations
 from airweave.domains.billing.fakes.repository import (
@@ -188,7 +189,8 @@ class TestForwardOverlapDetection:
         pr.seed(old_period)
 
         ops = BillingOperations(
-            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw
+            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw,
+            event_bus=FakeEventBus(),
         )
 
         await ops.create_billing_period(
@@ -226,7 +228,8 @@ class TestForwardOverlapDetection:
         pr.seed(future_period)
 
         ops = BillingOperations(
-            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw
+            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw,
+            event_bus=FakeEventBus(),
         )
 
         await ops.create_billing_period(
@@ -271,7 +274,8 @@ class TestForwardOverlapDetection:
         pr.seed(later)
 
         ops = BillingOperations(
-            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw
+            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw,
+            event_bus=FakeEventBus(),
         )
 
         await ops.create_billing_period(
@@ -309,7 +313,8 @@ class TestForwardOverlapDetection:
         pr.seed(old_completed)
 
         ops = BillingOperations(
-            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw
+            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw,
+            event_bus=FakeEventBus(),
         )
 
         await ops.create_billing_period(
@@ -355,7 +360,8 @@ class TestUoWAtomicity:
         now = datetime.now(timezone.utc)
 
         ops = BillingOperations(
-            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw
+            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw,
+            event_bus=FakeEventBus(),
         )
 
         result = await ops.create_billing_period(
@@ -387,7 +393,8 @@ class TestUoWAtomicity:
         now = datetime.now(timezone.utc)
 
         ops = BillingOperations(
-            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw
+            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw,
+            event_bus=FakeEventBus(),
         )
 
         with pytest.raises(RuntimeError, match="usage insert failed"):
@@ -431,7 +438,8 @@ class TestUoWAtomicity:
         pr.seed(later)
 
         ops = BillingOperations(
-            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw
+            billing_repo=br, period_repo=pr, usage_repo=usage_repo, payment_gateway=gw,
+            event_bus=FakeEventBus(),
         )
 
         result = await ops.create_billing_period(

--- a/backend/airweave/domains/source_connections/response.py
+++ b/backend/airweave/domains/source_connections/response.py
@@ -28,6 +28,7 @@ from airweave.domains.source_connections.protocols import (
 from airweave.domains.source_connections.types import SourceConnectionStats
 from airweave.domains.sources.protocols import SourceRegistryProtocol
 from airweave.domains.syncs.jobs.protocols import SyncJobRepositoryProtocol
+from airweave.domains.syncs.protocols import SyncRepositoryProtocol
 from airweave.models.source_connection import SourceConnection
 from airweave.models.sync_job import SyncJob
 from airweave.schemas.source_connection import (
@@ -84,6 +85,7 @@ class ResponseBuilder(ResponseBuilderProtocol):
         source_registry: SourceRegistryProtocol,
         entity_count_repo: EntityCountRepositoryProtocol,
         sync_job_repo: SyncJobRepositoryProtocol,
+        sync_repo: SyncRepositoryProtocol,
         auth_provider_registry: Optional["AuthProviderRegistryProtocol"] = None,
     ) -> None:
         """Initialize with all dependencies."""
@@ -93,6 +95,7 @@ class ResponseBuilder(ResponseBuilderProtocol):
         self._source_registry = source_registry
         self._entity_count_repo = entity_count_repo
         self._sync_job_repo = sync_job_repo
+        self._sync_repo = sync_repo
         self._auth_provider_registry = auth_provider_registry
 
     # ------------------------------------------------------------------
@@ -111,6 +114,14 @@ class ResponseBuilder(ResponseBuilderProtocol):
     ) -> SourceConnectionSchema:
         """Build complete SourceConnection response from an ORM object."""
         sync_details = await self._build_sync_details(db, source_conn, ctx)
+
+        sync_status = None
+        sync_pause_reason = None
+        if source_conn.sync_id:
+            sync_model = await self._sync_repo.get_without_connections(db, source_conn.sync_id, ctx)
+            if sync_model:
+                sync_status = sync_model.status
+                sync_pause_reason = sync_model.pause_reason
 
         last_job_status = None
         last_job_error_category = None
@@ -150,6 +161,8 @@ class ResponseBuilder(ResponseBuilderProtocol):
             schedule=schedule,
             sync=sync_details,
             sync_id=source_conn.sync_id,
+            sync_status=sync_status,
+            sync_pause_reason=sync_pause_reason,
             entities=entities,
             error_category=last_job_error_category,
             error_message=_GENERIC_ERROR_MESSAGES.get(last_job_error_category, None)

--- a/backend/airweave/domains/source_connections/tests/test_response.py
+++ b/backend/airweave/domains/source_connections/tests/test_response.py
@@ -28,6 +28,7 @@ from airweave.domains.source_connections.response import ResponseBuilder
 from airweave.domains.source_connections.types import LastJobInfo, SourceConnectionStats
 from airweave.domains.sources.fakes.registry import FakeSourceRegistry
 from airweave.domains.sources.types import SourceRegistryEntry
+from airweave.domains.syncs.fakes.repository import FakeSyncRepository
 from airweave.domains.syncs.jobs.fakes.repository import FakeSyncJobRepository
 from airweave.platform.configs._base import Fields
 from airweave.schemas.entity_count import EntityCountWithDefinition
@@ -209,6 +210,7 @@ class BuilderFixture:
         self.source_registry = FakeSourceRegistry()
         self.entity_count_repo = FakeEntityCountRepository()
         self.sync_job_repo = FakeSyncJobRepository()
+        self.sync_repo = FakeSyncRepository()
         self.builder = ResponseBuilder(
             sc_repo=self.sc_repo,
             connection_repo=self.connection_repo,
@@ -216,6 +218,7 @@ class BuilderFixture:
             source_registry=self.source_registry,
             entity_count_repo=self.entity_count_repo,
             sync_job_repo=self.sync_job_repo,
+            sync_repo=self.sync_repo,
         )
 
 
@@ -1486,6 +1489,7 @@ async def test_resolve_provider_info_no_readable_id():
         source_registry=FakeSourceRegistry(),
         entity_count_repo=FakeEntityCountRepository(),
         sync_job_repo=FakeSyncJobRepository(),
+        sync_repo=FakeSyncRepository(),
         auth_provider_registry=registry,
     )
     sc = _make_source_conn(readable_auth_provider_id=None)
@@ -1515,6 +1519,7 @@ async def test_resolve_provider_info_returns_url_and_short_name():
         source_registry=FakeSourceRegistry(),
         entity_count_repo=FakeEntityCountRepository(),
         sync_job_repo=FakeSyncJobRepository(),
+        sync_repo=FakeSyncRepository(),
         auth_provider_registry=registry,
     )
     sc = _make_source_conn(readable_auth_provider_id="my-composio")
@@ -1544,6 +1549,7 @@ async def test_resolve_provider_info_exception_returns_empty():
         source_registry=FakeSourceRegistry(),
         entity_count_repo=FakeEntityCountRepository(),
         sync_job_repo=FakeSyncJobRepository(),
+        sync_repo=FakeSyncRepository(),
         auth_provider_registry=registry,
     )
     sc = _make_source_conn(readable_auth_provider_id="my-composio")

--- a/backend/airweave/domains/sync_pipeline/orchestrator.py
+++ b/backend/airweave/domains/sync_pipeline/orchestrator.py
@@ -11,9 +11,10 @@ from airweave.core.events.sync import (
     AccessControlMembershipBatchProcessedEvent,
 )
 from airweave.core.protocols.event_bus import EventBus
-from airweave.core.shared_models import SyncJobStatus, SyncStatus
+from airweave.core.shared_models import SyncJobStatus, SyncPauseReason, SyncStatus
 from airweave.db.session import get_db_context
 from airweave.domains.access_control.pipeline import AccessControlPipeline
+from airweave.domains.sources.exceptions import SourceAuthError
 from airweave.domains.sources.exceptions.classifier import classify_error
 from airweave.domains.sync_pipeline.contexts import SyncContext
 from airweave.domains.sync_pipeline.contexts.runtime import SyncRuntime
@@ -676,17 +677,20 @@ class SyncOrchestrator:
             error_category=classification.category,
         )
 
-        if classification.category is not None:
+        # Pause sync for errors that won't resolve without user action
+        pause_reason = self._get_pause_reason(error)
+        if pause_reason is not None:
             try:
                 await self._sync_state_machine.transition(
                     sync_id=self.sync_context.sync.id,
                     target=SyncStatus.PAUSED,
                     ctx=self.sync_context,
-                    reason=f"Credential error: {classification.category.value}",
+                    reason=f"{pause_reason.value}: {error_message}",
+                    pause_reason=pause_reason,
                 )
             except Exception as pause_err:
                 self.sync_context.logger.warning(
-                    f"Failed to pause sync after credential error: {pause_err}",
+                    f"Failed to pause sync: {pause_err}",
                     exc_info=True,
                 )
 
@@ -709,6 +713,17 @@ class SyncOrchestrator:
             error=error_message,
             duration_ms=duration_ms,
         )
+
+    @staticmethod
+    def _get_pause_reason(error: Exception) -> SyncPauseReason | None:
+        """Determine if an error warrants pausing the sync."""
+        if isinstance(error, SourceAuthError):
+            return SyncPauseReason.CREDENTIAL_ERROR
+        if isinstance(error, UsageLimitExceededError):
+            return SyncPauseReason.USAGE_EXHAUSTED
+        if isinstance(error, PaymentRequiredError):
+            return SyncPauseReason.PAYMENT_REQUIRED
+        return None
 
     async def _handle_cancellation(self) -> None:
         """Centralized cancellation handler - explicit and immediate."""

--- a/backend/airweave/domains/sync_pipeline/orchestrator.py
+++ b/backend/airweave/domains/sync_pipeline/orchestrator.py
@@ -659,9 +659,19 @@ class SyncOrchestrator:
     async def _handle_sync_failure(self, error: Exception) -> None:
         """Handle sync failure by updating job status with error details."""
         error_message = get_error_message(error)
-        self.sync_context.logger.error(
-            f"Sync job {self.sync_context.sync_job.id} failed: {error_message}", exc_info=True
-        )
+        pause_reason = self._get_pause_reason(error)
+
+        # Expected graceful exits (usage exhausted, payment required, credential error)
+        # are pauses, not unexpected errors — log at warning without tracebacks.
+        if pause_reason is not None:
+            self.sync_context.logger.warning(
+                f"Sync job {self.sync_context.sync_job.id} paused "
+                f"({pause_reason.value}): {error_message}"
+            )
+        else:
+            self.sync_context.logger.error(
+                f"Sync job {self.sync_context.sync_job.id} failed: {error_message}", exc_info=True
+            )
 
         classification = classify_error(error)
 
@@ -678,7 +688,6 @@ class SyncOrchestrator:
         )
 
         # Pause sync for errors that won't resolve without user action
-        pause_reason = self._get_pause_reason(error)
         if pause_reason is not None:
             try:
                 await self._sync_state_machine.transition(

--- a/backend/airweave/domains/sync_pipeline/orchestrator.py
+++ b/backend/airweave/domains/sync_pipeline/orchestrator.py
@@ -14,7 +14,7 @@ from airweave.core.protocols.event_bus import EventBus
 from airweave.core.shared_models import SyncJobStatus, SyncPauseReason, SyncStatus
 from airweave.db.session import get_db_context
 from airweave.domains.access_control.pipeline import AccessControlPipeline
-from airweave.domains.sources.exceptions import SourceAuthError
+from airweave.domains.source_connections.types import ErrorClassification
 from airweave.domains.sources.exceptions.classifier import classify_error
 from airweave.domains.sync_pipeline.contexts import SyncContext
 from airweave.domains.sync_pipeline.contexts.runtime import SyncRuntime
@@ -659,7 +659,8 @@ class SyncOrchestrator:
     async def _handle_sync_failure(self, error: Exception) -> None:
         """Handle sync failure by updating job status with error details."""
         error_message = get_error_message(error)
-        pause_reason = self._get_pause_reason(error)
+        classification = classify_error(error)
+        pause_reason = self._get_pause_reason(error, classification)
 
         # Expected graceful exits (usage exhausted, payment required, credential error)
         # are pauses, not unexpected errors — log at warning without tracebacks.
@@ -672,8 +673,6 @@ class SyncOrchestrator:
             self.sync_context.logger.error(
                 f"Sync job {self.sync_context.sync_job.id} failed: {error_message}", exc_info=True
             )
-
-        classification = classify_error(error)
 
         stats = self.runtime.entity_tracker.get_stats()
 
@@ -724,14 +723,17 @@ class SyncOrchestrator:
         )
 
     @staticmethod
-    def _get_pause_reason(error: Exception) -> SyncPauseReason | None:
+    def _get_pause_reason(
+        error: Exception,
+        classification: ErrorClassification,
+    ) -> SyncPauseReason | None:
         """Determine if an error warrants pausing the sync."""
-        if isinstance(error, SourceAuthError):
-            return SyncPauseReason.CREDENTIAL_ERROR
         if isinstance(error, UsageLimitExceededError):
             return SyncPauseReason.USAGE_EXHAUSTED
         if isinstance(error, PaymentRequiredError):
             return SyncPauseReason.PAYMENT_REQUIRED
+        if classification.category is not None:
+            return SyncPauseReason.CREDENTIAL_ERROR
         return None
 
     async def _handle_cancellation(self) -> None:

--- a/backend/airweave/domains/sync_pipeline/orchestrator.py
+++ b/backend/airweave/domains/sync_pipeline/orchestrator.py
@@ -660,19 +660,6 @@ class SyncOrchestrator:
         """Handle sync failure by updating job status with error details."""
         error_message = get_error_message(error)
         classification = classify_error(error)
-        pause_reason = self._get_pause_reason(error, classification)
-
-        # Expected graceful exits (usage exhausted, payment required, credential error)
-        # are pauses, not unexpected errors — log at warning without tracebacks.
-        if pause_reason is not None:
-            self.sync_context.logger.warning(
-                f"Sync job {self.sync_context.sync_job.id} paused "
-                f"({pause_reason.value}): {error_message}"
-            )
-        else:
-            self.sync_context.logger.error(
-                f"Sync job {self.sync_context.sync_job.id} failed: {error_message}", exc_info=True
-            )
 
         stats = self.runtime.entity_tracker.get_stats()
 
@@ -686,21 +673,17 @@ class SyncOrchestrator:
             error_category=classification.category,
         )
 
-        # Pause sync for errors that won't resolve without user action
+        pause_reason = self._get_pause_reason(error, classification)
         if pause_reason is not None:
-            try:
-                await self._sync_state_machine.transition(
-                    sync_id=self.sync_context.sync.id,
-                    target=SyncStatus.PAUSED,
-                    ctx=self.sync_context,
-                    reason=f"{pause_reason.value}: {error_message}",
-                    pause_reason=pause_reason,
-                )
-            except Exception as pause_err:
-                self.sync_context.logger.warning(
-                    f"Failed to pause sync: {pause_err}",
-                    exc_info=True,
-                )
+            self.sync_context.logger.warning(
+                f"Sync {self.sync_context.sync.id} will pause "
+                f"({pause_reason.value}): {error_message}"
+            )
+            await self._pause_sync(pause_reason, error_message)
+        else:
+            self.sync_context.logger.error(
+                f"Sync job {self.sync_context.sync_job.id} failed: {error_message}", exc_info=True
+            )
 
         # Calculate duration from start to failure
         if not self.sync_context.sync_job.started_at:
@@ -735,6 +718,19 @@ class SyncOrchestrator:
         if classification.category is not None:
             return SyncPauseReason.CREDENTIAL_ERROR
         return None
+
+    async def _pause_sync(self, reason: SyncPauseReason, error_message: str) -> None:
+        """Pause the sync for errors that won't resolve without user action."""
+        try:
+            await self._sync_state_machine.transition(
+                sync_id=self.sync_context.sync.id,
+                target=SyncStatus.PAUSED,
+                ctx=self.sync_context,
+                reason=f"{reason.value}: {error_message}",
+                pause_reason=reason,
+            )
+        except Exception as err:
+            self.sync_context.logger.warning(f"Failed to pause sync: {err}", exc_info=True)
 
     async def _handle_cancellation(self) -> None:
         """Centralized cancellation handler - explicit and immediate."""

--- a/backend/airweave/domains/syncs/fakes/repository.py
+++ b/backend/airweave/domains/syncs/fakes/repository.py
@@ -1,6 +1,6 @@
 """Fake sync repository for testing."""
 
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -67,6 +67,22 @@ class FakeSyncRepository:
         model = self._models.get(sync_id)
         if model is not None:
             model.status = target
+
+    async def get_paused_by_reason(
+        self,
+        db: AsyncSession,
+        organization_id: UUID,
+        pause_reason: str,
+    ) -> List[Sync]:
+        """Return models matching pause_reason filter."""
+        self._calls.append(("get_paused_by_reason", db, organization_id, pause_reason))
+        return [
+            m
+            for m in self._models.values()
+            if m.organization_id == organization_id
+            and getattr(m, "status", None) == SyncStatus.PAUSED
+            and getattr(m, "pause_reason", None) == pause_reason
+        ]
 
     async def create(
         self,

--- a/backend/airweave/domains/syncs/fakes/state_machine.py
+++ b/backend/airweave/domains/syncs/fakes/state_machine.py
@@ -3,7 +3,7 @@
 from uuid import UUID
 
 from airweave.core.context import BaseContext
-from airweave.core.shared_models import SyncStatus
+from airweave.core.shared_models import SyncPauseReason, SyncStatus
 from airweave.domains.syncs.protocols import SyncStateMachineProtocol
 from airweave.domains.syncs.types import SyncTransitionResult
 
@@ -32,9 +32,10 @@ class FakeSyncStateMachine(SyncStateMachineProtocol):
         ctx: BaseContext,
         *,
         reason: str = "",
+        pause_reason: SyncPauseReason | None = None,
     ) -> SyncTransitionResult:
         """Record call and return canned result."""
-        self._calls.append(("transition", sync_id, target, ctx, reason))
+        self._calls.append(("transition", sync_id, target, ctx, reason, pause_reason))
         if self._should_raise:
             raise self._should_raise
         if self._result is not None:

--- a/backend/airweave/domains/syncs/protocols.py
+++ b/backend/airweave/domains/syncs/protocols.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from airweave import schemas
 from airweave.api.context import ApiContext
 from airweave.core.context import BaseContext
-from airweave.core.shared_models import SyncStatus
+from airweave.core.shared_models import SyncPauseReason, SyncStatus
 from airweave.db.unit_of_work import UnitOfWork
 from airweave.domains.sources.types import SourceRegistryEntry
 from airweave.domains.sync_pipeline.config import SyncConfig
@@ -89,6 +89,7 @@ class SyncStateMachineProtocol(Protocol):
         ctx: BaseContext,
         *,
         reason: str = "",
+        pause_reason: SyncPauseReason | None = None,
     ) -> SyncTransitionResult:
         """Execute a validated, idempotent sync status transition.
 

--- a/backend/airweave/domains/syncs/protocols.py
+++ b/backend/airweave/domains/syncs/protocols.py
@@ -68,6 +68,15 @@ class SyncRepositoryProtocol(Protocol):
         """Update an existing sync."""
         ...
 
+    async def get_paused_by_reason(
+        self,
+        db: AsyncSession,
+        organization_id: UUID,
+        pause_reason: str,
+    ) -> List[Sync]:
+        """Get all paused syncs for an org with a specific pause_reason."""
+        ...
+
 
 class SyncCursorRepositoryProtocol(Protocol):
     """Data access for sync cursor records."""

--- a/backend/airweave/domains/syncs/protocols.py
+++ b/backend/airweave/domains/syncs/protocols.py
@@ -146,6 +146,7 @@ class SyncServiceProtocol(Protocol):
         ctx: BaseContext,
         *,
         reason: str = "",
+        pause_reason: SyncPauseReason | None = None,
     ) -> SyncTransitionResult:
         """Pause a sync."""
         ...
@@ -158,6 +159,15 @@ class SyncServiceProtocol(Protocol):
         reason: str = "",
     ) -> SyncTransitionResult:
         """Resume a paused sync."""
+        ...
+
+    async def list_paused_by_reason(
+        self,
+        organization_id: UUID,
+        pause_reason: SyncPauseReason,
+        ctx: BaseContext,
+    ) -> List[schemas.Sync]:
+        """List paused syncs for an org filtered by pause_reason."""
         ...
 
     async def delete(

--- a/backend/airweave/domains/syncs/repository.py
+++ b/backend/airweave/domains/syncs/repository.py
@@ -1,9 +1,9 @@
 """Sync repository wrapping crud.sync."""
 
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
-from sqlalchemy import update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave import crud, schemas
@@ -45,6 +45,22 @@ class SyncRepository(SyncRepositoryProtocol):
         )
         if cursor.rowcount == 0:  # type: ignore[attr-defined]
             raise OptimisticLockError(sync_id, expected)
+
+    async def get_paused_by_reason(
+        self,
+        db: AsyncSession,
+        organization_id: UUID,
+        pause_reason: str,
+    ) -> List[Sync]:
+        """Get all paused syncs for an org with a specific pause_reason."""
+        result = await db.execute(
+            select(Sync).where(
+                Sync.organization_id == organization_id,
+                Sync.status == SyncStatus.PAUSED,
+                Sync.pause_reason == pause_reason,
+            )
+        )
+        return list(result.scalars().all())
 
     async def create(
         self,

--- a/backend/airweave/domains/syncs/service.py
+++ b/backend/airweave/domains/syncs/service.py
@@ -424,7 +424,7 @@ class SyncService(SyncServiceProtocol):
                         sync_id=sync.id,
                         target=SyncStatus.PAUSED,
                         ctx=ctx,
-                        reason=f"Credential error: {classification.category.value}",
+                        reason=f"{SyncPauseReason.CREDENTIAL_ERROR.value}: {classification.category.value}",
                         pause_reason=SyncPauseReason.CREDENTIAL_ERROR,
                     )
                 except Exception:

--- a/backend/airweave/domains/syncs/service.py
+++ b/backend/airweave/domains/syncs/service.py
@@ -22,7 +22,7 @@ from airweave import schemas
 from airweave.api.context import ApiContext
 from airweave.core.constants.reserved_ids import NATIVE_VESPA_UUID
 from airweave.core.context import BaseContext
-from airweave.core.shared_models import SyncJobStatus, SyncStatus
+from airweave.core.shared_models import SyncJobStatus, SyncPauseReason, SyncStatus
 from airweave.db.session import get_db_context
 from airweave.db.unit_of_work import UnitOfWork
 from airweave.domains.sources.exceptions.classifier import classify_error
@@ -407,6 +407,7 @@ class SyncService(SyncServiceProtocol):
                         target=SyncStatus.PAUSED,
                         ctx=ctx,
                         reason=f"Credential error: {classification.category.value}",
+                        pause_reason=SyncPauseReason.CREDENTIAL_ERROR,
                     )
                 except Exception:
                     ctx.logger.warning("Failed to pause sync after credential error", exc_info=True)

--- a/backend/airweave/domains/syncs/service.py
+++ b/backend/airweave/domains/syncs/service.py
@@ -161,10 +161,15 @@ class SyncService(SyncServiceProtocol):
         ctx: BaseContext,
         *,
         reason: str = "",
+        pause_reason: SyncPauseReason | None = None,
     ) -> SyncTransitionResult:
         """Pause a sync: update DB status, pause Temporal schedules."""
         return await self._state_machine.transition(
-            sync_id=sync_id, target=SyncStatus.PAUSED, ctx=ctx, reason=reason
+            sync_id=sync_id,
+            target=SyncStatus.PAUSED,
+            ctx=ctx,
+            reason=reason,
+            pause_reason=pause_reason,
         )
 
     async def resume(
@@ -178,6 +183,19 @@ class SyncService(SyncServiceProtocol):
         return await self._state_machine.transition(
             sync_id=sync_id, target=SyncStatus.ACTIVE, ctx=ctx, reason=reason
         )
+
+    async def list_paused_by_reason(
+        self,
+        organization_id: UUID,
+        pause_reason: SyncPauseReason,
+        ctx: BaseContext,
+    ) -> List[schemas.Sync]:
+        """List paused syncs for an org filtered by pause_reason."""
+        async with get_db_context() as db:
+            models = await self._sync_repo.get_paused_by_reason(
+                db, organization_id=organization_id, pause_reason=pause_reason.value
+            )
+            return [schemas.Sync.model_validate(m, from_attributes=True) for m in models]
 
     async def delete(
         self,

--- a/backend/airweave/domains/syncs/state_machine.py
+++ b/backend/airweave/domains/syncs/state_machine.py
@@ -16,7 +16,7 @@ from temporalio.service import RPCError
 
 from airweave.core.context import BaseContext
 from airweave.core.logging import logger
-from airweave.core.shared_models import SyncStatus
+from airweave.core.shared_models import SyncPauseReason, SyncStatus
 from airweave.db.session import get_db_context
 from airweave.domains.syncs.protocols import SyncRepositoryProtocol, SyncStateMachineProtocol
 from airweave.domains.syncs.types import (
@@ -67,6 +67,7 @@ class SyncStateMachine(SyncStateMachineProtocol):
         ctx: BaseContext,
         *,
         reason: str = "",
+        pause_reason: SyncPauseReason | None = None,
     ) -> SyncTransitionResult:
         """Execute a validated, idempotent sync status transition.
 
@@ -88,6 +89,10 @@ class SyncStateMachine(SyncStateMachineProtocol):
             self._validate_transition(current, target, sync_id)
 
             await self.sync_repo.transition_status(db, sync_id, current, target)
+            if target == SyncStatus.PAUSED:
+                sync_obj.pause_reason = pause_reason.value if pause_reason else None
+            elif target == SyncStatus.ACTIVE:
+                sync_obj.pause_reason = None
             await db.commit()
 
         logger.info(f"Sync {sync_id}: {current.value} → {target.value}")

--- a/backend/airweave/domains/syncs/subscribers/billing_unpause.py
+++ b/backend/airweave/domains/syncs/subscribers/billing_unpause.py
@@ -1,33 +1,31 @@
 """Unpause usage-exhausted syncs when a new billing period is created."""
 
-from typing import List
+from typing import ClassVar, Tuple
 
 from airweave.core.context import SystemContext
 from airweave.core.events.base import DomainEvent
 from airweave.core.events.billing import BillingPeriodCreatedEvent
 from airweave.core.logging import logger
 from airweave.core.protocols.event_bus import EventSubscriber
-from airweave.core.shared_models import SyncPauseReason, SyncStatus
+from airweave.core.shared_models import SyncPauseReason
 from airweave.db.session import get_db_context
 from airweave.domains.organizations.protocols import OrganizationRepositoryProtocol
-from airweave.domains.syncs.protocols import SyncRepositoryProtocol, SyncStateMachineProtocol
+from airweave.domains.syncs.protocols import SyncServiceProtocol
 from airweave.schemas.billing_period import BillingPeriodStatus
 
 
 class BillingUnpauseSubscriber(EventSubscriber):
     """Unpause usage-exhausted syncs when a new active billing period is created."""
 
-    EVENT_PATTERNS: List[str] = ["billing.period_created"]
+    EVENT_PATTERNS: ClassVar[Tuple[str, ...]] = ("billing.period_created",)
 
     def __init__(
         self,
-        sync_state_machine: SyncStateMachineProtocol,
-        sync_repo: SyncRepositoryProtocol,
+        sync_service: SyncServiceProtocol,
         org_repo: OrganizationRepositoryProtocol,
     ) -> None:
-        """Initialize with sync and org dependencies."""
-        self._sync_state_machine = sync_state_machine
-        self._sync_repo = sync_repo
+        """Initialize with sync service and org repo."""
+        self._sync_service = sync_service
         self._org_repo = org_repo
 
     async def handle(self, event: DomainEvent) -> None:
@@ -42,27 +40,26 @@ class BillingUnpauseSubscriber(EventSubscriber):
             org_schema = await self._org_repo.get(
                 db, id=event.organization_id, skip_access_validation=True
             )
-            if not org_schema:
-                logger.warning(f"Org {event.organization_id} not found for billing unpause")
-                return
-
-            paused_syncs = await self._sync_repo.get_paused_by_reason(
-                db,
-                organization_id=event.organization_id,
-                pause_reason=SyncPauseReason.USAGE_EXHAUSTED.value,
-            )
-
-        if not paused_syncs:
+        if not org_schema:
+            logger.warning(f"Org {event.organization_id} not found for billing unpause")
             return
 
         ctx = SystemContext(org_schema)
 
+        paused_syncs = await self._sync_service.list_paused_by_reason(
+            organization_id=event.organization_id,
+            pause_reason=SyncPauseReason.USAGE_EXHAUSTED,
+            ctx=ctx,
+        )
+
+        if not paused_syncs:
+            return
+
         for sync in paused_syncs:
             try:
-                await self._sync_state_machine.transition(
-                    sync_id=sync.id,
-                    target=SyncStatus.ACTIVE,
-                    ctx=ctx,
+                await self._sync_service.resume(
+                    sync.id,
+                    ctx,
                     reason="Unpaused: new billing period",
                 )
                 logger.info(f"Unpaused sync {sync.id} after billing period reset")

--- a/backend/airweave/domains/syncs/subscribers/billing_unpause.py
+++ b/backend/airweave/domains/syncs/subscribers/billing_unpause.py
@@ -1,0 +1,72 @@
+"""Unpause usage-exhausted syncs when a new billing period is created."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+from sqlalchemy import select
+
+from airweave import schemas
+from airweave.core.context import SystemContext
+from airweave.core.events.base import DomainEvent
+from airweave.core.events.billing import BillingPeriodCreatedEvent
+from airweave.core.logging import logger
+from airweave.core.shared_models import SyncPauseReason, SyncStatus
+from airweave.db.session import get_db_context
+from airweave.models.organization import Organization
+from airweave.models.sync import Sync
+from airweave.schemas.billing_period import BillingPeriodStatus
+
+if TYPE_CHECKING:
+    from airweave.core.protocols.event_bus import EventSubscriber
+    from airweave.domains.syncs.protocols import SyncStateMachineProtocol
+
+
+class BillingUnpauseSubscriber:
+    """Unpause usage-exhausted syncs when a new active billing period is created."""
+
+    EVENT_PATTERNS: List[str] = ["billing.period_created"]
+
+    def __init__(self, sync_state_machine: SyncStateMachineProtocol) -> None:
+        self._sync_state_machine = sync_state_machine
+
+    async def handle(self, event: DomainEvent) -> None:
+        if not isinstance(event, BillingPeriodCreatedEvent):
+            return
+
+        if event.status != BillingPeriodStatus.ACTIVE.value:
+            return
+
+        async with get_db_context() as db:
+            # Fetch org for SystemContext
+            org = await db.get(Organization, event.organization_id)
+            if not org:
+                logger.warning(f"Org {event.organization_id} not found for billing unpause")
+                return
+            org_schema = schemas.Organization.model_validate(org, from_attributes=True)
+
+            # Find paused syncs with usage_exhausted reason
+            stmt = select(Sync).where(
+                Sync.organization_id == event.organization_id,
+                Sync.status == SyncStatus.PAUSED.value,
+                Sync.pause_reason == SyncPauseReason.USAGE_EXHAUSTED.value,
+            )
+            result = await db.execute(stmt)
+            paused_syncs = result.scalars().all()
+
+        if not paused_syncs:
+            return
+
+        ctx = SystemContext(org_schema)
+
+        for sync in paused_syncs:
+            try:
+                await self._sync_state_machine.transition(
+                    sync_id=sync.id,
+                    target=SyncStatus.ACTIVE,
+                    ctx=ctx,
+                    reason="Unpaused: new billing period",
+                )
+                logger.info(f"Unpaused sync {sync.id} after billing period reset")
+            except Exception as e:
+                logger.warning(f"Failed to unpause sync {sync.id}: {e}")

--- a/backend/airweave/domains/syncs/subscribers/billing_unpause.py
+++ b/backend/airweave/domains/syncs/subscribers/billing_unpause.py
@@ -1,8 +1,6 @@
 """Unpause usage-exhausted syncs when a new billing period is created."""
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, List
+from typing import List
 
 from sqlalchemy import select
 
@@ -13,13 +11,10 @@ from airweave.core.events.billing import BillingPeriodCreatedEvent
 from airweave.core.logging import logger
 from airweave.core.shared_models import SyncPauseReason, SyncStatus
 from airweave.db.session import get_db_context
+from airweave.domains.syncs.protocols import SyncStateMachineProtocol
 from airweave.models.organization import Organization
 from airweave.models.sync import Sync
 from airweave.schemas.billing_period import BillingPeriodStatus
-
-if TYPE_CHECKING:
-    from airweave.core.protocols.event_bus import EventSubscriber
-    from airweave.domains.syncs.protocols import SyncStateMachineProtocol
 
 
 class BillingUnpauseSubscriber:

--- a/backend/airweave/domains/syncs/subscribers/billing_unpause.py
+++ b/backend/airweave/domains/syncs/subscribers/billing_unpause.py
@@ -2,18 +2,14 @@
 
 from typing import List
 
-from sqlalchemy import select
-
-from airweave import schemas
 from airweave.core.context import SystemContext
 from airweave.core.events.base import DomainEvent
 from airweave.core.events.billing import BillingPeriodCreatedEvent
 from airweave.core.logging import logger
 from airweave.core.shared_models import SyncPauseReason, SyncStatus
 from airweave.db.session import get_db_context
-from airweave.domains.syncs.protocols import SyncStateMachineProtocol
-from airweave.models.organization import Organization
-from airweave.models.sync import Sync
+from airweave.domains.organizations.protocols import OrganizationRepositoryProtocol
+from airweave.domains.syncs.protocols import SyncRepositoryProtocol, SyncStateMachineProtocol
 from airweave.schemas.billing_period import BillingPeriodStatus
 
 
@@ -22,10 +18,19 @@ class BillingUnpauseSubscriber:
 
     EVENT_PATTERNS: List[str] = ["billing.period_created"]
 
-    def __init__(self, sync_state_machine: SyncStateMachineProtocol) -> None:
+    def __init__(
+        self,
+        sync_state_machine: SyncStateMachineProtocol,
+        sync_repo: SyncRepositoryProtocol,
+        org_repo: OrganizationRepositoryProtocol,
+    ) -> None:
+        """Initialize with sync and org dependencies."""
         self._sync_state_machine = sync_state_machine
+        self._sync_repo = sync_repo
+        self._org_repo = org_repo
 
     async def handle(self, event: DomainEvent) -> None:
+        """Handle billing period created events by unpausing usage-exhausted syncs."""
         if not isinstance(event, BillingPeriodCreatedEvent):
             return
 
@@ -33,21 +38,18 @@ class BillingUnpauseSubscriber:
             return
 
         async with get_db_context() as db:
-            # Fetch org for SystemContext
-            org = await db.get(Organization, event.organization_id)
-            if not org:
+            org_schema = await self._org_repo.get(
+                db, id=event.organization_id, skip_access_validation=True
+            )
+            if not org_schema:
                 logger.warning(f"Org {event.organization_id} not found for billing unpause")
                 return
-            org_schema = schemas.Organization.model_validate(org, from_attributes=True)
 
-            # Find paused syncs with usage_exhausted reason
-            stmt = select(Sync).where(
-                Sync.organization_id == event.organization_id,
-                Sync.status == SyncStatus.PAUSED.value,
-                Sync.pause_reason == SyncPauseReason.USAGE_EXHAUSTED.value,
+            paused_syncs = await self._sync_repo.get_paused_by_reason(
+                db,
+                organization_id=event.organization_id,
+                pause_reason=SyncPauseReason.USAGE_EXHAUSTED.value,
             )
-            result = await db.execute(stmt)
-            paused_syncs = result.scalars().all()
 
         if not paused_syncs:
             return

--- a/backend/airweave/domains/syncs/subscribers/billing_unpause.py
+++ b/backend/airweave/domains/syncs/subscribers/billing_unpause.py
@@ -6,6 +6,7 @@ from airweave.core.context import SystemContext
 from airweave.core.events.base import DomainEvent
 from airweave.core.events.billing import BillingPeriodCreatedEvent
 from airweave.core.logging import logger
+from airweave.core.protocols.event_bus import EventSubscriber
 from airweave.core.shared_models import SyncPauseReason, SyncStatus
 from airweave.db.session import get_db_context
 from airweave.domains.organizations.protocols import OrganizationRepositoryProtocol
@@ -13,7 +14,7 @@ from airweave.domains.syncs.protocols import SyncRepositoryProtocol, SyncStateMa
 from airweave.schemas.billing_period import BillingPeriodStatus
 
 
-class BillingUnpauseSubscriber:
+class BillingUnpauseSubscriber(EventSubscriber):
     """Unpause usage-exhausted syncs when a new active billing period is created."""
 
     EVENT_PATTERNS: List[str] = ["billing.period_created"]

--- a/backend/airweave/domains/syncs/subscribers/tests/test_billing_unpause.py
+++ b/backend/airweave/domains/syncs/subscribers/tests/test_billing_unpause.py
@@ -1,7 +1,6 @@
 """Tests for BillingUnpauseSubscriber."""
 
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -33,38 +32,41 @@ def _make_sync(pause_reason: str, sync_id=None):
     return s
 
 
+def _make_subscriber(
+    paused_syncs=None,
+    org_schema=None,
+):
+    sync_state_machine = AsyncMock()
+    sync_repo = AsyncMock()
+    sync_repo.get_paused_by_reason = AsyncMock(return_value=paused_syncs or [])
+    org_repo = AsyncMock()
+    org_repo.get = AsyncMock(return_value=org_schema or MagicMock())
+
+    subscriber = BillingUnpauseSubscriber(
+        sync_state_machine=sync_state_machine,
+        sync_repo=sync_repo,
+        org_repo=org_repo,
+    )
+    return subscriber, sync_state_machine, sync_repo, org_repo
+
+
 @pytest.mark.asyncio
-async def test_unpauses_usage_exhausted_syncs_only():
-    """Only syncs paused for USAGE_EXHAUSTED are unpaused."""
+async def test_unpauses_usage_exhausted_syncs():
+    """Usage-exhausted syncs are unpaused."""
     usage_sync_1 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
     usage_sync_2 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
-    cred_sync = _make_sync(SyncPauseReason.CREDENTIAL_ERROR.value)
 
-    sync_state_machine = AsyncMock()
-    subscriber = BillingUnpauseSubscriber(sync_state_machine=sync_state_machine)
+    subscriber, sync_state_machine, sync_repo, _ = _make_subscriber(
+        paused_syncs=[usage_sync_1, usage_sync_2],
+    )
 
-    mock_org = MagicMock()
-    mock_org.id = ORG_ID
+    await subscriber.handle(_make_event())
 
-    mock_db = AsyncMock()
-    mock_db.get = AsyncMock(return_value=mock_org)
-
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = [usage_sync_1, usage_sync_2]
-    mock_db.execute = AsyncMock(return_value=mock_result)
-
-    with (
-        patch(
-            "airweave.domains.syncs.subscribers.billing_unpause.get_db_context"
-        ) as mock_ctx,
-        patch("airweave.domains.syncs.subscribers.billing_unpause.schemas") as mock_schemas,
-    ):
-        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_db)
-        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
-        mock_schemas.Organization.model_validate.return_value = MagicMock()
-
-        await subscriber.handle(_make_event())
-
+    sync_repo.get_paused_by_reason.assert_awaited_once_with(
+        sync_repo.get_paused_by_reason.call_args[0][0],  # db session
+        organization_id=ORG_ID,
+        pause_reason=SyncPauseReason.USAGE_EXHAUSTED.value,
+    )
     assert sync_state_machine.transition.await_count == 2
     transitioned_ids = {
         call.kwargs["sync_id"] for call in sync_state_machine.transition.call_args_list
@@ -75,38 +77,20 @@ async def test_unpauses_usage_exhausted_syncs_only():
 @pytest.mark.asyncio
 async def test_grace_period_does_not_unpause():
     """Events with GRACE status do not trigger unpause."""
-    sync_state_machine = AsyncMock()
-    subscriber = BillingUnpauseSubscriber(sync_state_machine=sync_state_machine)
+    subscriber, sync_state_machine, sync_repo, _ = _make_subscriber()
 
     await subscriber.handle(_make_event(status=BillingPeriodStatus.GRACE.value))
 
+    sync_repo.get_paused_by_reason.assert_not_awaited()
     sync_state_machine.transition.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_no_paused_syncs_is_noop():
     """No paused syncs means no transitions attempted."""
-    sync_state_machine = AsyncMock()
-    subscriber = BillingUnpauseSubscriber(sync_state_machine=sync_state_machine)
+    subscriber, sync_state_machine, _, _ = _make_subscriber(paused_syncs=[])
 
-    mock_org = MagicMock()
-    mock_db = AsyncMock()
-    mock_db.get = AsyncMock(return_value=mock_org)
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = []
-    mock_db.execute = AsyncMock(return_value=mock_result)
-
-    with (
-        patch(
-            "airweave.domains.syncs.subscribers.billing_unpause.get_db_context"
-        ) as mock_ctx,
-        patch("airweave.domains.syncs.subscribers.billing_unpause.schemas") as mock_schemas,
-    ):
-        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_db)
-        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
-        mock_schemas.Organization.model_validate.return_value = MagicMock()
-
-        await subscriber.handle(_make_event())
+    await subscriber.handle(_make_event())
 
     sync_state_machine.transition.assert_not_awaited()
 
@@ -117,30 +101,26 @@ async def test_unpause_failure_is_nonfatal():
     sync_1 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
     sync_2 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
 
-    sync_state_machine = AsyncMock()
+    subscriber, sync_state_machine, _, _ = _make_subscriber(
+        paused_syncs=[sync_1, sync_2],
+    )
     sync_state_machine.transition.side_effect = [
         Exception("temporal down"),
-        AsyncMock(),  # second call succeeds
+        AsyncMock(),
     ]
-    subscriber = BillingUnpauseSubscriber(sync_state_machine=sync_state_machine)
 
-    mock_org = MagicMock()
-    mock_db = AsyncMock()
-    mock_db.get = AsyncMock(return_value=mock_org)
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = [sync_1, sync_2]
-    mock_db.execute = AsyncMock(return_value=mock_result)
-
-    with (
-        patch(
-            "airweave.domains.syncs.subscribers.billing_unpause.get_db_context"
-        ) as mock_ctx,
-        patch("airweave.domains.syncs.subscribers.billing_unpause.schemas") as mock_schemas,
-    ):
-        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_db)
-        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
-        mock_schemas.Organization.model_validate.return_value = MagicMock()
-
-        await subscriber.handle(_make_event())
+    await subscriber.handle(_make_event())
 
     assert sync_state_machine.transition.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_org_not_found_returns_early():
+    """If org not found, no syncs are queried or unpaused."""
+    subscriber, sync_state_machine, sync_repo, org_repo = _make_subscriber()
+    org_repo.get = AsyncMock(return_value=None)
+
+    await subscriber.handle(_make_event())
+
+    sync_repo.get_paused_by_reason.assert_not_awaited()
+    sync_state_machine.transition.assert_not_awaited()

--- a/backend/airweave/domains/syncs/subscribers/tests/test_billing_unpause.py
+++ b/backend/airweave/domains/syncs/subscribers/tests/test_billing_unpause.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import pytest
 
 from airweave.core.events.billing import BillingPeriodCreatedEvent
-from airweave.core.shared_models import SyncPauseReason, SyncStatus
+from airweave.core.shared_models import SyncPauseReason
 from airweave.domains.syncs.subscribers.billing_unpause import BillingUnpauseSubscriber
 from airweave.schemas.billing_period import BillingPeriodStatus
 
@@ -24,103 +24,88 @@ def _make_event(status: str = BillingPeriodStatus.ACTIVE.value) -> BillingPeriod
     )
 
 
-def _make_sync(pause_reason: str, sync_id=None):
+def _make_sync(sync_id=None):
     s = MagicMock()
     s.id = sync_id or uuid4()
-    s.status = SyncStatus.PAUSED.value
-    s.pause_reason = pause_reason
     return s
 
 
-def _make_subscriber(
-    paused_syncs=None,
-    org_schema=None,
-):
-    sync_state_machine = AsyncMock()
-    sync_repo = AsyncMock()
-    sync_repo.get_paused_by_reason = AsyncMock(return_value=paused_syncs or [])
+def _make_subscriber(paused_syncs=None, org_schema=None):
+    sync_service = AsyncMock()
+    sync_service.list_paused_by_reason = AsyncMock(return_value=paused_syncs or [])
+    sync_service.resume = AsyncMock()
     org_repo = AsyncMock()
     org_repo.get = AsyncMock(return_value=org_schema or MagicMock())
 
     subscriber = BillingUnpauseSubscriber(
-        sync_state_machine=sync_state_machine,
-        sync_repo=sync_repo,
+        sync_service=sync_service,
         org_repo=org_repo,
     )
-    return subscriber, sync_state_machine, sync_repo, org_repo
+    return subscriber, sync_service, org_repo
 
 
 @pytest.mark.asyncio
 async def test_unpauses_usage_exhausted_syncs():
-    """Usage-exhausted syncs are unpaused."""
-    usage_sync_1 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
-    usage_sync_2 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
+    """Usage-exhausted syncs are unpaused via sync_service.resume."""
+    sync_1 = _make_sync()
+    sync_2 = _make_sync()
 
-    subscriber, sync_state_machine, sync_repo, _ = _make_subscriber(
-        paused_syncs=[usage_sync_1, usage_sync_2],
-    )
+    subscriber, sync_service, _ = _make_subscriber(paused_syncs=[sync_1, sync_2])
 
     await subscriber.handle(_make_event())
 
-    sync_repo.get_paused_by_reason.assert_awaited_once_with(
-        sync_repo.get_paused_by_reason.call_args[0][0],  # db session
-        organization_id=ORG_ID,
-        pause_reason=SyncPauseReason.USAGE_EXHAUSTED.value,
-    )
-    assert sync_state_machine.transition.await_count == 2
-    transitioned_ids = {
-        call.kwargs["sync_id"] for call in sync_state_machine.transition.call_args_list
-    }
-    assert transitioned_ids == {usage_sync_1.id, usage_sync_2.id}
+    sync_service.list_paused_by_reason.assert_awaited_once()
+    call_kwargs = sync_service.list_paused_by_reason.await_args.kwargs
+    assert call_kwargs["organization_id"] == ORG_ID
+    assert call_kwargs["pause_reason"] == SyncPauseReason.USAGE_EXHAUSTED
+
+    assert sync_service.resume.await_count == 2
+    resumed_ids = {call.args[0] for call in sync_service.resume.call_args_list}
+    assert resumed_ids == {sync_1.id, sync_2.id}
 
 
 @pytest.mark.asyncio
 async def test_grace_period_does_not_unpause():
     """Events with GRACE status do not trigger unpause."""
-    subscriber, sync_state_machine, sync_repo, _ = _make_subscriber()
+    subscriber, sync_service, _ = _make_subscriber()
 
     await subscriber.handle(_make_event(status=BillingPeriodStatus.GRACE.value))
 
-    sync_repo.get_paused_by_reason.assert_not_awaited()
-    sync_state_machine.transition.assert_not_awaited()
+    sync_service.list_paused_by_reason.assert_not_awaited()
+    sync_service.resume.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_no_paused_syncs_is_noop():
-    """No paused syncs means no transitions attempted."""
-    subscriber, sync_state_machine, _, _ = _make_subscriber(paused_syncs=[])
+    """No paused syncs means no resume attempts."""
+    subscriber, sync_service, _ = _make_subscriber(paused_syncs=[])
 
     await subscriber.handle(_make_event())
 
-    sync_state_machine.transition.assert_not_awaited()
+    sync_service.resume.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_unpause_failure_is_nonfatal():
-    """If one sync fails to unpause, the others still get processed."""
-    sync_1 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
-    sync_2 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
+    """If one sync fails to resume, the others still get processed."""
+    sync_1 = _make_sync()
+    sync_2 = _make_sync()
 
-    subscriber, sync_state_machine, _, _ = _make_subscriber(
-        paused_syncs=[sync_1, sync_2],
-    )
-    sync_state_machine.transition.side_effect = [
-        Exception("temporal down"),
-        AsyncMock(),
-    ]
+    subscriber, sync_service, _ = _make_subscriber(paused_syncs=[sync_1, sync_2])
+    sync_service.resume.side_effect = [Exception("temporal down"), None]
 
     await subscriber.handle(_make_event())
 
-    assert sync_state_machine.transition.await_count == 2
+    assert sync_service.resume.await_count == 2
 
 
 @pytest.mark.asyncio
 async def test_org_not_found_returns_early():
-    """If org not found, no syncs are queried or unpaused."""
-    subscriber, sync_state_machine, sync_repo, org_repo = _make_subscriber()
+    """If org not found, no syncs are queried or resumed."""
+    subscriber, sync_service, org_repo = _make_subscriber()
     org_repo.get = AsyncMock(return_value=None)
 
     await subscriber.handle(_make_event())
 
-    sync_repo.get_paused_by_reason.assert_not_awaited()
-    sync_state_machine.transition.assert_not_awaited()
+    sync_service.list_paused_by_reason.assert_not_awaited()
+    sync_service.resume.assert_not_awaited()

--- a/backend/airweave/domains/syncs/subscribers/tests/test_billing_unpause.py
+++ b/backend/airweave/domains/syncs/subscribers/tests/test_billing_unpause.py
@@ -1,0 +1,146 @@
+"""Tests for BillingUnpauseSubscriber."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from airweave.core.events.billing import BillingPeriodCreatedEvent
+from airweave.core.shared_models import SyncPauseReason, SyncStatus
+from airweave.domains.syncs.subscribers.billing_unpause import BillingUnpauseSubscriber
+from airweave.schemas.billing_period import BillingPeriodStatus
+
+
+ORG_ID = uuid4()
+
+
+def _make_event(status: str = BillingPeriodStatus.ACTIVE.value) -> BillingPeriodCreatedEvent:
+    return BillingPeriodCreatedEvent(
+        organization_id=ORG_ID,
+        billing_period_id=uuid4(),
+        plan="pro",
+        status=status,
+        transition="renewal",
+    )
+
+
+def _make_sync(pause_reason: str, sync_id=None):
+    s = MagicMock()
+    s.id = sync_id or uuid4()
+    s.status = SyncStatus.PAUSED.value
+    s.pause_reason = pause_reason
+    return s
+
+
+@pytest.mark.asyncio
+async def test_unpauses_usage_exhausted_syncs_only():
+    """Only syncs paused for USAGE_EXHAUSTED are unpaused."""
+    usage_sync_1 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
+    usage_sync_2 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
+    cred_sync = _make_sync(SyncPauseReason.CREDENTIAL_ERROR.value)
+
+    sync_state_machine = AsyncMock()
+    subscriber = BillingUnpauseSubscriber(sync_state_machine=sync_state_machine)
+
+    mock_org = MagicMock()
+    mock_org.id = ORG_ID
+
+    mock_db = AsyncMock()
+    mock_db.get = AsyncMock(return_value=mock_org)
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [usage_sync_1, usage_sync_2]
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    with (
+        patch(
+            "airweave.domains.syncs.subscribers.billing_unpause.get_db_context"
+        ) as mock_ctx,
+        patch("airweave.domains.syncs.subscribers.billing_unpause.schemas") as mock_schemas,
+    ):
+        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_schemas.Organization.model_validate.return_value = MagicMock()
+
+        await subscriber.handle(_make_event())
+
+    assert sync_state_machine.transition.await_count == 2
+    transitioned_ids = {
+        call.kwargs["sync_id"] for call in sync_state_machine.transition.call_args_list
+    }
+    assert transitioned_ids == {usage_sync_1.id, usage_sync_2.id}
+
+
+@pytest.mark.asyncio
+async def test_grace_period_does_not_unpause():
+    """Events with GRACE status do not trigger unpause."""
+    sync_state_machine = AsyncMock()
+    subscriber = BillingUnpauseSubscriber(sync_state_machine=sync_state_machine)
+
+    await subscriber.handle(_make_event(status=BillingPeriodStatus.GRACE.value))
+
+    sync_state_machine.transition.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_paused_syncs_is_noop():
+    """No paused syncs means no transitions attempted."""
+    sync_state_machine = AsyncMock()
+    subscriber = BillingUnpauseSubscriber(sync_state_machine=sync_state_machine)
+
+    mock_org = MagicMock()
+    mock_db = AsyncMock()
+    mock_db.get = AsyncMock(return_value=mock_org)
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    with (
+        patch(
+            "airweave.domains.syncs.subscribers.billing_unpause.get_db_context"
+        ) as mock_ctx,
+        patch("airweave.domains.syncs.subscribers.billing_unpause.schemas") as mock_schemas,
+    ):
+        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_schemas.Organization.model_validate.return_value = MagicMock()
+
+        await subscriber.handle(_make_event())
+
+    sync_state_machine.transition.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unpause_failure_is_nonfatal():
+    """If one sync fails to unpause, the others still get processed."""
+    sync_1 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
+    sync_2 = _make_sync(SyncPauseReason.USAGE_EXHAUSTED.value)
+
+    sync_state_machine = AsyncMock()
+    sync_state_machine.transition.side_effect = [
+        Exception("temporal down"),
+        AsyncMock(),  # second call succeeds
+    ]
+    subscriber = BillingUnpauseSubscriber(sync_state_machine=sync_state_machine)
+
+    mock_org = MagicMock()
+    mock_db = AsyncMock()
+    mock_db.get = AsyncMock(return_value=mock_org)
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [sync_1, sync_2]
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    with (
+        patch(
+            "airweave.domains.syncs.subscribers.billing_unpause.get_db_context"
+        ) as mock_ctx,
+        patch("airweave.domains.syncs.subscribers.billing_unpause.schemas") as mock_schemas,
+    ):
+        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_schemas.Organization.model_validate.return_value = MagicMock()
+
+        await subscriber.handle(_make_event())
+
+    assert sync_state_machine.transition.await_count == 2

--- a/backend/airweave/domains/syncs/tests/test_state_machine.py
+++ b/backend/airweave/domains/syncs/tests/test_state_machine.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import pytest
 from temporalio.service import RPCError
 
-from airweave.core.shared_models import SyncStatus
+from airweave.core.shared_models import SyncPauseReason, SyncStatus
 from airweave.domains.syncs.state_machine import SyncStateMachine
 from airweave.domains.syncs.types import (
     InvalidSyncTransitionError,
@@ -400,6 +400,81 @@ async def test_transition_optimistic_lock_failure():
     assert exc_info.value.sync_id == SYNC_ID
     assert exc_info.value.expected == SyncStatus.ACTIVE
     mock_db.commit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# pause_reason persistence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pause_sets_pause_reason():
+    """Transitioning to PAUSED with pause_reason persists it on the sync object."""
+    sync_repo = AsyncMock()
+    sync_obj = _make_sync_obj(SyncStatus.ACTIVE)
+    sync_repo.get_without_connections = AsyncMock(return_value=sync_obj)
+
+    sm = _build_sm(sync_repo=sync_repo)
+
+    mock_db = AsyncMock()
+    with patch(
+        "airweave.domains.syncs.state_machine.get_db_context"
+    ) as mock_ctx:
+        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await sm.transition(
+            SYNC_ID,
+            SyncStatus.PAUSED,
+            _make_ctx(),
+            reason="usage limit",
+            pause_reason=SyncPauseReason.USAGE_EXHAUSTED,
+        )
+
+    assert sync_obj.pause_reason == SyncPauseReason.USAGE_EXHAUSTED.value
+
+
+@pytest.mark.asyncio
+async def test_unpause_clears_pause_reason():
+    """Transitioning to ACTIVE clears pause_reason."""
+    sync_repo = AsyncMock()
+    sync_obj = _make_sync_obj(SyncStatus.PAUSED)
+    sync_obj.pause_reason = SyncPauseReason.USAGE_EXHAUSTED.value
+    sync_repo.get_without_connections = AsyncMock(return_value=sync_obj)
+
+    sm = _build_sm(sync_repo=sync_repo)
+
+    mock_db = AsyncMock()
+    with patch(
+        "airweave.domains.syncs.state_machine.get_db_context"
+    ) as mock_ctx:
+        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await sm.transition(SYNC_ID, SyncStatus.ACTIVE, _make_ctx())
+
+    assert sync_obj.pause_reason is None
+
+
+@pytest.mark.asyncio
+async def test_pause_without_reason_sets_none():
+    """Transitioning to PAUSED without pause_reason sets None (backwards compat)."""
+    sync_repo = AsyncMock()
+    sync_obj = _make_sync_obj(SyncStatus.ACTIVE)
+    sync_repo.get_without_connections = AsyncMock(return_value=sync_obj)
+
+    sm = _build_sm(sync_repo=sync_repo)
+
+    mock_db = AsyncMock()
+    with patch(
+        "airweave.domains.syncs.state_machine.get_db_context"
+    ) as mock_ctx:
+        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await sm.transition(SYNC_ID, SyncStatus.PAUSED, _make_ctx(), reason="manual")
+
+    assert sync_obj.pause_reason is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/airweave/models/sync.py
+++ b/backend/airweave/models/sync.py
@@ -38,6 +38,7 @@ class Sync(OrganizationBase, UserMixin):
     )
     temporal_schedule_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     sync_type: Mapped[str] = mapped_column(String(50), default="full")
+    pause_reason: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     sync_metadata: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
     sync_config: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
 

--- a/backend/airweave/schemas/source_connection.py
+++ b/backend/airweave/schemas/source_connection.py
@@ -685,6 +685,14 @@ class SourceConnection(BaseModel):
         description="ID of the associated sync (internal use)",
         json_schema_extra={"example": "660e8400-e29b-41d4-a716-446655440001"},
     )
+    sync_status: Optional[str] = Field(
+        None,
+        description="Status of the associated sync (active, paused, inactive, error)",
+    )
+    sync_pause_reason: Optional[str] = Field(
+        None,
+        description="Why the sync is paused (usage_exhausted, payment_required, credential_error, manual)",
+    )
 
     # Entity information
     entities: Optional[EntitySummary] = Field(

--- a/backend/airweave/schemas/sync.py
+++ b/backend/airweave/schemas/sync.py
@@ -26,6 +26,7 @@ class SyncBase(BaseModel):
     sync_metadata: Optional[dict] = None
     sync_config: Optional[SyncConfig] = None
     status: Optional[SyncStatus] = SyncStatus.ACTIVE
+    pause_reason: Optional[str] = None
 
     @field_validator("cron_schedule")
     def validate_cron_schedule(cls, v: str) -> str:
@@ -151,6 +152,7 @@ class SyncWithoutConnections(BaseModel):
     cron_schedule: Optional[str] = None
     next_scheduled_run: Optional[datetime] = None
     status: SyncStatus
+    pause_reason: Optional[str] = None
     sync_metadata: Optional[dict] = None
     sync_config: Optional[SyncConfig] = None
     temporal_schedule_id: Optional[str] = None

--- a/backend/alembic/versions/0001_add_pause_reason_to_sync.py
+++ b/backend/alembic/versions/0001_add_pause_reason_to_sync.py
@@ -1,6 +1,6 @@
 """Add pause_reason column to sync table.
 
-Revision ID: b2c3d4e5f6g7
+Revision ID: 0001
 Revises: 0000
 Create Date: 2026-03-26
 """
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = "b2c3d4e5f6g7"
+revision = "0001"
 down_revision = "0000"
 branch_labels = None
 depends_on = None

--- a/backend/alembic/versions/b2c3d4e5f6g7_add_pause_reason_to_sync.py
+++ b/backend/alembic/versions/b2c3d4e5f6g7_add_pause_reason_to_sync.py
@@ -1,0 +1,24 @@
+"""Add pause_reason column to sync table.
+
+Revision ID: b2c3d4e5f6g7
+Revises: 0000
+Create Date: 2026-03-26
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b2c3d4e5f6g7"
+down_revision = "0000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("sync", sa.Column("pause_reason", sa.String(64), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("sync", "pause_reason")

--- a/backend/tests/e2e/smoke/test_schedule_pause_unpause.py
+++ b/backend/tests/e2e/smoke/test_schedule_pause_unpause.py
@@ -63,6 +63,13 @@ class TestSchedulePauseUnpause:
             return None
         return detail.get("schedule", {}).get("state", {}).get("paused", False)
 
+    async def _get_schedule_pause_note(self, schedule_id: str) -> Optional[str]:
+        """Return the pause note from a Temporal schedule, or None if not found."""
+        detail = await self._get_schedule_detail(schedule_id)
+        if detail is None:
+            return None
+        return detail.get("schedule", {}).get("state", {}).get("notes", "")
+
     async def _get_paused_states(self, sync_id: str) -> Dict[str, Optional[bool]]:
         """Return {prefix: paused_bool} for all schedule prefixes."""
         states = {}
@@ -180,6 +187,13 @@ class TestSchedulePauseUnpause:
         # Verify schedule is now paused
         assert await self._is_schedule_paused(primary_schedule) is True, (
             "Schedule should be paused after credential error"
+        )
+
+        # Verify the pause note contains the credential error reason
+        note = await self._get_schedule_pause_note(primary_schedule)
+        assert note is not None
+        assert "credential_error" in note.lower(), (
+            f"Pause note should contain credential_error reason, got: {note}"
         )
 
         # Cleanup

--- a/frontend/src/components/collection/BillingPauseCard.tsx
+++ b/frontend/src/components/collection/BillingPauseCard.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { AlertCircle, CreditCard, ArrowRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/lib/theme-provider';
+import { DESIGN_SYSTEM } from '@/lib/design-system';
+
+interface BillingPauseCardProps {
+  pauseReason: 'usage_exhausted' | 'payment_required';
+}
+
+const REASON_CONFIG: Record<string, {
+  icon: React.ElementType;
+  title: string;
+  description: string;
+  ctaLabel: string;
+  ctaUrl: string;
+}> = {
+  usage_exhausted: {
+    icon: AlertCircle,
+    title: 'Usage Limit Reached',
+    description: 'Syncing is paused because your plan\'s usage limit has been reached. It will resume automatically when your billing period resets, or you can upgrade now.',
+    ctaLabel: 'Upgrade Plan',
+    ctaUrl: '/organization/settings?tab=billing',
+  },
+  payment_required: {
+    icon: CreditCard,
+    title: 'Payment Required',
+    description: 'Syncing is paused due to a billing issue. Please update your payment method to resume.',
+    ctaLabel: 'Update Billing',
+    ctaUrl: '/organization/settings?tab=billing',
+  },
+};
+
+export const BillingPauseCard: React.FC<BillingPauseCardProps> = ({ pauseReason }) => {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+  const config = REASON_CONFIG[pauseReason];
+
+  if (!config) return null;
+
+  const Icon = config.icon;
+
+  return (
+    <div className={cn(
+      'rounded-xl border p-5 space-y-4',
+      isDark ? 'border-amber-800/30 bg-amber-900/10' : 'border-amber-200 bg-amber-50',
+    )}>
+      <div className="flex items-start gap-3">
+        <div className={cn(
+          'flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center',
+          isDark ? 'bg-gray-800/60' : 'bg-white shadow-sm',
+        )}>
+          <Icon className={cn('h-5 w-5', isDark ? 'text-amber-400' : 'text-amber-600')} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className={cn(
+            DESIGN_SYSTEM.typography.sizes.header,
+            DESIGN_SYSTEM.typography.weights.semibold,
+            'mb-1',
+            isDark ? 'text-gray-100' : 'text-gray-900',
+          )}>
+            {config.title}
+          </h3>
+          <p className={cn(
+            DESIGN_SYSTEM.typography.sizes.body,
+            isDark ? 'text-gray-400' : 'text-gray-600',
+          )}>
+            {config.description}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 pt-1">
+        <a
+          href={config.ctaUrl}
+          className={cn(
+            'inline-flex items-center gap-2 px-4 py-2 rounded-lg shadow-sm',
+            DESIGN_SYSTEM.typography.sizes.body,
+            DESIGN_SYSTEM.typography.weights.medium,
+            'transition-all duration-200',
+            'bg-primary text-primary-foreground hover:bg-primary/90',
+          )}
+        >
+          {config.ctaLabel}
+          <ArrowRight className="h-3.5 w-3.5" />
+        </a>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/collection/SourceConnectionStateView.tsx
+++ b/frontend/src/components/collection/SourceConnectionStateView.tsx
@@ -12,6 +12,7 @@ import { apiClient } from '@/lib/api';
 import { toast } from '@/hooks/use-toast';
 import { SourceConnectionSettings } from './SourceConnectionSettings';
 import { EntityStateList } from './EntityStateList';
+import { BillingPauseCard } from './BillingPauseCard';
 import { SyncErrorCard } from './SyncErrorCard';
 import { CredentialErrorView } from './CredentialErrorView';
 import { SourceAuthenticationView } from '@/components/shared/SourceAuthenticationView';
@@ -569,6 +570,13 @@ const SourceConnectionStateView: React.FC<Props> = ({
     if (currentSyncJob?.status === 'cancelled') return { text: 'Cancelled', color: 'bg-gray-500', icon: null };
     if (isRunning) return { text: 'Syncing', color: 'bg-blue-500 animate-pulse', icon: 'loader' };
     if (isPending) return { text: 'Pending', color: 'bg-yellow-500 animate-pulse', icon: 'loader' };
+    if (sourceConnection?.sync_status === 'paused') {
+      const reason = sourceConnection?.sync_pause_reason;
+      if (reason === 'usage_exhausted') return { text: 'Paused — Usage Limit', color: 'bg-amber-500', icon: null };
+      if (reason === 'payment_required') return { text: 'Paused — Payment Required', color: 'bg-amber-500', icon: null };
+      if (reason === 'credential_error') return { text: 'Paused — Auth Error', color: 'bg-amber-500', icon: null };
+      return { text: 'Paused', color: 'bg-amber-500', icon: null };
+    }
     return { text: 'Ready', color: 'bg-gray-400', icon: null };
   };
 
@@ -867,6 +875,12 @@ const SourceConnectionStateView: React.FC<Props> = ({
               error={sourceConnection?.sync?.last_job?.error || currentSyncJob?.error || "The last sync failed. Check the logs for more details."}
               isDark={isDark}
             />
+          )}
+
+          {/* Show billing pause card for usage/payment issues */}
+          {!isFederatedSource && sourceConnection?.sync_pause_reason &&
+           (sourceConnection.sync_pause_reason === 'usage_exhausted' || sourceConnection.sync_pause_reason === 'payment_required') && (
+            <BillingPauseCard pauseReason={sourceConnection.sync_pause_reason} />
           )}
 
           {/* Federated Search Info Card - Only show for federated sources */}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -119,6 +119,8 @@ export interface SourceConnection {
   // Sync details
   sync?: Record<string, any>;
   sync_id?: string;
+  sync_status?: string;
+  sync_pause_reason?: 'credential_error' | 'usage_exhausted' | 'payment_required' | 'manual' | null;
   organization_id?: string;
   connection_id?: string;
   created_by_email?: string;


### PR DESCRIPTION
## Summary

Builds on #1714 (SyncStateMachine). Adds `pause_reason` to the Sync model so we know *why* a sync was paused, and auto-unpauses usage-exhausted syncs when a new billing period is created.

- Add `SyncPauseReason` enum (`credential_error`, `usage_exhausted`, `payment_required`, `manual`) and `pause_reason` column to `sync` table
- Wire `pause_reason` through `SyncStateMachine.transition()` — persisted on PAUSED, cleared on ACTIVE
- Orchestrator pauses syncs on `SourceAuthError`, `UsageLimitExceededError`, `PaymentRequiredError` with appropriate reason
- New `BillingPeriodCreatedEvent` domain event, published from `BillingOperations.create_billing_period()`
- New `BillingUnpauseSubscriber` listens for `billing.period_created` and unpauses all `USAGE_EXHAUSTED` syncs for the org
- Split factory billing setup to resolve circular dependency (repos early, services after event_bus)


Introduces new UI for these scenarios.
<img width="746" height="280" alt="Screenshot 2026-04-17 at 05 23 05" src="https://github.com/user-attachments/assets/93fff8c6-a46e-458a-a396-2edc52756c26" />
<img width="710" height="287" alt="Screenshot 2026-04-17 at 05 23 57" src="https://github.com/user-attachments/assets/a073dc72-e5ae-434c-acf8-567976ce3d0c" />
