### PR TITLE
chore: update Node.js version in GitHub Actions workflow from 18 to 20

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install Fern
         run: npm install -g fern-api


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump Node.js in the `fern-docs` GitHub Actions workflow from 18 to 20 to use the current LTS and avoid Node 18 deprecation warnings.

<sup>Written for commit c21ba64db98ca0520a312bc039fe2cdb224d2795. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

