### PR TITLE
feat(sharepoint): client credentials auth + ACL-filtered search

### DIFF
--- a/backend/airweave/api/v1/endpoints/search.py
+++ b/backend/airweave/api/v1/endpoints/search.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 from collections.abc import AsyncGenerator
 
-from fastapi import Depends, Path
+from fastapi import Depends, Path, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import StreamingResponse
 
@@ -349,3 +349,97 @@ async def admin_stream_agentic_search(
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
+
+
+@admin_router.post(
+    "/{readable_id}/search/instant/as-user",
+    response_model=SearchV2Response,
+    summary="Instant Search as User (Admin)",
+    description=(
+        "Admin-only: Instant search with access control applied for a specific user principal."
+    ),
+)
+async def admin_instant_search_as_user(
+    readable_id: str = Path(...),
+    request: InstantSearchRequest = ...,  # type: ignore[assignment]
+    user_principal: str = Query(
+        ...,
+        description="User principal (email) to search as. "
+        "Access control filtering will use this user's resolved group memberships.",
+    ),
+    db: AsyncSession = Depends(deps.get_db),
+    ctx: ApiContext = Depends(deps.get_context),
+    usage_checker: UsageLimitCheckerProtocol = Inject(UsageLimitCheckerProtocol),
+    service: InstantSearchServiceProtocol = Inject(InstantSearchServiceProtocol),
+) -> SearchV2Response:
+    """Admin-only: instant search with ACL filtering for a specific user."""
+    _require_admin(ctx)
+    await usage_checker.is_allowed(db, ctx.organization.id, ActionType.QUERIES)
+
+    results = await service.search(
+        db, ctx, readable_id, request, user_principal_override=user_principal
+    )
+    return SearchV2Response(results=results.results)
+
+
+@admin_router.post(
+    "/{readable_id}/search/classic/as-user",
+    response_model=SearchV2Response,
+    summary="Classic Search as User (Admin)",
+    description=(
+        "Admin-only: Classic search with access control applied for a specific user principal."
+    ),
+)
+async def admin_classic_search_as_user(
+    readable_id: str = Path(...),
+    request: ClassicSearchRequest = ...,  # type: ignore[assignment]
+    user_principal: str = Query(
+        ...,
+        description="User principal (email) to search as. "
+        "Access control filtering will use this user's resolved group memberships.",
+    ),
+    db: AsyncSession = Depends(deps.get_db),
+    ctx: ApiContext = Depends(deps.get_context),
+    usage_checker: UsageLimitCheckerProtocol = Inject(UsageLimitCheckerProtocol),
+    service: ClassicSearchServiceProtocol = Inject(ClassicSearchServiceProtocol),
+) -> SearchV2Response:
+    """Admin-only: classic search with ACL filtering for a specific user."""
+    _require_admin(ctx)
+    await usage_checker.is_allowed(db, ctx.organization.id, ActionType.QUERIES)
+
+    results = await service.search(
+        db, ctx, readable_id, request, user_principal_override=user_principal
+    )
+    return SearchV2Response(results=results.results)
+
+
+@admin_router.post(
+    "/{readable_id}/search/agentic/as-user",
+    response_model=SearchV2Response,
+    summary="Agentic Search as User (Admin)",
+    description=(
+        "Admin-only: Agentic search with access control applied for a specific user principal."
+    ),
+)
+async def admin_agentic_search_as_user(
+    readable_id: str = Path(...),
+    request: AgenticSearchRequest = ...,  # type: ignore[assignment]
+    user_principal: str = Query(
+        ...,
+        description="User principal (email) to search as. "
+        "Access control filtering will use this user's resolved group memberships.",
+    ),
+    db: AsyncSession = Depends(deps.get_db),
+    ctx: ApiContext = Depends(deps.get_context),
+    usage_checker: UsageLimitCheckerProtocol = Inject(UsageLimitCheckerProtocol),
+    service: AgenticSearchServiceProtocol = Inject(AgenticSearchServiceProtocol),
+) -> SearchV2Response:
+    """Admin-only: agentic search with ACL filtering for a specific user."""
+    _require_admin(ctx)
+    await usage_checker.is_allowed(db, ctx.organization.id, ActionType.TOKENS)
+
+    results = await service.search(
+        db, ctx, readable_id, request, user_principal_override=user_principal
+    )
+    truncated = results.results[: request.limit] if request.limit else results.results
+    return SearchV2Response(results=truncated)

--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -470,6 +470,7 @@ def create_container(settings: Settings) -> Container:
         entity_definition_registry=source_deps["entity_definition_registry"],
         event_bus=event_bus,
         source_lifecycle=source_deps["source_lifecycle_service"],
+        access_broker=access_broker,
     )
 
     # -----------------------------------------------------------------
@@ -1270,6 +1271,7 @@ def _create_search_services(
     entity_definition_registry: "EntityDefinitionRegistry",
     event_bus: "EventBus",
     source_lifecycle: "SourceLifecycleService",
+    access_broker: "AccessBroker",
 ) -> dict:
     """Create search domain services (LLM, tokenizer, reranker, metadata builder, per-tier).
 
@@ -1337,6 +1339,7 @@ def _create_search_services(
         sc_repo=sc_repo,
         source_registry=source_registry,
         source_lifecycle=source_lifecycle,
+        access_broker=access_broker,
     )
 
     # 6. Per-tier services

--- a/backend/airweave/domains/oauth/callback_service.py
+++ b/backend/airweave/domains/oauth/callback_service.py
@@ -205,6 +205,7 @@ class OAuthCallbackService:
         await self._validate_oauth2_token_or_raise(
             source_entry=source_entry,
             access_token=token_response.access_token,
+            config=source_conn_shell.config_fields,
             ctx=ctx,
         )
 
@@ -590,6 +591,7 @@ class OAuthCallbackService:
         *,
         source_entry: SourceRegistryEntry | None,
         access_token: str,
+        config: dict | None = None,
         ctx: ApiContext,
     ) -> None:
         """Validate OAuth2 token using source lifecycle service; fail callback if invalid."""
@@ -600,6 +602,7 @@ class OAuthCallbackService:
             await self._source_lifecycle.validate(
                 short_name=source_entry.short_name,
                 credentials=access_token,
+                config=config,
             )
         except (SourceNotFoundError, SourceError) as e:
             raise http_exception_for_credential_validation(

--- a/backend/airweave/domains/oauth/oauth2_service.py
+++ b/backend/airweave/domains/oauth/oauth2_service.py
@@ -453,6 +453,82 @@ class OAuth2Service(OAuth2ServiceProtocol):
             expires_in=response.expires_in,
         )
 
+    async def exchange_token_for_scope(
+        self,
+        db: AsyncSession,
+        integration_short_name: str,
+        connection_id: UUID,
+        ctx: ApiContext,
+        scope: str,
+    ) -> str:
+        """Exchange refresh token for an access token with a different scope.
+
+        Uses the existing refresh token but requests a different resource scope
+        (e.g., SharePoint REST API scope instead of Graph scope).
+        Does NOT persist the rotated refresh token.
+
+        Returns the access token string for the requested scope.
+        """
+        connection = await self.conn_repo.get(db=db, id=connection_id, ctx=ctx)
+        if not connection or not connection.integration_credential_id:
+            raise OAuthRefreshCredentialMissingError(
+                f"Connection {connection_id} not found or has no credential",
+                integration_short_name=integration_short_name,
+            )
+
+        credential = await self.cred_repo.get(
+            db=db, id=connection.integration_credential_id, ctx=ctx
+        )
+        if not credential:
+            raise OAuthRefreshCredentialMissingError(
+                "Integration credential not found",
+                integration_short_name=integration_short_name,
+            )
+
+        decrypted = self.encryptor.decrypt(credential.encrypted_credentials)
+        refresh_token = await self._get_refresh_token(ctx.logger, decrypted)
+
+        integration_config = await self._get_integration_config(ctx.logger, integration_short_name)
+
+        client_id, client_secret = await self._get_client_credentials(
+            integration_config, None, decrypted
+        )
+
+        # Build request with explicit scope (unlike normal refresh which skips scope)
+        headers = {"Content-Type": integration_config.content_type}
+        payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "scope": scope,
+        }
+
+        if integration_config.client_credential_location == "header":
+            encoded = self._encode_client_credentials(client_id, client_secret)
+            headers["Authorization"] = f"Basic {encoded}"
+        else:
+            payload["client_id"] = client_id
+            payload["client_secret"] = client_secret
+
+        ctx.logger.info(
+            f"Exchanging token for scope {scope} (integration={integration_short_name})"
+        )
+
+        response = await self._make_token_request(
+            ctx.logger,
+            integration_config.backend_url,
+            headers,
+            payload,
+            integration_short_name=integration_short_name,
+        )
+
+        # Parse response but do NOT persist the refresh token
+        token_response = OAuth2TokenResponse(**response.json())
+        ctx.logger.info(
+            f"Successfully exchanged token for scope {scope} "
+            f"(expires_in={token_response.expires_in})"
+        )
+        return str(token_response.access_token)
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------

--- a/backend/airweave/domains/oauth/protocols.py
+++ b/backend/airweave/domains/oauth/protocols.py
@@ -143,6 +143,24 @@ class OAuth2ServiceProtocol(Protocol):
         """
         ...
 
+    async def exchange_token_for_scope(
+        self,
+        db: AsyncSession,
+        integration_short_name: str,
+        connection_id: UUID,
+        ctx: ApiContext,
+        scope: str,
+    ) -> str:
+        """Exchange refresh token for an access token with a different scope.
+
+        Uses the existing refresh token but requests a different resource scope.
+        Does NOT persist the rotated refresh token (the response token is
+        scoped to the new resource and should not replace the original).
+
+        Returns the access token string for the requested scope.
+        """
+        ...
+
 
 # ---------------------------------------------------------------------------
 # Init session + redirect session repositories

--- a/backend/airweave/domains/search/adapters/vector_db/fakes/vector_db.py
+++ b/backend/airweave/domains/search/adapters/vector_db/fakes/vector_db.py
@@ -61,6 +61,7 @@ class FakeVectorDB:
         plan: SearchPlan,
         embeddings: QueryEmbeddings,
         collection_id: str,
+        acl_principals: list[str] | None = None,
     ) -> CompiledQuery:
         """Return a fake compiled query, or raise seeded error."""
         self._calls.append(("compile_query", plan, embeddings, collection_id))

--- a/backend/airweave/domains/search/adapters/vector_db/protocol.py
+++ b/backend/airweave/domains/search/adapters/vector_db/protocol.py
@@ -1,6 +1,6 @@
 """Vector database protocol for the search module."""
 
-from typing import Protocol
+from typing import Optional, Protocol
 
 from airweave.domains.search.types.embeddings import QueryEmbeddings
 from airweave.domains.search.types.filters import FilterGroup
@@ -23,6 +23,7 @@ class VectorDBProtocol(Protocol):
         plan: SearchPlan,
         embeddings: QueryEmbeddings,
         collection_id: str,
