### PR TITLE
fix(ci): use in-project venvs for mypy and import-linter jobs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -83,9 +83,17 @@ jobs:
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: 2.3.2
-          virtualenvs-create: false
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+      - name: Load cached venv
+        id: cached-mypy-deps
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ./backend/.venv
+          key: mypy-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        run: poetry install
+        if: steps.cached-mypy-deps.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction
       - name: Run mypy
         if: github.event_name == 'push'
         run: poetry run mypy --config-file pyproject.toml airweave/
@@ -116,8 +124,16 @@ jobs:
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: 2.3.2
-          virtualenvs-create: false
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+      - name: Load cached venv
+        id: cached-importlint-deps
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ./backend/.venv
+          key: lint-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install lint dependencies
+        if: steps.cached-importlint-deps.outputs.cache-hit != 'true'
         run: poetry install --only lint --no-interaction --no-root
       - name: Run import-linter
         run: poetry run lint-imports


### PR DESCRIPTION
## Summary
- mypy and import-linter CI jobs used `virtualenvs-create: false`, so `poetry run diff-quality` couldn't find the console script
- Switch all three jobs to the same pattern: in-project venv with caching

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `mypy` and `import-linter` CI jobs to in-project `poetry` virtualenvs with caching so `poetry run` finds console scripts like `diff-quality`. Aligns all three code-quality jobs to the same pattern and speeds up runs by caching `./backend/.venv` and installing only on cache misses.

<sup>Written for commit d62597079d56907a5448445b6b877b8e1d2538e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

