### PR TITLE
fix(docs): update connector links to use the correct documentation paths

### DIFF
--- a/fern/docs/pages/connectors/overview.mdx
+++ b/fern/docs/pages/connectors/overview.mdx
@@ -18,14 +18,14 @@ Airweave supports many different types of connectors across productivity tools, 
 ### Popular Connectors
 
 <CardGroup cols={4}>
-  <Card title="Slack" icon="fa-brands fa-slack" href="/connectors/slack" />
-  <Card title="GitHub" icon="fa-brands fa-github" href="/connectors/github" />
-  <Card title="Google Drive" icon="fa-brands fa-google-drive" href="/connectors/google_drive" />
-  <Card title="Salesforce" icon="fa-brands fa-salesforce" href="/connectors/salesforce" />
-  <Card title="Gmail" icon="fa-brands fa-google" href="/connectors/gmail" />
-  <Card title="HubSpot" icon="fa-brands fa-hubspot" href="/connectors/hubspot" />
-  <Card title="Dropbox" icon="fa-brands fa-dropbox" href="/connectors/dropbox" />
-  <Card title="Stripe" icon="fa-brands fa-stripe" href="/connectors/stripe" />
+  <Card title="Slack" icon="fa-brands fa-slack" href="/docs/connectors/slack" />
+  <Card title="GitHub" icon="fa-brands fa-github" href="/docs/connectors/github" />
+  <Card title="Google Drive" icon="fa-brands fa-google-drive" href="/docs/connectors/google_drive" />
+  <Card title="Salesforce" icon="fa-brands fa-salesforce" href="/docs/connectors/salesforce" />
+  <Card title="Gmail" icon="fa-brands fa-google" href="/docs/connectors/gmail" />
+  <Card title="HubSpot" icon="fa-brands fa-hubspot" href="/docs/connectors/hubspot" />
+  <Card title="Dropbox" icon="fa-brands fa-dropbox" href="/docs/connectors/dropbox" />
+  <Card title="Stripe" icon="fa-brands fa-stripe" href="/docs/connectors/stripe" />
 </CardGroup>
 
 ### All Connectors
@@ -33,57 +33,57 @@ Airweave supports many different types of connectors across productivity tools, 
 <Accordion title="Browse all connectors by category">
 
 ### Productivity & Collaboration
-- [Notion](/connectors/notion)
-- [Slack](/connectors/slack)
-- [Asana](/connectors/asana)
-- [Monday](/connectors/monday)
-- [Linear](/connectors/linear)
-- [Trello](/connectors/trello)
-- [Clickup](/connectors/clickup)
-- [Todoist](/connectors/todoist)
-- [Airtable](/connectors/airtable)
+- [Notion](/docs/connectors/notion)
+- [Slack](/docs/connectors/slack)
+- [Asana](/docs/connectors/asana)
+- [Monday](/docs/connectors/monday)
+- [Linear](/docs/connectors/linear)
+- [Trello](/docs/connectors/trello)
+- [Clickup](/docs/connectors/clickup)
+- [Todoist](/docs/connectors/todoist)
+- [Airtable](/docs/connectors/airtable)
 
 ### Cloud Storage & Documents
-- [Google Drive](/connectors/google_drive)
-- [Google Docs](/connectors/google_docs)
-- [Google Slides](/connectors/google_slides)
-- [Dropbox](/connectors/dropbox)
-- [OneDrive](/connectors/onedrive)
-- [Box](/connectors/box)
-- [SharePoint](/connectors/sharepoint)
-- [Word](/connectors/word)
-- [OneNote](/connectors/onenote)
+- [Google Drive](/docs/connectors/google_drive)
+- [Google Docs](/docs/connectors/google_docs)
+- [Google Slides](/docs/connectors/google_slides)
+- [Dropbox](/docs/connectors/dropbox)
+- [OneDrive](/docs/connectors/onedrive)
+- [Box](/docs/connectors/box)
+- [SharePoint](/docs/connectors/sharepoint)
+- [Word](/docs/connectors/word)
+- [OneNote](/docs/connectors/onenote)
 
 ### Developer Tools
-- [GitHub](/connectors/github)
-- [GitLab](/connectors/gitlab)
-- [Bitbucket](/connectors/bitbucket)
-- [Jira](/connectors/jira)
-- [Confluence](/connectors/confluence)
+- [GitHub](/docs/connectors/github)
+- [GitLab](/docs/connectors/gitlab)
+- [Bitbucket](/docs/connectors/bitbucket)
+- [Jira](/docs/connectors/jira)
+- [Confluence](/docs/connectors/confluence)
 
 ### CRM & Sales
-- [Salesforce](/connectors/salesforce)
-- [HubSpot](/connectors/hubspot)
-- [Pipedrive](/connectors/pipedrive)
-- [Attio](/connectors/attio)
-- [Zoho CRM](/connectors/zoho_crm)
+- [Salesforce](/docs/connectors/salesforce)
+- [HubSpot](/docs/connectors/hubspot)
+- [Pipedrive](/docs/connectors/pipedrive)
+- [Attio](/docs/connectors/attio)
+- [Zoho CRM](/docs/connectors/zoho_crm)
 
 ### Communication & Email
-- [Gmail](/connectors/gmail)
-- [Outlook Mail](/connectors/outlook_mail)
-- [Outlook Calendar](/connectors/outlook_calendar)
-- [Google Calendar](/connectors/google_calendar)
-- [Teams](/connectors/teams)
+- [Gmail](/docs/connectors/gmail)
+- [Outlook Mail](/docs/connectors/outlook_mail)
+- [Outlook Calendar](/docs/connectors/outlook_calendar)
+- [Google Calendar](/docs/connectors/google_calendar)
+- [Teams](/docs/connectors/teams)
 
 ### Support & Service
-- [Zendesk](/connectors/zendesk)
+- [Zendesk](/docs/connectors/zendesk)
 
 ### E-commerce & Payments
-- [Shopify](/connectors/shopify)
-- [Stripe](/connectors/stripe)
+- [Shopify](/docs/connectors/shopify)
+- [Stripe](/docs/connectors/stripe)
 
 ### Other
-- [Ctti](/connectors/ctti)
+- [Ctti](/docs/connectors/ctti)
 
 </Accordion>
 


### PR DESCRIPTION
Updated the links for various connectors in the overview documentation to point to the correct `/docs/connectors/` paths instead of the previous `/connectors/` paths. This change ensures that users can access the appropriate documentation for each connector.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed broken connector links in the connectors overview by switching from /connectors/... to /docs/connectors/... so users land on the right docs pages. Updated Popular Connectors cards and all category lists.

<sup>Written for commit 90fe115327ca8c3f62e91dc439188916b436c288. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