+        acl_principals: Optional[list[str]] = None,
     ) -> CompiledQuery:
         """Compile plan and embeddings into a DB-specific query.
 
@@ -30,6 +31,10 @@ class VectorDBProtocol(Protocol):
             plan: Search plan with queries, filters, strategy, pagination.
             embeddings: Dense and sparse embeddings for the queries.
             collection_id: Collection readable ID for tenant filtering.
+            acl_principals: Resolved user principals for access control filtering.
+                None = no AC sources in collection (skip filtering).
+                [] = user has no principals (only public entities visible).
+                ["user:x", "group:y"] = match these principals.
 
         Returns:
             CompiledQuery with raw (full) and display (no embeddings) versions.

--- a/backend/airweave/domains/search/adapters/vector_db/vespa_client.py
+++ b/backend/airweave/domains/search/adapters/vector_db/vespa_client.py
@@ -87,9 +87,10 @@ class VespaVectorDB:
         plan: SearchPlan,
         embeddings: QueryEmbeddings,
         collection_id: str,
+        acl_principals: Optional[list[str]] = None,
     ) -> CompiledQuery:
         """Compile plan and embeddings into Vespa query."""
-        yql = self._build_yql(plan, collection_id)
+        yql = self._build_yql(plan, collection_id, acl_principals=acl_principals)
         params = self._build_params(plan, embeddings)
 
         raw_query = {"yql": yql, "params": params}
@@ -236,7 +237,12 @@ class VespaVectorDB:
     # YQL Building
     # =========================================================================
 
-    def _build_yql(self, plan: SearchPlan, collection_id: str) -> str:
+    def _build_yql(
+        self,
+        plan: SearchPlan,
+        collection_id: str,
+        acl_principals: Optional[list[str]] = None,
+    ) -> str:
         """Build the complete YQL query string."""
         num_embeddings = self._count_dense_embeddings(plan)
         retrieval_clause = self._build_retrieval_clause(plan.retrieval_strategy, num_embeddings)
@@ -250,10 +256,30 @@ class VespaVectorDB:
         if filter_yql:
             where_parts.append(f"({filter_yql})")
 
+        acl_yql = self._build_acl_clause(acl_principals)
+        if acl_yql:
+            where_parts.append(f"({acl_yql})")
+
         all_schemas = ", ".join(ALL_VESPA_SCHEMAS)
         yql = f"select * from sources {all_schemas} where {' AND '.join(where_parts)}"
 
         return yql
+
+    def _build_acl_clause(self, acl_principals: Optional[list[str]]) -> Optional[str]:
+        """Build access control YQL clause from resolved principals.
+
+        Returns None if acl_principals is None (no AC sources → skip filtering).
+        Returns a clause that matches public entities or entities with matching viewers.
+        """
+        if acl_principals is None:
+            return None
+
+        clauses = ["access_is_public = true"]
+        for principal in acl_principals:
+            escaped = principal.replace("\\", "\\\\").replace("'", "\\'")
+            clauses.append(f"access_viewers contains '{escaped}'")
+
+        return " OR ".join(clauses)
 
     def _build_retrieval_clause(
         self,

--- a/backend/airweave/domains/search/agentic/agent.py
+++ b/backend/airweave/domains/search/agentic/agent.py
@@ -128,11 +128,13 @@ class Agent:
         ctx: ApiContext,
         readable_id: str,
         request: AgenticSearchRequest,
+        user_principal_override: str | None = None,
     ) -> SearchResults:
         """Run the agent loop. Emits events throughout. Returns collected results."""
         start_time = time.monotonic()
         state = AgentState()
         diag = _DiagnosticsAccumulator()
+        self._user_principal_override = user_principal_override
         ctx.logger.info(
             f"Agentic search started collection={readable_id} query={request.query!r} "
             f"thinking={request.thinking}"
@@ -208,7 +210,14 @@ class Agent:
         thinking_enabled = request.thinking
 
         # Construct per-request tools
-        dispatcher = self._build_dispatcher(collection_id, user_filter, db, ctx, readable_id)
+        dispatcher = self._build_dispatcher(
+            collection_id,
+            user_filter,
+            db,
+            ctx,
+            readable_id,
+            user_principal=self._user_principal_override,
+        )
 
         context_mgr = ContextManager(
             tokenizer=self._tokenizer,
@@ -587,6 +596,7 @@ class Agent:
         db: AsyncSession,
         ctx: ApiContext,
         collection_readable_id: str,
+        user_principal: str | None = None,
     ) -> ToolDispatcher:
         """Construct tools and dispatcher for this request."""
         return ToolDispatcher(
@@ -598,6 +608,7 @@ class Agent:
                     db=db,
                     ctx=ctx,
                     collection_readable_id=collection_readable_id,
+                    user_principal=user_principal,
                 ),
                 ToolName.READ: ReadTool(
                     vector_db=self._vector_db,

--- a/backend/airweave/domains/search/agentic/service.py
+++ b/backend/airweave/domains/search/agentic/service.py
@@ -72,6 +72,7 @@ class AgenticSearchService(AgenticSearchServiceProtocol):
         ctx: ApiContext,
         readable_id: str,
         request: AgenticSearchRequest,
+        user_principal_override: str | None = None,
     ) -> SearchResults:
         """Run agentic search and return results."""
         agent = Agent(
@@ -85,4 +86,6 @@ class AgenticSearchService(AgenticSearchServiceProtocol):
             event_bus=self._event_bus,
             config=SearchConfig(),
         )
-        return await agent.run(db, ctx, readable_id, request)
+        return await agent.run(
+            db, ctx, readable_id, request, user_principal_override=user_principal_override
+        )

--- a/backend/airweave/domains/search/agentic/tools/search.py
+++ b/backend/airweave/domains/search/agentic/tools/search.py
@@ -43,6 +43,7 @@ class SearchTool(Tool):
         db: AsyncSession,
         ctx: ApiContext,
         collection_readable_id: str,
+        user_principal: str | None = None,
     ) -> None:
         """Initialize with executor, user filter, collection ID, and request context."""
         self._executor = executor
@@ -51,6 +52,7 @@ class SearchTool(Tool):
         self._db = db
         self._ctx = ctx
         self._collection_readable_id = collection_readable_id
+        self._user_principal = user_principal
 
     async def execute(
         self,
@@ -67,6 +69,7 @@ class SearchTool(Tool):
             db=self._db,
             ctx=self._ctx,
             collection_readable_id=self._collection_readable_id,
+            user_principal=self._user_principal,
         )
 
         # Track new results in state

--- a/backend/airweave/domains/search/classic/service.py
+++ b/backend/airweave/domains/search/classic/service.py
@@ -68,13 +68,16 @@ class ClassicSearchService(ClassicSearchServiceProtocol):
         ctx: ApiContext,
         readable_id: str,
         request: ClassicSearchRequest,
+        user_principal_override: str | None = None,
     ) -> SearchResults:
         """Generate strategy via LLM, execute, optionally rerank, return results."""
         start_time = time.monotonic()
         ctx.logger.info(f"Classic search started collection={readable_id} query={request.query!r}")
 
         try:
-            result = await self._execute(db, ctx, readable_id, request, start_time)
+            result = await self._execute(
+                db, ctx, readable_id, request, start_time, user_principal_override
+            )
             duration_ms = int((time.monotonic() - start_time) * 1000)
             ctx.logger.info(
                 f"Classic search completed collection={readable_id} "
@@ -106,6 +109,7 @@ class ClassicSearchService(ClassicSearchServiceProtocol):
         readable_id: str,
         request: ClassicSearchRequest,
         start_time: float,
+        user_principal_override: str | None = None,
     ) -> SearchResults:
         """Internal execution — resolve collection, LLM strategy, search, rerank."""
         # 1. Resolve collection
@@ -157,6 +161,7 @@ class ClassicSearchService(ClassicSearchServiceProtocol):
             db=db,
             ctx=ctx,
             collection_readable_id=readable_id,
+            user_principal=user_principal_override,
         )
 
         # 6. Optional rerank

--- a/backend/airweave/domains/search/executor.py
+++ b/backend/airweave/domains/search/executor.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave.api.context import ApiContext
+from airweave.domains.access_control.protocols import AccessBrokerProtocol
 from airweave.domains.embedders.protocols import DenseEmbedderProtocol, SparseEmbedderProtocol
 from airweave.domains.search.adapters.vector_db.protocol import VectorDBProtocol
 from airweave.domains.search.builders.search_plan import SearchPlanBuilder
@@ -67,6 +68,7 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         sc_repo: SourceConnectionRepositoryProtocol,
         source_registry: SourceRegistryProtocol,
         source_lifecycle: SourceLifecycleServiceProtocol,
+        access_broker: AccessBrokerProtocol,
     ) -> None:
         """Initialize with embedders, vector database, and federated source dependencies."""
         self._dense_embedder = dense_embedder
@@ -75,6 +77,7 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         self._sc_repo = sc_repo
         self._source_registry = source_registry
         self._source_lifecycle = source_lifecycle
+        self._access_broker = access_broker
 
     async def execute(
         self,
@@ -84,8 +87,14 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         db: AsyncSession,
         ctx: ApiContext,
         collection_readable_id: str,
+        user_principal: Optional[str] = None,
     ) -> SearchResults:
         """Execute the full search pipeline including federated sources."""
+        # 0. Resolve access control principals
+        acl_principals = await self._resolve_acl_principals(
+            db, ctx, user_principal, collection_readable_id
+        )
+
         # 1. Merge plan filters with user filters
         complete_plan = SearchPlanBuilder.build(plan, user_filter)
 
@@ -106,7 +115,9 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         # 4. Run vector DB search and federated search in parallel
         fetch_limit = original_offset + original_limit
 
-        vector_task = asyncio.create_task(self._execute_vector_search(complete_plan, collection_id))
+        vector_task = asyncio.create_task(
+            self._execute_vector_search(complete_plan, collection_id, acl_principals)
+        )
 
         fed_task = None
         if federated_sources:
@@ -130,6 +141,10 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         #    Filter federated results in-memory and merge, or slice vector-only.
         fed_filtered = self._apply_filters_in_memory(fed_results, complete_plan.filter_groups)
 
+        # Also apply ACL filtering to federated results in-memory
+        if acl_principals is not None:
+            fed_filtered = self._apply_acl_in_memory(fed_filtered, acl_principals)
+
         if fed_filtered:
             merged = self._merge_with_rrf(vector_results, fed_filtered)
             return SearchResults(results=merged[original_offset : original_offset + original_limit])
@@ -143,6 +158,7 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         self,
         plan: SearchPlan,
         collection_id: str,
+        acl_principals: Optional[list[str]] = None,
     ) -> list[SearchResult]:
         """Embed, compile, and execute vector DB search.
 
@@ -174,8 +190,67 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
             plan=plan,
             embeddings=embeddings,
             collection_id=collection_id,
+            acl_principals=acl_principals,
         )
         return (await self._vector_db.execute_query(compiled_query)).results
+
+    # ------------------------------------------------------------------
+    # Access control resolution
+    # ------------------------------------------------------------------
+
+    async def _resolve_acl_principals(
+        self,
+        db: AsyncSession,
+        ctx: ApiContext,
+        user_principal: Optional[str],
+        collection_readable_id: str,
+    ) -> Optional[list[str]]:
+        """Resolve user's ACL principals for a collection.
+
+        Returns None if user_principal is not set or collection has no AC sources.
+        Returns a list of principals (possibly empty) otherwise.
+        """
+        if not user_principal:
+            return None
+
+        access_context = await self._access_broker.resolve_access_context_for_collection(
+            db=db,
+            user_principal=user_principal,
+            readable_collection_id=collection_readable_id,
+            organization_id=ctx.organization.id,
+        )
+
+        if access_context is None:
+            return None
+
+        principals = list(access_context.all_principals)
+        ctx.logger.info(f"[ACL] Resolved {len(principals)} principals for user '{user_principal}'")
+        return principals
+
+    @staticmethod
+    def _apply_acl_in_memory(
+        results: list[SearchResult],
+        principals: list[str],
+    ) -> list[SearchResult]:
+        """Apply ACL filtering to results in-memory (for federated sources).
+
+        Keeps results that are:
+        - From non-AC sources (is_public is None — no ACL data means pass through)
+        - Explicitly public (is_public is True)
+        - Matching a viewer principal
+        """
+        principal_set = set(principals)
+
+        def _passes(r: SearchResult) -> bool:
+            if r.access.is_public is None:
+                return True  # Non-AC source — no access data, pass through
+            if r.access.is_public:
+                return True
+            if r.access.viewers:
+                return bool(principal_set & set(r.access.viewers))
+            return False
+
+        return [r for r in results if _passes(r)]
 
     # ------------------------------------------------------------------
     # Federated source discovery

--- a/backend/airweave/domains/search/fakes/executor.py
+++ b/backend/airweave/domains/search/fakes/executor.py
@@ -40,6 +40,7 @@ class FakeSearchPlanExecutor(SearchPlanExecutorProtocol):
         db: Any = None,
         ctx: Any = None,
         collection_readable_id: str = "",
+        user_principal: str | None = None,
     ) -> SearchResults:
         """Record the call and return seeded result, or raise seeded error."""
         self._calls.append(("execute", plan, user_filter, collection_id))

--- a/backend/airweave/domains/search/instant/service.py
+++ b/backend/airweave/domains/search/instant/service.py
@@ -49,13 +49,16 @@ class InstantSearchService(InstantSearchServiceProtocol):
         ctx: ApiContext,
         readable_id: str,
         request: InstantSearchRequest,
+        user_principal_override: str | None = None,
     ) -> SearchResults:
         """Build plan from request and execute."""
         start_time = time.monotonic()
         ctx.logger.info(f"Instant search started collection={readable_id} query={request.query!r}")
 
         try:
-            result = await self._execute(db, ctx, readable_id, request, start_time)
+            result = await self._execute(
+                db, ctx, readable_id, request, start_time, user_principal_override
+            )
             duration_ms = int((time.monotonic() - start_time) * 1000)
             ctx.logger.info(
                 f"Instant search completed collection={readable_id} "
@@ -87,6 +90,7 @@ class InstantSearchService(InstantSearchServiceProtocol):
         readable_id: str,
         request: InstantSearchRequest,
         start_time: float,
+        user_principal_override: str | None = None,
     ) -> SearchResults:
         """Internal execution — resolve collection, build plan, execute."""
         collection = await self._collection_repo.get_by_readable_id(db, readable_id, ctx)
@@ -107,6 +111,7 @@ class InstantSearchService(InstantSearchServiceProtocol):
             db=db,
             ctx=ctx,
             collection_readable_id=readable_id,
+            user_principal=user_principal_override,
         )
 
         duration_ms = int((time.monotonic() - start_time) * 1000)

--- a/backend/airweave/domains/search/protocols.py
+++ b/backend/airweave/domains/search/protocols.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,6 +39,7 @@ class SearchPlanExecutorProtocol(Protocol):
         db: AsyncSession,
         ctx: ApiContext,
         collection_readable_id: str,
+        user_principal: Optional[str] = None,
     ) -> SearchResults:
         """Execute a search plan and return results."""
         ...
@@ -68,6 +69,7 @@ class InstantSearchServiceProtocol(Protocol):
         ctx: ApiContext,
         readable_id: str,
         request: InstantSearchRequest,
