### PR TITLE
supply-chain attack on trivy action 0.34.2 - Update Trivy action to v0.35.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.component }}
 
       - name: Trivy image scan
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.2
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.component }}:${{ steps.meta.outputs.version }}
           format: sarif


### PR DESCRIPTION
trivy-action was the target of a supply-chain attack (CVE-2026-33634) just weeks ago where 76 version tags were force-pushed to malicious commits. The safe version is v0.35.0 (SHA 57a97c7).

based on the information available, the attack force-pushed tags 0.0.1 through 0.34.2 (**the version that Airweave is using**) to malicious commits, but v0.35.0 was not compromised because Aqua Security had already enabled immutable tags starting from that release.

Resolves #1752

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `aquasecurity/trivy-action` to v0.35.0 in the build workflow to avoid the recent supply-chain attack (CVE-2026-33634). We were using v0.34.2, which was among the compromised tags.

<sup>Written for commit 6048e748315d09c0d2e75be78efac7413cf864db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