+        user_principal_override: Optional[str] = None,
     ) -> SearchResults:
         """Execute instant search and return results."""
         ...
@@ -83,6 +85,7 @@ class ClassicSearchServiceProtocol(Protocol):
         ctx: ApiContext,
         readable_id: str,
         request: ClassicSearchRequest,
+        user_principal_override: Optional[str] = None,
     ) -> SearchResults:
         """Execute classic search and return results."""
         ...
@@ -98,6 +101,7 @@ class AgenticSearchServiceProtocol(Protocol):
         ctx: ApiContext,
         readable_id: str,
         request: AgenticSearchRequest,
+        user_principal_override: Optional[str] = None,
     ) -> SearchResults:
         """Execute agentic search and return results."""
         ...

--- a/backend/airweave/domains/search/tests/test_executor.py
+++ b/backend/airweave/domains/search/tests/test_executor.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 
 import pytest
 
+from airweave.domains.access_control.fakes.broker import FakeAccessBroker
 from airweave.domains.embedders.fakes.embedder import FakeDenseEmbedder, FakeSparseEmbedder
 from airweave.domains.search.adapters.vector_db.fakes.vector_db import FakeVectorDB
 from airweave.domains.search.executor import (
@@ -255,6 +256,7 @@ def _build_executor(
         sc_repo=sc_repo or FakeSourceConnectionRepository(),
         source_registry=source_registry or FakeSourceRegistry(),
         source_lifecycle=source_lifecycle or FakeSourceLifecycleService(),
+        access_broker=FakeAccessBroker(),
     )
 
 
@@ -913,6 +915,7 @@ class TestExecutorErrorPaths:
             sc_repo=FakeSourceConnectionRepository(),
             source_registry=FakeSourceRegistry(),
             source_lifecycle=FakeSourceLifecycleService(),
+            access_broker=FakeAccessBroker(),
         )
 
         with pytest.raises(RuntimeError, match="provider down"):
@@ -938,6 +941,7 @@ class TestExecutorErrorPaths:
             sc_repo=FakeSourceConnectionRepository(),
             source_registry=FakeSourceRegistry(),
             source_lifecycle=FakeSourceLifecycleService(),
+            access_broker=FakeAccessBroker(),
         )
 
         with pytest.raises(RuntimeError, match="timeout"):

--- a/backend/airweave/domains/sources/token_providers/oauth.py
+++ b/backend/airweave/domains/sources/token_providers/oauth.py
@@ -146,6 +146,31 @@ class OAuthTokenProvider(TokenProviderProtocol):
             self._apply_refresh(result)
             return self._token
 
+    async def get_token_for_resource(self, resource_scope: str) -> Optional[str]:
+        """Exchange refresh token for an access token scoped to a different resource.
+
+        Used by SharePoint Online to get a SP REST API token from a Graph-scoped
+        refresh token. The exchange does not persist the rotated refresh token.
+
+        Returns None if refresh is not supported.
+        """
+        if not self._can_refresh:
+            return None
+
+        try:
+            async with get_db_context() as db:
+                result = await self._oauth2_service.exchange_token_for_scope(
+                    db=db,
+                    integration_short_name=self._source_short_name,
+                    connection_id=self._connection_id,
+                    ctx=self._ctx,
+                    scope=resource_scope,
+                )
+                return str(result)
+        except Exception as e:
+            self._logger.warning(f"Failed to exchange token for scope {resource_scope}: {e}")
+            return None
+
     # ------------------------------------------------------------------
     # Private
     # ------------------------------------------------------------------

--- a/backend/airweave/domains/sources/validation.py
+++ b/backend/airweave/domains/sources/validation.py
@@ -37,14 +37,12 @@ class SourceValidationService(SourceValidationServiceProtocol):
         """
         entry = self._get_entry_or_404(short_name)
 
-        if not config_fields:
-            return {}
-
-        payload = self._as_mapping(config_fields)
-
         config_class = entry.config_ref
         if config_class is None:
-            return payload
+            # Source has no config schema — anything goes
+            return self._as_mapping(config_fields) if config_fields else {}
+
+        payload = self._as_mapping(config_fields) if config_fields else {}
 
         self._enforce_feature_flags(short_name, payload, config_class, ctx)
 

--- a/backend/airweave/domains/storage/file_service.py
+++ b/backend/airweave/domains/storage/file_service.py
@@ -61,7 +61,7 @@ class FileService:
     @staticmethod
     async def _resolve_headers(auth: SourceAuthProvider, url: str) -> dict:
         """Build auth headers. Pre-signed URLs skip the bearer token."""
-        if "X-Amz-Algorithm" in url:
+        if "X-Amz-Algorithm" in url or "tempauth=" in url:
             return {}
         token = await auth.get_token() if hasattr(auth, "get_token") else None
         if not token:

--- a/backend/airweave/domains/sync_pipeline/builders/destinations.py
+++ b/backend/airweave/domains/sync_pipeline/builders/destinations.py
@@ -24,6 +24,7 @@ class DestinationsContextBuilder:
         collection: schemas.CollectionRecord,
         logger: ContextualLogger,
         execution_config: Optional[SyncConfig] = None,
+        source_supports_acl: bool = False,
     ) -> List[BaseDestination]:
         """Build destinations."""
         return await cls._create_destinations(
@@ -31,6 +32,7 @@ class DestinationsContextBuilder:
             collection=collection,
             logger=logger,
             execution_config=execution_config,
+            source_supports_acl=source_supports_acl,
         )
 
     # -------------------------------------------------------------------------
@@ -44,6 +46,7 @@ class DestinationsContextBuilder:
         collection: schemas.CollectionRecord,
         logger: ContextualLogger,
         execution_config: Optional[SyncConfig] = None,
+        source_supports_acl: bool = False,
     ) -> List[BaseDestination]:
         """Create destination instances."""
         destinations = []
@@ -59,6 +62,7 @@ class DestinationsContextBuilder:
                     destination_connection_id=destination_connection_id,
                     collection=collection,
                     logger=logger,
+                    source_supports_acl=source_supports_acl,
                 )
                 if destination:
                     destinations.append(destination)
@@ -87,18 +91,20 @@ class DestinationsContextBuilder:
         destination_connection_id: UUID,
         collection: schemas.CollectionRecord,
         logger: ContextualLogger,
+        source_supports_acl: bool = False,
     ) -> Optional[BaseDestination]:
         """Create a single destination instance."""
         if destination_connection_id != NATIVE_VESPA_UUID:
             logger.warning(f"Unknown destination connection {destination_connection_id}, skipping")
             return None
-        return await cls._create_vespa(collection, logger)
+        return await cls._create_vespa(collection, logger, source_supports_acl=source_supports_acl)
 
     @classmethod
     async def _create_vespa(
         cls,
         collection: schemas.CollectionRecord,
         logger: ContextualLogger,
+        source_supports_acl: bool = False,
     ) -> BaseDestination:
         """Create native Vespa destination directly."""
         logger.info("Using native Vespa destination (settings-based)")
@@ -109,6 +115,7 @@ class DestinationsContextBuilder:
             organization_id=collection.organization_id,
             vector_size=None,
             logger=logger,
+            source_supports_acl=source_supports_acl,
         )
         logger.info("Created native Vespa destination")
         return destination

--- a/backend/airweave/domains/sync_pipeline/factory.py
+++ b/backend/airweave/domains/sync_pipeline/factory.py
@@ -184,12 +184,14 @@ class SyncFactory(SyncFactoryProtocol):
             execution_config=resolved_config,
             access_token=access_token,
         )
+        source_entry = self._source_registry.get(sc.short_name)
         destinations = await self._build_destinations(
             db=db,
             sync=sync,
             collection=collection,
             ctx=ctx,
             execution_config=resolved_config,
+            source_supports_acl=source_entry.supports_access_control,
         )
         entity_tracker = await self._build_entity_tracker(
             db=db,
@@ -498,6 +500,7 @@ class SyncFactory(SyncFactoryProtocol):
         collection: schemas.CollectionRecord,
         ctx: BaseContext,
         execution_config: SyncConfig,
+        source_supports_acl: bool = False,
     ) -> list:
         """Build destination instances for the sync."""
         dest_logger = LoggerConfigurator.configure_logger(
@@ -513,6 +516,7 @@ class SyncFactory(SyncFactoryProtocol):
             collection=collection,
             logger=dest_logger,
             execution_config=execution_config,
+            source_supports_acl=source_supports_acl,
         )
 
     # -------------------------------------------------------------------------

--- a/backend/airweave/platform/configs/auth.py
+++ b/backend/airweave/platform/configs/auth.py
@@ -752,6 +752,42 @@ class ShopifyAuthConfig(AuthConfig):
     )
 
 
+class SharePointOnlineAppAuthConfig(AuthConfig):
+    """SharePoint Online app-only authentication using client credentials.
+
+    Uses client_id + client_secret for Microsoft Graph API calls,
+    and a certificate private key for SharePoint REST API calls.
+    Requires an Azure AD app registration with application permissions
+    and admin consent.
+    """
+
+    tenant_id: str = Field(
+        title="Tenant ID",
+        description="Azure AD tenant ID (e.g., 'contoso.onmicrosoft.com' or a UUID)",
+        min_length=1,
+    )
+    client_id: str = Field(
+        title="Client ID",
+        description="Application (client) ID from the Azure AD app registration",
+        min_length=1,
+    )
+    client_secret: str = Field(
+        title="Client Secret",
+        description="Client secret from the Azure AD app registration (for Graph API)",
+        min_length=1,
+        json_schema_extra={"is_secret": True},
+    )
+    private_key: str = Field(
+        title="Private Key (PEM)",
+        description=(
+            "PEM-encoded private key for certificate authentication "
+            "(for SharePoint REST API). Starts with '-----BEGIN PRIVATE KEY-----'"
+        ),
+        min_length=1,
+        json_schema_extra={"is_secret": True},
+    )
+
+
 class ServiceNowAuthConfig(AuthConfig):
     """ServiceNow instance authentication credentials schema.
 

--- a/backend/airweave/platform/configs/auth.py
+++ b/backend/airweave/platform/configs/auth.py
@@ -786,6 +786,16 @@ class SharePointOnlineAppAuthConfig(AuthConfig):
         min_length=1,
         json_schema_extra={"is_secret": True},
     )
+    certificate: str = Field(
+        default="",
+        title="Certificate (PEM)",
+        description=(
+            "PEM-encoded certificate that was uploaded to the Azure AD app registration. "
+            "Used to compute the x5t thumbprint for SP REST API token exchange. "
+            "If omitted, SP site group expansion will not work."
+        ),
+        json_schema_extra={"is_secret": True},
+    )
 
 
 class ServiceNowAuthConfig(AuthConfig):

--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -1191,20 +1191,21 @@ class SharePointOnlineConfig(SourceConfig):
     """
 
     site_url: str = Field(
-        ...,
+        default="",
         title="SharePoint Site URL",
         description=(
-            "URL of the SharePoint site to sync "
+            "URL of a specific SharePoint site to sync "
             "(e.g., 'https://contoso.sharepoint.com/sites/Marketing'). "
-            "Create one source connection per site."
+            "Leave empty to sync all sites in the tenant."
         ),
-        min_length=1,
     )
 
     @field_validator("site_url")
     @classmethod
     def validate_site_url_ssrf(cls, v: str) -> str:
         """Validate site URL for SSRF safety."""
+        if not v:
+            return v
         validate_url(v.strip())
         return v.strip()
 

--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -1191,27 +1191,22 @@ class SharePointOnlineConfig(SourceConfig):
     """
 
     site_url: str = Field(
-        default="",
+        ...,
         title="SharePoint Site URL",
         description=(
-            "URL of the SharePoint site(s) to sync. Supports a single URL "
-            "(e.g., 'https://contoso.sharepoint.com/sites/Marketing'), "
-            "comma-separated URLs for multiple sites, or leave empty to "
-            "sync all accessible sites."
+            "URL of the SharePoint site to sync "
+            "(e.g., 'https://contoso.sharepoint.com/sites/Marketing'). "
+            "Create one source connection per site."
         ),
+        min_length=1,
     )
 
     @field_validator("site_url")
     @classmethod
     def validate_site_url_ssrf(cls, v: str) -> str:
-        """Validate each comma-separated site URL for SSRF safety."""
-        if not v:
-            return v
-        for url in v.split(","):
-            url = url.strip()
-            if url:
-                validate_url(url)
-        return v
+        """Validate site URL for SSRF safety."""
+        validate_url(v.strip())
+        return v.strip()
 
     include_personal_sites: bool = Field(
         default=False,

--- a/backend/airweave/platform/destinations/vespa/destination.py
+++ b/backend/airweave/platform/destinations/vespa/destination.py
@@ -112,10 +112,12 @@ class VespaDestination(VectorDBDestination):
         instance.organization_id = organization_id
 
         # Initialize components
+        source_supports_acl = kwargs.get("source_supports_acl", False)
         instance._client = await VespaClient.connect(logger=instance.logger)
         instance._transformer = EntityTransformer(
             collection_id=collection_id,
             logger=instance.logger,
+            source_supports_acl=source_supports_acl,
         )
         instance._query_builder = QueryBuilder()
 

--- a/backend/airweave/platform/destinations/vespa/transformer.py
+++ b/backend/airweave/platform/destinations/vespa/transformer.py
@@ -25,7 +25,7 @@ from airweave.platform.entities._base import (
 
 
 def _sanitize_for_vespa(text: str) -> str:
-    """Sanitize text for Vespa by removing illegal characters.
+    r"""Sanitize text for Vespa by removing illegal characters.
 
     Vespa strictly rejects:
     1. Control characters (code points < 32) except \n (0x0A), \r (0x0D), \t (0x09)
@@ -167,15 +167,20 @@ class EntityTransformer:
         self,
         collection_id: Optional[UUID] = None,
         logger: Optional[ContextualLogger] = None,
+        source_supports_acl: bool = False,
     ):
         """Initialize the entity transformer.
 
         Args:
             collection_id: SQL collection UUID for multi-tenant filtering
             logger: Optional logger for debug/warning messages
+            source_supports_acl: Whether the source supports access control.
+                When True, entities with no access data default to invisible (fail-closed).
+                When False, entities default to public (visible to all).
         """
         self.collection_id = collection_id
         self._logger = logger or default_logger
+        self._source_supports_acl = source_supports_acl
 
     def transform(self, entity: BaseEntity) -> VespaDocument:
         """Transform a single entity to Vespa document format.
@@ -343,13 +348,17 @@ class EntityTransformer:
         """Add access control fields.
 
         Always sets access control fields with appropriate defaults:
-        - AC-enabled sources: Use the actual ACL values from entity.access
-        - Non-AC sources: Set is_public=True so entities are visible to everyone
+        - If entity has access data: use the actual ACL values
+        - AC-enabled source but no access data: fail-closed (invisible)
+        - Non-AC source: default to public (visible to everyone)
         """
         access = getattr(entity, "access", None)
         if access is not None:
             fields["access_is_public"] = access.is_public
             fields["access_viewers"] = access.viewers if access.viewers else []
+        elif self._source_supports_acl:
+            fields["access_is_public"] = False
+            fields["access_viewers"] = []
         else:
             fields["access_is_public"] = True
             fields["access_viewers"] = []

--- a/backend/airweave/platform/sources/__init__.py
+++ b/backend/airweave/platform/sources/__init__.py
@@ -50,7 +50,7 @@ from .salesforce import SalesforceSource
 from .servicenow import ServiceNowSource
 from .sharepoint import SharePointSource
 from .sharepoint2019v2.source import SharePoint2019V2Source
-from .sharepoint_online.source import SharePointOnlineSource
+from .sharepoint_online.source import SharePointOnlineAppSource, SharePointOnlineSource
 from .shopify import ShopifySource
 from .slab import SlabSource
 from .slack import SlackSource
@@ -117,6 +117,7 @@ ALL_SOURCES: list[type] = [
     SharePointSource,
     SharePoint2019V2Source,
     SharePointOnlineSource,
+    SharePointOnlineAppSource,
     ShopifySource,
     SlabSource,
     SliteSource,

--- a/backend/airweave/platform/sources/sharepoint_online/__init__.py
+++ b/backend/airweave/platform/sources/sharepoint_online/__init__.py
@@ -1,8 +1,12 @@
 """SharePoint Online source connector.
 
 Uses Microsoft Graph API for content sync and Entra ID for access control.
+Two variants: OAuth (delegated) and App (client credentials).
 """
 
-from airweave.platform.sources.sharepoint_online.source import SharePointOnlineSource
+from airweave.platform.sources.sharepoint_online.source import (
+    SharePointOnlineAppSource,
+    SharePointOnlineSource,
+)
 
-__all__ = ["SharePointOnlineSource"]
+__all__ = ["SharePointOnlineSource", "SharePointOnlineAppSource"]

--- a/backend/airweave/platform/sources/sharepoint_online/builders.py
+++ b/backend/airweave/platform/sources/sharepoint_online/builders.py
@@ -9,11 +9,10 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from airweave.domains.sync_pipeline.exceptions import EntityProcessingError
-from airweave.platform.entities._base import Breadcrumb
+from airweave.platform.entities._base import AccessControl, Breadcrumb
 from airweave.platform.entities.sharepoint_online import (
     SharePointOnlineDriveEntity,
     SharePointOnlineFileEntity,
-    SharePointOnlineItemEntity,
     SharePointOnlinePageEntity,
     SharePointOnlineSiteEntity,
 )
@@ -32,6 +31,7 @@ def _parse_datetime(dt_str: Optional[str]) -> Optional[datetime]:
 async def build_site_entity(
     site_data: Dict[str, Any],
     breadcrumbs: List[Breadcrumb],
+    access: Optional[AccessControl] = None,
 ) -> SharePointOnlineSiteEntity:
     """Build a site entity from Graph API site data."""
     site_id = site_data.get("id")
@@ -53,6 +53,7 @@ async def build_site_entity(
         created_at=_parse_datetime(site_data.get("createdDateTime")),
         last_modified_at=_parse_datetime(site_data.get("lastModifiedDateTime")),
         breadcrumbs=breadcrumbs,
+        access=access,
     )
 
 
@@ -60,6 +61,7 @@ async def build_drive_entity(
     drive_data: Dict[str, Any],
     site_id: str,
     breadcrumbs: List[Breadcrumb],
+    access: Optional[AccessControl] = None,
 ) -> SharePointOnlineDriveEntity:
     """Build a drive entity from Graph API drive data."""
     drive_id = drive_data.get("id")
@@ -84,6 +86,7 @@ async def build_drive_entity(
         created_at=_parse_datetime(drive_data.get("createdDateTime")),
         last_modified_at=_parse_datetime(drive_data.get("lastModifiedDateTime")),
         breadcrumbs=breadcrumbs,
+        access=access,
     )
 
 
@@ -154,46 +157,11 @@ async def build_file_entity(
     )
 
 
-async def build_item_entity(
-    item_data: Dict[str, Any],
-    site_id: str,
-    list_id: str,
-    breadcrumbs: List[Breadcrumb],
-) -> SharePointOnlineItemEntity:
-    """Build a list item entity from Graph API list item data."""
-    item_id = item_data.get("id")
-    if not item_id:
-        raise EntityProcessingError("Missing id for list item")
-
-    fields = item_data.get("fields", {}) or {}
-    title = fields.get("Title") or fields.get("title") or item_data.get("id", "Untitled")
-
-    content_type = None
-    ct_obj = item_data.get("contentType")
-    if ct_obj:
-        content_type = ct_obj.get("name")
-
-    spo_entity_id = f"spo:item:{site_id}:{list_id}:{item_id}"
-
-    return SharePointOnlineItemEntity(
-        spo_entity_id=spo_entity_id,
-        item_id=item_id,
-        list_id=list_id,
-        site_id=site_id,
-        title=title,
-        web_url=item_data.get("webUrl", ""),
-        content_type=content_type,
-        fields=fields,
-        created_at=_parse_datetime(item_data.get("createdDateTime")),
-        updated_at=_parse_datetime(item_data.get("lastModifiedDateTime")),
-        breadcrumbs=breadcrumbs,
-    )
-
-
 async def build_page_entity(
     page_data: Dict[str, Any],
     site_id: str,
     breadcrumbs: List[Breadcrumb],
+    access: Optional[AccessControl] = None,
 ) -> SharePointOnlinePageEntity:
     """Build a page entity from Graph API site page data."""
     page_id = page_data.get("id")
@@ -214,4 +182,5 @@ async def build_page_entity(
         created_at=_parse_datetime(page_data.get("createdDateTime")),
         updated_at=_parse_datetime(page_data.get("lastModifiedDateTime")),
         breadcrumbs=breadcrumbs,
+        access=access,
     )

--- a/backend/airweave/platform/sources/sharepoint_online/client.py
+++ b/backend/airweave/platform/sources/sharepoint_online/client.py
@@ -137,6 +137,12 @@ class GraphClient:
         async for site in self.get_paginated(url, params):
             yield site
 
+    async def get_all_sites(self) -> AsyncGenerator[Dict[str, Any], None]:
+        """Enumerate all sites in the tenant (requires application permissions)."""
+        url = f"{GRAPH_BASE_URL}/sites/getAllSites"
+        async for site in self.get_paginated(url):
+            yield site
+
     async def get_subsites(self, site_id: str) -> AsyncGenerator[Dict[str, Any], None]:
         """Get subsites of a SharePoint site."""
         url = f"{GRAPH_BASE_URL}/sites/{site_id}/sites"
@@ -233,11 +239,18 @@ class GraphClient:
         self,
         drive_id: str,
         delta_token: str = "",
+        prefer_headers: Optional[List[str]] = None,
     ) -> Tuple[List[Dict[str, Any]], str]:
         """Get changes since the last delta token.
 
         Returns (changed_items, new_delta_token).
         If delta_token is empty, returns all items (initial sync).
+
+        Args:
+            drive_id: The drive to query.
+            delta_token: Continuation token from a previous delta query.
+            prefer_headers: Optional Prefer header values for app-only delta
+                (e.g., ["deltashowsharingchanges", "deltashowremovedasdeleted"]).
         """
         if delta_token:
             url = delta_token  # Delta tokens are full URLs
@@ -249,7 +262,15 @@ class GraphClient:
         delta_link = ""
 
         while current_url:
-            data = await self.get(current_url)
+            if prefer_headers:
+                headers = await self._headers()
+                headers["Prefer"] = ", ".join(prefer_headers)
+                self.logger.debug(f"GET {current_url} (Prefer: {headers['Prefer']})")
+                response = await self._http_client.get(current_url, headers=headers, timeout=30.0)
+                response.raise_for_status()
+                data = response.json()
+            else:
+                data = await self.get(current_url)
             items = data.get("value", [])
             all_items.extend(items)
 

--- a/backend/airweave/platform/sources/sharepoint_online/client.py
+++ b/backend/airweave/platform/sources/sharepoint_online/client.py
@@ -282,6 +282,20 @@ class GraphClient:
                 return []
             raise
 
+    async def get_drive_root_permissions(
+        self,
+        drive_id: str,
+    ) -> List[Dict[str, Any]]:
+        """Get permissions for the root of a drive (site-level permissions)."""
+        url = f"{GRAPH_BASE_URL}/drives/{drive_id}/root/permissions"
+        try:
+            data = await self.get(url)
+            return data.get("value", [])
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code in (404, 403):
+                return []
+            raise
+
     # -- Lists --
 
     async def get_lists(self, site_id: str) -> AsyncGenerator[Dict[str, Any], None]:

--- a/backend/airweave/platform/sources/sharepoint_online/source.py
+++ b/backend/airweave/platform/sources/sharepoint_online/source.py
@@ -18,6 +18,10 @@ Access graph generation:
 Incremental sync:
 - Uses Graph delta queries (/drives/{id}/root/delta)
 - Per-drive delta tokens stored in cursor
+
+Two source variants:
+- SharePointOnlineSource: OAuth (delegated user auth)
+- SharePointOnlineAppSource: Client credentials (app-only auth)
 """
 
 from __future__ import annotations
@@ -35,6 +39,7 @@ from airweave.domains.access_control.schemas import MembershipTuple
 from airweave.domains.browse_tree.types import BrowseNode, NodeSelectionData
 from airweave.domains.sources.exceptions import SourceAuthError
 from airweave.domains.sources.token_providers.credential import DirectCredentialProvider
+from airweave.domains.sources.token_providers.protocol import TokenProviderProtocol
 from airweave.domains.sources.token_providers.static import StaticTokenProvider
 from airweave.domains.storage import FileSkippedException
 from airweave.domains.storage.file_service import FileService
@@ -64,7 +69,7 @@ from airweave.platform.sources.sharepoint_online.builders import (
 )
 from airweave.platform.sources.sharepoint_online.client import GRAPH_BASE_URL, GraphClient
 from airweave.platform.sources.sharepoint_online.graph_groups import EntraGroupExpander
-from airweave.schemas.source_connection import AuthenticationMethod
+from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
 
 MAX_CONCURRENT_FILE_DOWNLOADS = 10
 ITEM_BATCH_SIZE = 50
@@ -79,180 +84,77 @@ class PendingFileDownload:
     item_id: str
 
 
-@source(
-    name="SharePoint Online",
-    short_name="sharepoint_online",
-    auth_methods=[AuthenticationMethod.DIRECT],
-    auth_config_class=SharePointOnlineAppAuthConfig,
-    config_class=SharePointOnlineConfig,
-    supports_continuous=True,
-    cursor_class=SharePointOnlineCursor,
-    supports_access_control=True,
-    supports_browse_tree=True,
-    feature_flag="sharepoint_2019_v2",
-    labels=["Collaboration", "File Storage"],
-)
-class SharePointOnlineSource(BaseSource):
-    """SharePoint Online source using Microsoft Graph API.
+# =============================================================================
+# Base class — shared sync, browse tree, download, and ACL logic
+# =============================================================================
 
-    Syncs sites, drives, files, lists, and pages with full ACL support.
-    Uses Entra ID for group membership expansion.
+
+class SharePointOnlineBase(BaseSource):
+    """Shared implementation for SharePoint Online sources.
+
+    Subclasses must implement the auth-specific hooks:
+    - create() — class constructor
+    - _get_access_token() — return a valid Microsoft Graph token
+    - _handle_401() — refresh/re-exchange on 401, return new token
+    - _make_sp_token_provider() — callable returning SP REST API token
+    - _get_download_auth(url) — auth suitable for file download
+    - _discover_sites(graph_client) — site discovery strategy
     """
 
-    @classmethod
-    async def create(
-        cls,
-        *,
-        auth: DirectCredentialProvider,
-        logger: ContextualLogger,
-        http_client: AirweaveHttpClient,
-        config: SharePointOnlineConfig,
-    ) -> SharePointOnlineSource:
-        """Create and configure a SharePoint Online source instance."""
-        instance = cls(auth=auth, logger=logger, http_client=http_client)
-        instance._site_url = config.site_url.rstrip("/") if config.site_url else ""
-        instance._include_personal_sites = config.include_personal_sites
-        instance._include_pages = config.include_pages
-        instance._item_level_entra_groups: set = set()
-        instance._item_level_sp_groups: set = set()
+    # Instance attributes set by _init_common()
+    _site_url: str
+    _include_personal_sites: bool
+    _include_pages: bool
+    _item_level_entra_groups: set
+    _item_level_sp_groups: set
 
-        creds: SharePointOnlineAppAuthConfig = auth.credentials
-        instance._tenant_id = creds.tenant_id
-        instance._client_id = creds.client_id
-        instance._client_secret = creds.client_secret
-        instance._private_key = creds.private_key
+    def _init_common(self, config: SharePointOnlineConfig) -> None:
+        """Initialize fields shared by both OAuth and client-credentials sources."""
+        self._site_url = config.site_url.rstrip("/") if config.site_url else ""
+        self._include_personal_sites = config.include_personal_sites
+        self._include_pages = config.include_pages
+        self._item_level_entra_groups = set()
+        self._item_level_sp_groups = set()
 
-        # Token cache
-        instance._graph_token: Optional[str] = None
-        instance._graph_token_expires: float = 0.0
-        instance._sp_tokens: Dict[str, tuple] = {}  # hostname -> (token, expires_at)
+    # -- Auth hooks (subclasses override) --
 
-        # Exchange for initial Graph token
-        instance._graph_token = await instance._exchange_graph_token()
-        instance._graph_token_expires = asyncio.get_event_loop().time() + 3500
+    async def _get_access_token(self) -> str:
+        """Get a valid Microsoft Graph access token."""
+        raise NotImplementedError
 
-        return instance
+    async def _handle_401(self) -> str:
+        """Handle a 401 by refreshing/re-exchanging. Returns new token."""
+        raise NotImplementedError
 
-    # -- Token exchange (app-only mode) --
+    def _make_sp_token_provider(self) -> Optional[Callable]:
+        """Create an async callable returning a SharePoint REST API token, or None."""
+        raise NotImplementedError
 
-    async def _exchange_graph_token(self) -> str:
-        """Exchange client credentials for a Microsoft Graph access token."""
-        url = f"https://login.microsoftonline.com/{self._tenant_id}/oauth2/v2.0/token"
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                data={
-                    "grant_type": "client_credentials",
-                    "client_id": self._client_id,
-                    "client_secret": self._client_secret,
-                    "scope": "https://graph.microsoft.com/.default",
-                },
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            self.logger.info(f"App-only Graph token obtained (expires_in={data.get('expires_in')})")
-            return data["access_token"]
+    async def _get_download_auth(self, url: str) -> Any:
+        """Return an auth object suitable for FileService.download_from_url."""
+        return self.auth
 
-    async def _exchange_sp_token_with_certificate(self, hostname: str) -> str:
-        """Exchange certificate credentials for a SharePoint REST API access token."""
-        import base64
-        import datetime
-        import hashlib
-        import time as _time
+    async def _discover_sites(self, graph_client: GraphClient) -> List[Dict[str, Any]]:
+        """Discover SharePoint sites to sync."""
+        raise NotImplementedError
 
-        import jwt as pyjwt
-        from cryptography import x509
-        from cryptography.hazmat.primitives import serialization
-        from cryptography.hazmat.primitives.hashes import SHA256
-        from cryptography.x509.oid import NameOID
+    @property
+    def _delta_prefer_headers(self) -> List[str]:
+        """Prefer headers for delta queries (permission change tracking)."""
+        return []
 
-        token_url = f"https://login.microsoftonline.com/{self._tenant_id}/oauth2/v2.0/token"
-
-        private_key = serialization.load_pem_private_key(self._private_key.encode(), password=None)
-        # Derive x5t from the certificate (we need to get the cert from the private key)
-        # Since we only have the private key, derive x5t from it
-        # Actually, Microsoft needs the certificate thumbprint. We'll compute it from
-        # the private key's public key — but the x5t should match the uploaded cert.
-        # For self-signed certs, we can generate a temporary cert from the key.
-        # Simpler: just use the private key to sign, Azure AD matches by key ID.
-
-        # Generate a self-signed cert from the private key for x5t computation
-        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "airweave")])
-        cert = (
-            x509.CertificateBuilder()
-            .subject_name(subject)
-            .issuer_name(subject)
-            .public_key(private_key.public_key())
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.datetime.utcnow())
-            .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=365))
-            .sign(private_key, SHA256())
-        )
-        cert_der = cert.public_bytes(serialization.Encoding.DER)
-        cert_hash = hashlib.sha1(cert_der).digest()
-        x5t = base64.urlsafe_b64encode(cert_hash).rstrip(b"=").decode()
-
-        now = int(_time.time())
-        assertion = pyjwt.encode(
-            {
-                "aud": token_url,
-                "iss": self._client_id,
-                "sub": self._client_id,
-                "jti": str(now),
-                "nbf": now,
-                "exp": now + 600,
-            },
-            private_key,
-            algorithm="RS256",
-            headers={"x5t": x5t},
-        )
-
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                token_url,
-                data={
-                    "grant_type": "client_credentials",
-                    "client_id": self._client_id,
-                    "client_assertion_type": (
-                        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-                    ),
-                    "client_assertion": assertion,
-                    "scope": f"https://{hostname}/.default",
-                },
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            self.logger.info(
-                f"App-only SP token for {hostname} obtained (expires_in={data.get('expires_in')})"
-            )
-            return data["access_token"]
-
-    async def _get_graph_token(self) -> str:
-        """Get a valid Graph token, re-exchanging if expired."""
-        now = asyncio.get_event_loop().time()
-        if self._graph_token and now < self._graph_token_expires:
-            return self._graph_token
-        self._graph_token = await self._exchange_graph_token()
-        self._graph_token_expires = now + 3500  # ~58 min
-        return self._graph_token
-
-    async def _get_sp_token(self, hostname: str) -> str:
-        """Get a valid SP REST API token for a hostname, re-exchanging if expired."""
-        now = asyncio.get_event_loop().time()
-        cached = self._sp_tokens.get(hostname)
-        if cached:
-            token, expires_at = cached
-            if now < expires_at:
-                return token
-        token = await self._exchange_sp_token_with_certificate(hostname)
-        self._sp_tokens[hostname] = (token, now + 3500)
-        return token
-
-    # -- Client factory --
+    # -- Shared client factories --
 
     def _create_graph_client(self) -> GraphClient:
         return GraphClient(
-            access_token_provider=self._get_graph_token,
+            access_token_provider=self._get_access_token,
+            http_client=self.http_client,
+            logger=self.logger,
+        )
+
+    def _create_group_expander(self) -> EntraGroupExpander:
+        return EntraGroupExpander(
+            access_token_provider=self._get_access_token,
             http_client=self.http_client,
             logger=self.logger,
         )
@@ -265,14 +167,13 @@ class SharePointOnlineSource(BaseSource):
     )
     async def _get(self, url: str, params: Optional[Dict] = None) -> Dict[str, Any]:
         """Make an authenticated GET request to Microsoft Graph API."""
-        token = await self._get_graph_token()
+        token = await self._get_access_token()
         headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
         response = await self.http_client.get(url, headers=headers, params=params)
 
         if response.status_code == 401:
-            self.logger.warning("Received 401 — re-exchanging token")
-            self._graph_token_expires = 0  # force re-exchange
-            new_token = await self._get_graph_token()
+            self.logger.warning("Received 401 from Microsoft Graph API — refreshing token")
+            new_token = await self._handle_401()
             headers = {"Authorization": f"Bearer {new_token}", "Accept": "application/json"}
             response = await self.http_client.get(url, headers=headers, params=params)
 
@@ -283,42 +184,12 @@ class SharePointOnlineSource(BaseSource):
         )
         return response.json()
 
-    def _create_group_expander(self) -> EntraGroupExpander:
-        return EntraGroupExpander(
-            access_token_provider=self._get_graph_token,
-            http_client=self.http_client,
-            logger=self.logger,
-        )
-
     def _derive_sp_hostname(self) -> Optional[str]:
         """Derive the SharePoint hostname from the site URL."""
         if not self._site_url:
             return None
         parsed = urlparse(self._site_url)
         return parsed.netloc or None
-
-    def _make_sp_token_provider(self) -> Optional[Callable]:
-        """Create an async callable that returns a SharePoint-scoped token.
-
-        Returns None if the site URL is not set.
-        """
-        hostname = self._derive_sp_hostname()
-        if not hostname:
-            return None
-
-        async def _provider() -> str:
-            return await self._get_sp_token(hostname)
-
-        return _provider
-
-    @property
-    def _delta_prefer_headers(self) -> List[str]:
-        """Prefer headers for delta queries (permission change tracking)."""
-        return [
-            "deltashowsharingchanges",
-            "deltashowremovedasdeleted",
-            "deltatraversepermissiongaps",
-        ]
 
     def _track_entity_groups(self, entity: BaseEntity) -> None:
         """Track Entra ID and SP site groups found in entity permissions."""
@@ -368,14 +239,7 @@ class SharePointOnlineSource(BaseSource):
         self,
         parent_node_id: Optional[str] = None,
     ) -> List[BrowseNode]:
-        """Lazy-load tree nodes from Microsoft Graph API.
-
-        Tree structure:
-        - Root (parent_node_id=None): returns discovered sites
-        - Site node (site:{site_id}): returns drives for the site
-        - Drive node (drive:{site_id}|{drive_id}): returns root children of the drive
-        - Folder node (folder:{drive_id}|{folder_id}): returns children of the folder
-        """
+        """Lazy-load tree nodes from Microsoft Graph API."""
         graph_client = self._create_graph_client()
         nodes: List[BrowseNode] = []
 
@@ -514,14 +378,7 @@ class SharePointOnlineSource(BaseSource):
                     f"https://graph.microsoft.com/v1.0/drives/{drive_id}/items/{item_id}/content"
                 )
 
-            # For client-credentials auth, the download URL is either a pre-signed
-            # tempauth URL (no auth header needed) or a Graph API content URL
-            # (needs Graph bearer token). DirectCredentialProvider has no get_token(),
-            # so we provide a StaticTokenProvider with the Graph token as fallback.
-            auth = self.auth
-            if isinstance(auth, DirectCredentialProvider) and "tempauth=" not in entity.url:
-                graph_token = await self._get_graph_token()
-                auth = StaticTokenProvider(graph_token)
+            auth = await self._get_download_auth(entity.url)
 
             await files.download_from_url(
                 entity=entity,
@@ -613,35 +470,6 @@ class SharePointOnlineSource(BaseSource):
             async for entity in self._incremental_sync(cursor, files):
                 yield entity
 
-    async def _discover_sites(self, graph_client: GraphClient) -> List[Dict[str, Any]]:
-        """Discover sites to sync based on config.
-
-        When site_url is set: resolve the specific site.
-        When empty: use getAllSites for complete enumeration (app permissions).
-        """
-        sites = []
-
-        if self._site_url:
-            parsed = urlparse(self._site_url)
-            hostname = parsed.netloc
-            site_path = parsed.path.lstrip("/")
-            try:
-                site = await graph_client.get_site_by_url(hostname, site_path)
-                sites.append(site)
-            except SourceAuthError:
-                raise
-            except Exception as e:
-                self.logger.warning(f"Could not resolve site URL {self._site_url}: {e}")
-                raise
-        else:
-            async for site in graph_client.get_all_sites():
-                if not self._include_personal_sites and site.get("isPersonalSite", False):
-                    continue
-                sites.append(site)
-
-        self.logger.info(f"Discovered {len(sites)} sites to sync")
-        return sites
-
     async def _resolve_unresolved_viewers(
         self, entity: BaseEntity, graph_client: GraphClient
     ) -> None:
@@ -668,11 +496,7 @@ class SharePointOnlineSource(BaseSource):
         entity.access.viewers = new_viewers
 
     async def _fetch_sp_group_viewers(self) -> List[str]:
-        """Fetch all SP site groups and return their viewer strings.
-
-        Uses the shared http_client with SP-scoped token headers.
-        Returns empty list if SP token is unavailable.
-        """
+        """Fetch all SP site groups and return their viewer strings."""
         sp_token_provider = self._make_sp_token_provider()
         if not sp_token_provider or not self._site_url:
             return []
@@ -1246,10 +1070,7 @@ class SharePointOnlineSource(BaseSource):
                 yield membership
 
     async def _expand_sp_site_groups(self) -> AsyncGenerator[MembershipTuple, None]:
-        """Expand tracked SP site groups into user memberships.
-
-        Uses the shared http_client with SP-scoped token headers.
-        """
+        """Expand tracked SP site groups into user memberships."""
         sp_group_names = list(self._item_level_sp_groups)
         if not sp_group_names or not self._site_url:
             return
@@ -1318,3 +1139,348 @@ class SharePointOnlineSource(BaseSource):
 
         group_expander.log_stats()
         self.logger.info(f"Access control extraction complete: {membership_count} memberships")
+
+
+# =============================================================================
+# OAuth source — delegated user auth
+# =============================================================================
+
+
+@source(
+    name="SharePoint Online",
+    short_name="sharepoint_online",
+    auth_methods=[
+        AuthenticationMethod.OAUTH_BROWSER,
+        AuthenticationMethod.OAUTH_TOKEN,
+        AuthenticationMethod.AUTH_PROVIDER,
+    ],
+    oauth_type=OAuthType.WITH_ROTATING_REFRESH,
+    auth_config_class=None,
+    config_class=SharePointOnlineConfig,
+    supports_continuous=True,
+    cursor_class=SharePointOnlineCursor,
+    supports_access_control=True,
+    supports_browse_tree=True,
+    feature_flag="sharepoint_2019_v2",
+    labels=["Collaboration", "File Storage"],
+)
+class SharePointOnlineSource(SharePointOnlineBase):
+    """SharePoint Online source using delegated OAuth.
+
+    Uses the signed-in user's permissions via OAuth browser flow.
+    Site discovery uses Graph search (delegated permissions).
+    """
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        auth: TokenProviderProtocol,
+        logger: ContextualLogger,
+        http_client: AirweaveHttpClient,
+        config: SharePointOnlineConfig,
+    ) -> SharePointOnlineSource:
+        """Create and configure an OAuth SharePoint Online source."""
+        instance = cls(auth=auth, logger=logger, http_client=http_client)
+        instance._init_common(config)
+        return instance
+
+    async def _get_access_token(self) -> str:
+        return await self.auth.get_token()
+
+    async def _handle_401(self) -> str:
+        if self.auth.supports_refresh:
+            return await self.auth.force_refresh()
+        return await self.auth.get_token()
+
+    def _make_sp_token_provider(self) -> Optional[Callable]:
+        """Create SP token provider via OAuth scope exchange."""
+        sp_scope = self._derive_sp_resource_scope()
+        if not sp_scope:
+            return None
+
+        async def _provider() -> str:
+            token = await self.get_token_for_resource(sp_scope)
+            if not token:
+                raise RuntimeError(f"Could not obtain SharePoint token for scope {sp_scope}")
+            return token
+
+        return _provider
+
+    def _derive_sp_resource_scope(self) -> Optional[str]:
+        """Derive the SharePoint resource scope from the site URL.
+
+        E.g. https://neenacorp.sharepoint.com/sites/JAman
+             -> https://neenacorp.sharepoint.com/.default
+        """
+        if not self._site_url:
+            return None
+        parsed = urlparse(self._site_url)
+        if not parsed.netloc:
+            return None
+        return f"https://{parsed.netloc}/.default"
+
+    async def _discover_sites(self, graph_client: GraphClient) -> List[Dict[str, Any]]:
+        """Discover sites via Graph search (delegated permissions).
+
+        Supports:
+          - Single URL: "https://tenant.sharepoint.com/sites/MySite"
+          - Comma-separated: "https://tenant.sharepoint.com/sites/A, .../sites/B"
+          - Empty string: search all accessible sites
+        """
+        sites = []
+
+        if self._site_url:
+            urls = [u.strip() for u in self._site_url.split(",") if u.strip()]
+            for url in urls:
+                parsed = urlparse(url)
+                hostname = parsed.netloc
+                site_path = parsed.path.lstrip("/")
+                try:
+                    site = await graph_client.get_site_by_url(hostname, site_path)
+                    sites.append(site)
+                except SourceAuthError:
+                    raise
+                except Exception as e:
+                    self.logger.warning(f"Could not resolve site URL {url}: {e}")
+                    raise
+        else:
+            async for site in graph_client.search_sites("*"):
+                if not self._include_personal_sites and site.get("isPersonalSite", False):
+                    continue
+                sites.append(site)
+
+        self.logger.info(f"Discovered {len(sites)} sites to sync")
+        return sites
+
+
+# =============================================================================
+# Client credentials source — app-only auth
+# =============================================================================
+
+
+@source(
+    name="SharePoint Online (App)",
+    short_name="sharepoint_online_app",
+    auth_methods=[AuthenticationMethod.DIRECT],
+    auth_config_class=SharePointOnlineAppAuthConfig,
+    config_class=SharePointOnlineConfig,
+    supports_continuous=True,
+    cursor_class=SharePointOnlineCursor,
+    supports_access_control=True,
+    supports_browse_tree=True,
+    feature_flag="sharepoint_2019_v2",
+    labels=["Collaboration", "File Storage"],
+)
+class SharePointOnlineAppSource(SharePointOnlineBase):
+    """SharePoint Online source using client credentials (app-only auth).
+
+    Uses client_id + client_secret for Graph API and certificate-based
+    authentication for SharePoint REST API. Requires Azure AD app registration
+    with application permissions and admin consent.
+    """
+
+    _tenant_id: str
+    _client_id: str
+    _client_secret: str
+    _private_key: str
+    _certificate: str
+    _graph_token: Optional[str]
+    _graph_token_expires: float
+    _sp_tokens: Dict[str, tuple[str, float]]
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        auth: DirectCredentialProvider,
+        logger: ContextualLogger,
+        http_client: AirweaveHttpClient,
+        config: SharePointOnlineConfig,
+    ) -> SharePointOnlineAppSource:
+        """Create and configure a client-credentials SharePoint Online source."""
+        instance = cls(auth=auth, logger=logger, http_client=http_client)
+        instance._init_common(config)
+
+        creds: SharePointOnlineAppAuthConfig = auth.credentials
+        instance._tenant_id = creds.tenant_id
+        instance._client_id = creds.client_id
+        instance._client_secret = creds.client_secret
+        instance._private_key = creds.private_key
+        instance._certificate = creds.certificate
+
+        # Token cache
+        instance._graph_token = None
+        instance._graph_token_expires = 0.0
+        instance._sp_tokens = {}  # hostname -> (token, expires_at)
+
+        # Exchange for initial Graph token
+        instance._graph_token = await instance._exchange_graph_token()
+        instance._graph_token_expires = asyncio.get_event_loop().time() + 3500
+
+        return instance
+
+    # -- Token exchange (app-only mode) --
+
+    async def _exchange_graph_token(self) -> str:
+        """Exchange client credentials for a Microsoft Graph access token."""
+        url = f"https://login.microsoftonline.com/{self._tenant_id}/oauth2/v2.0/token"
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                    "scope": "https://graph.microsoft.com/.default",
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            self.logger.info(f"App-only Graph token obtained (expires_in={data.get('expires_in')})")
+            return str(data["access_token"])
+
+    async def _exchange_sp_token_with_certificate(self, hostname: str) -> str:
+        """Exchange certificate credentials for a SharePoint REST API access token."""
+        import base64
+        import hashlib
+        import time as _time
+
+        import jwt as pyjwt
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+        from cryptography.x509 import load_pem_x509_certificate
+
+        token_url = f"https://login.microsoftonline.com/{self._tenant_id}/oauth2/v2.0/token"
+
+        loaded_key = serialization.load_pem_private_key(self._private_key.encode(), password=None)
+        if not isinstance(loaded_key, RSAPrivateKey):
+            raise ValueError("SharePoint certificate auth requires an RSA private key")
+        private_key: RSAPrivateKey = loaded_key
+
+        if not self._certificate:
+            raise ValueError(
+                "Certificate PEM is required for SP REST API token exchange. "
+                "Provide the PEM certificate that was uploaded to the Azure AD app registration."
+            )
+
+        cert = load_pem_x509_certificate(self._certificate.encode())
+        cert_der = cert.public_bytes(serialization.Encoding.DER)
+        cert_hash = hashlib.sha1(cert_der).digest()  # noqa: S324
+        x5t = base64.urlsafe_b64encode(cert_hash).rstrip(b"=").decode()
+
+        now = int(_time.time())
+        assertion = pyjwt.encode(
+            {
+                "aud": token_url,
+                "iss": self._client_id,
+                "sub": self._client_id,
+                "jti": str(now),
+                "nbf": now,
+                "exp": now + 600,
+            },
+            private_key,
+            algorithm="RS256",
+            headers={"x5t": x5t},
+        )
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                token_url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self._client_id,
+                    "client_assertion_type": (
+                        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                    ),
+                    "client_assertion": assertion,
+                    "scope": f"https://{hostname}/.default",
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            self.logger.info(
+                f"App-only SP token for {hostname} obtained (expires_in={data.get('expires_in')})"
+            )
+            return str(data["access_token"])
+
+    async def _get_sp_token(self, hostname: str) -> str:
+        """Get a valid SP REST API token for a hostname, re-exchanging if expired."""
+        now = asyncio.get_event_loop().time()
+        cached = self._sp_tokens.get(hostname)
+        if cached:
+            token, expires_at = cached
+            if now < expires_at:
+                return token
+        token = await self._exchange_sp_token_with_certificate(hostname)
+        self._sp_tokens[hostname] = (token, now + 3500)
+        return token
+
+    # -- Auth hooks --
+
+    async def _get_access_token(self) -> str:
+        now = asyncio.get_event_loop().time()
+        if self._graph_token and now < self._graph_token_expires:
+            return self._graph_token
+        self._graph_token = await self._exchange_graph_token()
+        self._graph_token_expires = now + 3500  # ~58 min
+        return self._graph_token
+
+    async def _handle_401(self) -> str:
+        self._graph_token_expires = 0  # force re-exchange
+        return await self._get_access_token()
+
+    def _make_sp_token_provider(self) -> Optional[Callable]:
+        """Create SP token provider via certificate exchange."""
+        hostname = self._derive_sp_hostname()
+        if not hostname:
+            return None
+
+        async def _provider() -> str:
+            return await self._get_sp_token(hostname)
+
+        return _provider
+
+    @property
+    def _delta_prefer_headers(self) -> List[str]:
+        return [
+            "deltashowsharingchanges",
+            "deltashowremovedasdeleted",
+            "deltatraversepermissiongaps",
+        ]
+
+    async def _get_download_auth(self, url: str) -> Any:
+        """For client-credentials auth, use StaticTokenProvider for Graph URLs."""
+        if "tempauth=" in url:
+            return self.auth  # pre-signed URL, no auth needed
+        graph_token = await self._get_access_token()
+        return StaticTokenProvider(graph_token)
+
+    async def _discover_sites(self, graph_client: GraphClient) -> List[Dict[str, Any]]:
+        """Discover sites via getAllSites (application permissions).
+
+        When site_url is set: resolve the specific site.
+        When empty: use getAllSites for complete enumeration.
+        """
+        sites = []
+
+        if self._site_url:
+            parsed = urlparse(self._site_url)
+            hostname = parsed.netloc
+            site_path = parsed.path.lstrip("/")
+            try:
+                site = await graph_client.get_site_by_url(hostname, site_path)
+                sites.append(site)
+            except SourceAuthError:
+                raise
+            except Exception as e:
+                self.logger.warning(f"Could not resolve site URL {self._site_url}: {e}")
+                raise
+        else:
+            async for site in graph_client.get_all_sites():
+                if not self._include_personal_sites and site.get("isPersonalSite", False):
+                    continue
+                sites.append(site)
+
+        self.logger.info(f"Discovered {len(sites)} sites to sync")
+        return sites

--- a/backend/airweave/platform/sources/sharepoint_online/source.py
+++ b/backend/airweave/platform/sources/sharepoint_online/source.py
@@ -597,6 +597,7 @@ class SharePointOnlineSource(BaseSource):
 
             try:
                 site_entity = await build_site_entity(site_data, [], access=site_access)
+                self._track_entity_groups(site_entity)
                 yield site_entity
                 entity_count += 1
 
@@ -629,6 +630,7 @@ class SharePointOnlineSource(BaseSource):
                     drive_entity = await build_drive_entity(
                         drive_data, site_id, site_breadcrumbs, access=drive_access
                     )
+                    self._track_entity_groups(drive_entity)
                     yield drive_entity
                     entity_count += 1
 
@@ -728,6 +730,7 @@ class SharePointOnlineSource(BaseSource):
                             page_entity = await build_page_entity(
                                 page_data, site_id, site_breadcrumbs, access=site_access
                             )
+                            self._track_entity_groups(page_entity)
                             yield page_entity
                             entity_count += 1
                         except EntityProcessingError as e:
@@ -890,6 +893,7 @@ class SharePointOnlineSource(BaseSource):
                     break
 
                 site_entity = await build_site_entity(site_data, [], access=targeted_site_access)
+                self._track_entity_groups(site_entity)
                 yield site_entity
                 entity_count += 1
             except SourceAuthError:
@@ -988,6 +992,7 @@ class SharePointOnlineSource(BaseSource):
             drive_entity = await build_drive_entity(
                 drive_data, site_id, site_breadcrumbs, access=drive_access
             )
+            self._track_entity_groups(drive_entity)
             yield drive_entity
 
             drive_breadcrumbs = site_breadcrumbs + [

--- a/backend/airweave/platform/sources/sharepoint_online/source.py
+++ b/backend/airweave/platform/sources/sharepoint_online/source.py
@@ -34,11 +34,12 @@ from airweave.core.logging import ContextualLogger
 from airweave.domains.access_control.schemas import MembershipTuple
 from airweave.domains.browse_tree.types import BrowseNode, NodeSelectionData
 from airweave.domains.sources.exceptions import SourceAuthError
-from airweave.domains.sources.token_providers.protocol import TokenProviderProtocol
+from airweave.domains.sources.token_providers.credential import DirectCredentialProvider
 from airweave.domains.storage import FileSkippedException
 from airweave.domains.storage.file_service import FileService
 from airweave.domains.sync_pipeline.exceptions import EntityProcessingError
 from airweave.domains.syncs.cursors.cursor import SyncCursor
+from airweave.platform.configs.auth import SharePointOnlineAppAuthConfig
 from airweave.platform.configs.config import SharePointOnlineConfig
 from airweave.platform.cursors.sharepoint_online import SharePointOnlineCursor
 from airweave.platform.decorators import source
@@ -62,7 +63,7 @@ from airweave.platform.sources.sharepoint_online.builders import (
 )
 from airweave.platform.sources.sharepoint_online.client import GRAPH_BASE_URL, GraphClient
 from airweave.platform.sources.sharepoint_online.graph_groups import EntraGroupExpander
-from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
+from airweave.schemas.source_connection import AuthenticationMethod
 
 MAX_CONCURRENT_FILE_DOWNLOADS = 10
 ITEM_BATCH_SIZE = 50
@@ -80,13 +81,8 @@ class PendingFileDownload:
 @source(
     name="SharePoint Online",
     short_name="sharepoint_online",
-    auth_methods=[
-        AuthenticationMethod.OAUTH_BROWSER,
-        AuthenticationMethod.OAUTH_TOKEN,
-        AuthenticationMethod.AUTH_PROVIDER,
-    ],
-    oauth_type=OAuthType.WITH_ROTATING_REFRESH,
-    auth_config_class=None,
+    auth_methods=[AuthenticationMethod.DIRECT],
+    auth_config_class=SharePointOnlineAppAuthConfig,
     config_class=SharePointOnlineConfig,
     supports_continuous=True,
     cursor_class=SharePointOnlineCursor,
@@ -106,7 +102,7 @@ class SharePointOnlineSource(BaseSource):
     async def create(
         cls,
         *,
-        auth: TokenProviderProtocol,
+        auth: DirectCredentialProvider,
         logger: ContextualLogger,
         http_client: AirweaveHttpClient,
         config: SharePointOnlineConfig,
@@ -118,11 +114,144 @@ class SharePointOnlineSource(BaseSource):
         instance._include_pages = config.include_pages
         instance._item_level_entra_groups: set = set()
         instance._item_level_sp_groups: set = set()
+
+        creds: SharePointOnlineAppAuthConfig = auth.credentials
+        instance._tenant_id = creds.tenant_id
+        instance._client_id = creds.client_id
+        instance._client_secret = creds.client_secret
+        instance._private_key = creds.private_key
+
+        # Token cache
+        instance._graph_token: Optional[str] = None
+        instance._graph_token_expires: float = 0.0
+        instance._sp_tokens: Dict[str, tuple] = {}  # hostname -> (token, expires_at)
+
+        # Exchange for initial Graph token
+        instance._graph_token = await instance._exchange_graph_token()
+        instance._graph_token_expires = asyncio.get_event_loop().time() + 3500
+
         return instance
+
+    # -- Token exchange (app-only mode) --
+
+    async def _exchange_graph_token(self) -> str:
+        """Exchange client credentials for a Microsoft Graph access token."""
+        url = f"https://login.microsoftonline.com/{self._tenant_id}/oauth2/v2.0/token"
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                    "scope": "https://graph.microsoft.com/.default",
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            self.logger.info(f"App-only Graph token obtained (expires_in={data.get('expires_in')})")
+            return data["access_token"]
+
+    async def _exchange_sp_token_with_certificate(self, hostname: str) -> str:
+        """Exchange certificate credentials for a SharePoint REST API access token."""
+        import base64
+        import datetime
+        import hashlib
+        import time as _time
+
+        import jwt as pyjwt
+        from cryptography import x509
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.hashes import SHA256
+        from cryptography.x509.oid import NameOID
+
+        token_url = f"https://login.microsoftonline.com/{self._tenant_id}/oauth2/v2.0/token"
+
+        private_key = serialization.load_pem_private_key(self._private_key.encode(), password=None)
+        # Derive x5t from the certificate (we need to get the cert from the private key)
+        # Since we only have the private key, derive x5t from it
+        # Actually, Microsoft needs the certificate thumbprint. We'll compute it from
+        # the private key's public key — but the x5t should match the uploaded cert.
+        # For self-signed certs, we can generate a temporary cert from the key.
+        # Simpler: just use the private key to sign, Azure AD matches by key ID.
+
+        # Generate a self-signed cert from the private key for x5t computation
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "airweave")])
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.utcnow())
+            .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=365))
+            .sign(private_key, SHA256())
+        )
+        cert_der = cert.public_bytes(serialization.Encoding.DER)
+        cert_hash = hashlib.sha1(cert_der).digest()
+        x5t = base64.urlsafe_b64encode(cert_hash).rstrip(b"=").decode()
+
+        now = int(_time.time())
+        assertion = pyjwt.encode(
+            {
+                "aud": token_url,
+                "iss": self._client_id,
+                "sub": self._client_id,
+                "jti": str(now),
+                "nbf": now,
+                "exp": now + 600,
+            },
+            private_key,
+            algorithm="RS256",
+            headers={"x5t": x5t},
+        )
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                token_url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self._client_id,
+                    "client_assertion_type": (
+                        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                    ),
+                    "client_assertion": assertion,
+                    "scope": f"https://{hostname}/.default",
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            self.logger.info(
+                f"App-only SP token for {hostname} obtained (expires_in={data.get('expires_in')})"
+            )
+            return data["access_token"]
+
+    async def _get_graph_token(self) -> str:
+        """Get a valid Graph token, re-exchanging if expired."""
+        now = asyncio.get_event_loop().time()
+        if self._graph_token and now < self._graph_token_expires:
+            return self._graph_token
+        self._graph_token = await self._exchange_graph_token()
+        self._graph_token_expires = now + 3500  # ~58 min
+        return self._graph_token
+
+    async def _get_sp_token(self, hostname: str) -> str:
+        """Get a valid SP REST API token for a hostname, re-exchanging if expired."""
+        now = asyncio.get_event_loop().time()
+        cached = self._sp_tokens.get(hostname)
+        if cached:
+            token, expires_at = cached
+            if now < expires_at:
+                return token
+        token = await self._exchange_sp_token_with_certificate(hostname)
+        self._sp_tokens[hostname] = (token, now + 3500)
+        return token
+
+    # -- Client factory --
 
     def _create_graph_client(self) -> GraphClient:
         return GraphClient(
-            access_token_provider=self.auth.get_token,
+            access_token_provider=self._get_graph_token,
             http_client=self.http_client,
             logger=self.logger,
         )
@@ -135,13 +264,14 @@ class SharePointOnlineSource(BaseSource):
     )
     async def _get(self, url: str, params: Optional[Dict] = None) -> Dict[str, Any]:
         """Make an authenticated GET request to Microsoft Graph API."""
-        token = await self.auth.get_token()
+        token = await self._get_graph_token()
         headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
         response = await self.http_client.get(url, headers=headers, params=params)
 
-        if response.status_code == 401 and self.auth.supports_refresh:
-            self.logger.warning("Received 401 from Microsoft Graph API — refreshing token")
-            new_token = await self.auth.force_refresh()
+        if response.status_code == 401:
+            self.logger.warning("Received 401 — re-exchanging token")
+            self._graph_token_expires = 0  # force re-exchange
+            new_token = await self._get_graph_token()
             headers = {"Authorization": f"Bearer {new_token}", "Accept": "application/json"}
             response = await self.http_client.get(url, headers=headers, params=params)
 
@@ -154,40 +284,40 @@ class SharePointOnlineSource(BaseSource):
 
     def _create_group_expander(self) -> EntraGroupExpander:
         return EntraGroupExpander(
-            access_token_provider=self.auth.get_token,
+            access_token_provider=self._get_graph_token,
             http_client=self.http_client,
             logger=self.logger,
         )
 
-    def _derive_sp_resource_scope(self) -> Optional[str]:
-        """Derive the SharePoint resource scope from the site URL.
-
-        E.g. https://neenacorp.sharepoint.com/sites/JAman
-             -> https://neenacorp.sharepoint.com/.default
-        """
+    def _derive_sp_hostname(self) -> Optional[str]:
+        """Derive the SharePoint hostname from the site URL."""
         if not self._site_url:
             return None
         parsed = urlparse(self._site_url)
-        if not parsed.netloc:
-            return None
-        return f"https://{parsed.netloc}/.default"
+        return parsed.netloc or None
 
     def _make_sp_token_provider(self) -> Optional[Callable]:
         """Create an async callable that returns a SharePoint-scoped token.
 
-        Returns None if the site URL is not set or no token manager is available.
+        Returns None if the site URL is not set.
         """
-        sp_scope = self._derive_sp_resource_scope()
-        if not sp_scope:
+        hostname = self._derive_sp_hostname()
+        if not hostname:
             return None
 
         async def _provider() -> str:
-            token = await self.get_token_for_resource(sp_scope)
-            if not token:
-                raise RuntimeError(f"Could not obtain SharePoint token for scope {sp_scope}")
-            return token
+            return await self._get_sp_token(hostname)
 
         return _provider
+
+    @property
+    def _delta_prefer_headers(self) -> List[str]:
+        """Prefer headers for delta queries (permission change tracking)."""
+        return [
+            "deltashowsharingchanges",
+            "deltashowremovedasdeleted",
+            "deltatraversepermissiongaps",
+        ]
 
     def _track_entity_groups(self, entity: BaseEntity) -> None:
         """Track Entra ID and SP site groups found in entity permissions."""
@@ -473,29 +603,25 @@ class SharePointOnlineSource(BaseSource):
     async def _discover_sites(self, graph_client: GraphClient) -> List[Dict[str, Any]]:
         """Discover sites to sync based on config.
 
-        Supports:
-          - Single URL: "https://tenant.sharepoint.com/sites/MySite"
-          - Comma-separated: "https://tenant.sharepoint.com/sites/A, .../sites/B"
-          - Empty string: discover all accessible sites
+        When site_url is set: resolve the specific site.
+        When empty: use getAllSites for complete enumeration (app permissions).
         """
         sites = []
 
         if self._site_url:
-            urls = [u.strip() for u in self._site_url.split(",") if u.strip()]
-            for url in urls:
-                parsed = urlparse(url)
-                hostname = parsed.netloc
-                site_path = parsed.path.lstrip("/")
-                try:
-                    site = await graph_client.get_site_by_url(hostname, site_path)
-                    sites.append(site)
-                except SourceAuthError:
-                    raise
-                except Exception as e:
-                    self.logger.warning(f"Could not resolve site URL {url}: {e}")
-                    raise
+            parsed = urlparse(self._site_url)
+            hostname = parsed.netloc
+            site_path = parsed.path.lstrip("/")
+            try:
+                site = await graph_client.get_site_by_url(hostname, site_path)
+                sites.append(site)
+            except SourceAuthError:
+                raise
+            except Exception as e:
+                self.logger.warning(f"Could not resolve site URL {self._site_url}: {e}")
+                raise
         else:
-            async for site in graph_client.search_sites("*"):
+            async for site in graph_client.get_all_sites():
                 if not self._include_personal_sites and site.get("isPersonalSite", False):
                     continue
                 sites.append(site)
@@ -702,7 +828,9 @@ class SharePointOnlineSource(BaseSource):
 
                     if cursor:
                         try:
-                            _, delta_token = await graph_client.get_drive_delta(drive_id)
+                            _, delta_token = await graph_client.get_drive_delta(
+                                drive_id, prefer_headers=self._delta_prefer_headers
+                            )
                             if delta_token:
                                 cursor_schema = SharePointOnlineCursor(**cursor.data)
                                 cursor_schema.update_entity_cursor(
@@ -776,7 +904,9 @@ class SharePointOnlineSource(BaseSource):
 
         for drive_id, token in delta_tokens.items():
             try:
-                changed_items, new_token = await graph_client.get_drive_delta(drive_id, token)
+                changed_items, new_token = await graph_client.get_drive_delta(
+                    drive_id, token, prefer_headers=self._delta_prefer_headers
+                )
             except SourceAuthError:
                 raise
             except Exception as e:

--- a/backend/airweave/platform/sources/sharepoint_online/source.py
+++ b/backend/airweave/platform/sources/sharepoint_online/source.py
@@ -35,6 +35,7 @@ from airweave.domains.access_control.schemas import MembershipTuple
 from airweave.domains.browse_tree.types import BrowseNode, NodeSelectionData
 from airweave.domains.sources.exceptions import SourceAuthError
 from airweave.domains.sources.token_providers.credential import DirectCredentialProvider
+from airweave.domains.sources.token_providers.static import StaticTokenProvider
 from airweave.domains.storage import FileSkippedException
 from airweave.domains.storage.file_service import FileService
 from airweave.domains.sync_pipeline.exceptions import EntityProcessingError
@@ -512,10 +513,20 @@ class SharePointOnlineSource(BaseSource):
                 entity.url = (
                     f"https://graph.microsoft.com/v1.0/drives/{drive_id}/items/{item_id}/content"
                 )
+
+            # For client-credentials auth, the download URL is either a pre-signed
+            # tempauth URL (no auth header needed) or a Graph API content URL
+            # (needs Graph bearer token). DirectCredentialProvider has no get_token(),
+            # so we provide a StaticTokenProvider with the Graph token as fallback.
+            auth = self.auth
+            if isinstance(auth, DirectCredentialProvider) and "tempauth=" not in entity.url:
+                graph_token = await self._get_graph_token()
+                auth = StaticTokenProvider(graph_token)
+
             await files.download_from_url(
                 entity=entity,
                 client=self.http_client,
-                auth=self.auth,
+                auth=auth,
                 logger=self.logger,
             )
             return entity
@@ -547,6 +558,8 @@ class SharePointOnlineSource(BaseSource):
                     self.logger.debug(f"File download skipped for {item.drive_id}/{item.item_id}")
                 except EntityProcessingError as e:
                     self.logger.warning(f"Skipping file download: {e}")
+                except Exception as e:
+                    self.logger.warning(f"Unexpected error downloading {item.entity.name}: {e}")
 
         tasks = [asyncio.create_task(download_one(p)) for p in pending]
         await asyncio.gather(*tasks, return_exceptions=True)
@@ -819,6 +832,8 @@ class SharePointOnlineSource(BaseSource):
 
                             except EntityProcessingError as e:
                                 self.logger.warning(f"Skipping file: {e}")
+                            except Exception as e:
+                                self.logger.warning(f"Unexpected error processing file: {e}")
 
                     if pending_files and files:
                         downloaded = await self._download_files_parallel(pending_files, files)

--- a/backend/airweave/platform/sources/sharepoint_online/source.py
+++ b/backend/airweave/platform/sources/sharepoint_online/source.py
@@ -53,6 +53,7 @@ from airweave.platform.sources.retry_helpers import (
     retry_if_rate_limit_or_timeout,
     wait_rate_limit_with_backoff,
 )
+from airweave.platform.sources.sharepoint_online.acl import extract_access_control
 from airweave.platform.sources.sharepoint_online.builders import (
     build_drive_entity,
     build_file_entity,
@@ -578,8 +579,24 @@ class SharePointOnlineSource(BaseSource):
         for site_data in sites:
             site_id = site_data.get("id", "")
 
+            # Collect all drives for this site (single API call)
+            all_drives = []
+            async for drive_data in graph_client.get_drives(site_id):
+                all_drives.append(drive_data)
+
+            # Fetch site-level permissions from the first drive's root.
+            site_access = None
+            if all_drives:
+                try:
+                    site_permissions = await graph_client.get_drive_root_permissions(
+                        all_drives[0]["id"]
+                    )
+                    site_access = await extract_access_control(site_permissions)
+                except Exception as e:
+                    self.logger.warning(f"Could not fetch site-level permissions: {e}")
+
             try:
-                site_entity = await build_site_entity(site_data, [])
+                site_entity = await build_site_entity(site_data, [], access=site_access)
                 yield site_entity
                 entity_count += 1
 
@@ -595,10 +612,23 @@ class SharePointOnlineSource(BaseSource):
 
             sp_group_viewers = await self._fetch_sp_group_viewers()
 
-            async for drive_data in graph_client.get_drives(site_id):
+            for drive_data in all_drives:
                 drive_id = drive_data.get("id", "")
                 try:
-                    drive_entity = await build_drive_entity(drive_data, site_id, site_breadcrumbs)
+                    # Each drive gets its own root permissions
+                    drive_access = site_access
+                    if drive_id != all_drives[0]["id"]:
+                        try:
+                            drive_permissions = await graph_client.get_drive_root_permissions(
+                                drive_id
+                            )
+                            drive_access = await extract_access_control(drive_permissions)
+                        except Exception:
+                            pass  # Fall back to site_access
+
+                    drive_entity = await build_drive_entity(
+                        drive_data, site_id, site_breadcrumbs, access=drive_access
+                    )
                     yield drive_entity
                     entity_count += 1
 
@@ -696,7 +726,7 @@ class SharePointOnlineSource(BaseSource):
                     async for page_data in graph_client.get_pages(site_id):
                         try:
                             page_entity = await build_page_entity(
-                                page_data, site_id, site_breadcrumbs
+                                page_data, site_id, site_breadcrumbs, access=site_access
                             )
                             yield page_entity
                             entity_count += 1
@@ -848,7 +878,18 @@ class SharePointOnlineSource(BaseSource):
 
             try:
                 site_data = await graph_client.get_site(site_id)
-                site_entity = await build_site_entity(site_data, [])
+
+                # Fetch site-level permissions from first drive root
+                targeted_site_access = None
+                async for peek_drive in graph_client.get_drives(site_id):
+                    try:
+                        perms = await graph_client.get_drive_root_permissions(peek_drive["id"])
+                        targeted_site_access = await extract_access_control(perms)
+                    except Exception:
+                        pass
+                    break
+
+                site_entity = await build_site_entity(site_data, [], access=targeted_site_access)
                 yield site_entity
                 entity_count += 1
             except SourceAuthError:
@@ -935,7 +976,18 @@ class SharePointOnlineSource(BaseSource):
         """Sync all files in a single drive (used by both full and targeted sync)."""
         try:
             drive_data = await graph_client.get_drive(drive_id)
-            drive_entity = await build_drive_entity(drive_data, site_id, site_breadcrumbs)
+
+            # Fetch drive root permissions for the drive entity
+            drive_access = None
+            try:
+                drive_permissions = await graph_client.get_drive_root_permissions(drive_id)
+                drive_access = await extract_access_control(drive_permissions)
+            except Exception:
+                pass
+
+            drive_entity = await build_drive_entity(
+                drive_data, site_id, site_breadcrumbs, access=drive_access
+            )
             yield drive_entity
 
             drive_breadcrumbs = site_breadcrumbs + [

--- a/backend/tests/unit/platform/configs/test_config_ssrf.py
+++ b/backend/tests/unit/platform/configs/test_config_ssrf.py
@@ -221,13 +221,13 @@ class TestSharePointOnlineConfig:
         with pytest.raises(ValidationError, match="SSRF|blocked"):
             SharePointOnlineConfig(site_url="http://127.0.0.1")
 
-    def test_empty_site_url_rejected(self):
-        with pytest.raises(ValidationError):
-            SharePointOnlineConfig(site_url="")
+    def test_empty_site_url_passes(self):
+        cfg = SharePointOnlineConfig(site_url="")
+        assert cfg.site_url == ""
 
-    def test_missing_site_url_rejected(self):
-        with pytest.raises(ValidationError):
-            SharePointOnlineConfig()
+    def test_missing_site_url_defaults_empty(self):
+        cfg = SharePointOnlineConfig()
+        assert cfg.site_url == ""
 
     def test_accepts_valid_site_url(self):
         cfg = SharePointOnlineConfig(

--- a/backend/tests/unit/platform/configs/test_config_ssrf.py
+++ b/backend/tests/unit/platform/configs/test_config_ssrf.py
@@ -217,21 +217,23 @@ class TestSharePoint2019V2Config:
 
 
 class TestSharePointOnlineConfig:
-    def test_rejects_loopback_in_csv(self):
+    def test_rejects_loopback(self):
         with pytest.raises(ValidationError, match="SSRF|blocked"):
-            SharePointOnlineConfig(
-                site_url="https://ok.sharepoint.com, http://127.0.0.1"
-            )
+            SharePointOnlineConfig(site_url="http://127.0.0.1")
 
-    def test_empty_site_url_passes(self):
-        cfg = SharePointOnlineConfig(site_url="")
-        assert cfg.site_url == ""
+    def test_empty_site_url_rejected(self):
+        with pytest.raises(ValidationError):
+            SharePointOnlineConfig(site_url="")
 
-    def test_accepts_valid_csv(self):
+    def test_missing_site_url_rejected(self):
+        with pytest.raises(ValidationError):
+            SharePointOnlineConfig()
+
+    def test_accepts_valid_site_url(self):
         cfg = SharePointOnlineConfig(
-            site_url="https://a.sharepoint.com, https://b.sharepoint.com"
+            site_url="https://contoso.sharepoint.com/sites/Marketing"
         )
-        assert cfg.site_url == "https://a.sharepoint.com, https://b.sharepoint.com"
+        assert cfg.site_url == "https://contoso.sharepoint.com/sites/Marketing"
 
 
 class TestSalesforceConfig:


### PR DESCRIPTION
## Summary
- **Client credentials auth for SharePoint Online**: Switches from delegated OAuth to application-level `client_id`/`client_secret` + optional certificate for SP REST API, enabling headless/server-to-server syncs
- **ACL-filtered search (V2)**: Adds `user_principal` parameter to the search API so queries can be scoped to what a specific user is allowed to see, with Vespa YQL filtering on access control viewers + group memberships
- **File download fix**: `DirectCredentialProvider` has no `get_token()`, so `FileService` failed on every download. Now recognizes SharePoint `tempauth=` URLs as pre-signed and falls back to a Graph bearer token for Graph API content endpoints

## Key changes
- `backend/airweave/platform/sources/sharepoint_online/source.py` — Client credentials auth, SP site group tracking on all entity types, file download fix for `DirectCredentialProvider`
- `backend/airweave/platform/configs/auth.py` — New `SharePointOnlineAppAuthConfig` (tenant_id, client_id, client_secret, private_key)
- `backend/airweave/domains/search/executor.py` — ACL filtering in V2 search via Vespa YQL
- `backend/airweave/domains/storage/file_service.py` — Recognize `tempauth=` URLs as pre-signed

## Test results (ACL test suite against live SharePoint Online)
- **13/15** static ACL tests pass (0 data leakage, 2 too-restrictive)
- 2 failures are SP site group tests (TC-SG-001, TC-SG-002) — known issue: certificate thumbprint computation generates a new cert each call instead of using the uploaded cert, so SP REST API token exchange fails silently
- 18/18 file downloads succeed with client credentials auth

## Known issues
- SP site group expansion requires matching the uploaded certificate's thumbprint (`x5t`). Current code regenerates a self-signed cert per call → thumbprint mismatch. Fix: accept the PEM certificate alongside the private key.
- Incremental ACL tests require `Group.ReadWrite.All` admin consent (not granted in test tenant)

## Test plan
- [x] Full sync with client credentials — 18 files + 2 structural entities synced
- [x] ACL test suite — 13/15 pass, 0 data leakage
- [ ] Regression test with OAuth delegated auth (existing flow)
- [ ] SP site group expansion with correct certificate thumbprint


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds client-credentials auth for SharePoint Online with certificate-based SP REST tokens, ACL-filtered V2 search, and fixes for pre-signed/Graph file downloads. Splits the SharePoint connector into OAuth and App variants behind a shared base.

- New Features
  - SharePoint Online app-only auth: `DIRECT` with `SharePointOnlineAppAuthConfig` (`tenant_id`, `client_id`, `client_secret`, `private_key`, `certificate`). Exchanges Graph tokens via client credentials and SP REST tokens per hostname; tenant-wide discovery via getAllSites; delta supports permission-change Prefer headers.
  - Source split: Two connectors — `sharepoint_online` (OAuth, delegated) and `sharepoint_online_app` (client credentials), both using a shared base.
  - Access-aware indexing: Set access on site/drive/page (from drive root permissions), track Entra and SP groups, and fail-closed for AC sources without access data.
  - ACL search: Executor resolves principals via AccessBroker and applies a Vespa YQL ACL clause; federated results are ACL-filtered in-memory. Vector DB protocol and Vespa client accept `acl_principals`. Admin “search as user” endpoints: `/{readable_id}/search/{instant|classic|agentic}/as-user?user_principal=email`.
  - Token utilities: `OAuth2Service.exchange_token_for_scope()` and OAuth provider `get_token_for_resource()` for resource-scoped tokens.
  - File downloads: Treat `tempauth=` URLs as pre-signed and use a Graph bearer token for Graph content endpoints in app-only mode.

- Migration
  - Create new SharePoint connections using `DIRECT` + `SharePointOnlineAppAuthConfig` (include the PEM certificate). `site_url` may be empty to sync all sites or set to a single site URL. Run a full sync to populate ACL fields in Vespa.

<sup>Written for commit 94c3fbab6cfbb5ac47eb69e13f4d7faadc3fd03f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

