### PR TITLE
fix: cancel path for pending sync jobs

### DIFF
--- a/backend/airweave/domains/sync_pipeline/orchestrator.py
+++ b/backend/airweave/domains/sync_pipeline/orchestrator.py
@@ -23,7 +23,7 @@ from airweave.domains.sync_pipeline.stream import AsyncSourceStream
 from airweave.domains.sync_pipeline.worker_pool import AsyncWorkerPool
 from airweave.domains.syncs.cursors.service import SyncCursorService
 from airweave.domains.syncs.jobs.protocols import SyncJobStateMachineProtocol
-from airweave.domains.syncs.jobs.types import LifecycleData
+from airweave.domains.syncs.jobs.types import InvalidTransitionError, LifecycleData
 from airweave.domains.syncs.protocols import SyncStateMachineProtocol
 from airweave.domains.temporal.metrics import worker_metrics
 from airweave.domains.usage.exceptions import (
@@ -714,21 +714,49 @@ class SyncOrchestrator:
         """Centralized cancellation handler - explicit and immediate."""
         self.sync_context.logger.info("Handling cancellation...")
 
-        # 1. Cancel all pending tasks IMMEDIATELY
+        # Cancel all pending tasks immediately
         if self.worker_pool:
             await self.worker_pool.cancel_all()
 
-        # 2. Cancel stream to stop producer
+        # Cancel stream to stop producer
         await self.stream.cancel()
 
-        await self._state_machine.transition(
-            sync_job_id=self.sync_context.sync_job.id,
-            target=SyncJobStatus.CANCELLED,
-            ctx=self.sync_context,
-            lifecycle_data=self._lifecycle_data,
-        )
+        # Transition through CANCELLING → CANCELLED.
+        # RUNNING → CANCELLING is required by the state machine.
+        # If still PENDING (cancellation before _start_sync completed),
+        # PENDING → CANCELLING is invalid, so fall through to direct CANCELLED.
+        #
+        # The workflow will also attempt these transitions via
+        # TransitionSyncJobActivity once the CancelledError propagates.
+        # That redundancy is intentional — it guards against the activity
+        # being killed before the error reaches the workflow.
+        try:
+            await self._state_machine.transition(
+                sync_job_id=self.sync_context.sync_job.id,
+                target=SyncJobStatus.CANCELLING,
+                ctx=self.sync_context,
+                lifecycle_data=self._lifecycle_data,
+            )
+        except InvalidTransitionError as exc:
+            self.sync_context.logger.debug(
+                "Skipped CANCELLING transition",
+                current_state=exc.current.value,
+            )
 
-        # 4. Track sync cancelled
+        try:
+            await self._state_machine.transition(
+                sync_job_id=self.sync_context.sync_job.id,
+                target=SyncJobStatus.CANCELLED,
+                ctx=self.sync_context,
+                lifecycle_data=self._lifecycle_data,
+            )
+        except InvalidTransitionError as exc:
+            self.sync_context.logger.warning(
+                "Skipped CANCELLED transition — job in unexpected terminal state",
+                current_state=exc.current.value,
+            )
+
+        # Track sync cancelled
         if not self.sync_context.sync_job.started_at:
             # This can happen if cancellation occurs during _start_sync before
             # the job status is updated with started_at

--- a/backend/airweave/domains/sync_pipeline/tests/test_orchestrator_coverage.py
+++ b/backend/airweave/domains/sync_pipeline/tests/test_orchestrator_coverage.py
@@ -1,6 +1,5 @@
 """Coverage tests for SyncOrchestrator — missing state_machine.transition lines."""
 
-import asyncio
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
@@ -12,6 +11,7 @@ from airweave.core.shared_models import ConnectionStatus, IntegrationType, SyncJ
 from airweave.domains.sync_pipeline.contexts.sync import SyncContext
 from airweave.domains.sync_pipeline.orchestrator import SyncOrchestrator
 from airweave.domains.sync_pipeline.pipeline.entity_tracker import SyncStats
+from airweave.domains.syncs.jobs.types import InvalidTransitionError
 
 MODULE = "airweave.domains.sync_pipeline.orchestrator"
 
@@ -184,11 +184,37 @@ async def test_handle_sync_failure_calls_state_machine_transition():
 
 
 @pytest.mark.unit
-async def test_handle_cancellation_calls_state_machine_transition():
-    """_handle_cancellation calls state_machine.transition with CANCELLED."""
+async def test_handle_cancellation_transitions_through_cancelling():
+    """_handle_cancellation transitions RUNNING → CANCELLING → CANCELLED."""
     orch, sm = _make_orchestrator()
 
     with patch(f"{MODULE}.business_events"):
         await orch._handle_cancellation()
 
-    assert any(c["target"] == SyncJobStatus.CANCELLED for c in sm.calls)
+    targets = [c["target"] for c in sm.calls]
+    assert targets == [SyncJobStatus.CANCELLING, SyncJobStatus.CANCELLED]
+
+
+@pytest.mark.unit
+async def test_handle_cancellation_pending_falls_through_to_cancelled():
+    """When CANCELLING raises InvalidTransitionError (PENDING), go directly to CANCELLED."""
+
+    class PendingStateMachine:
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        async def transition(self, **kwargs):
+            self.calls.append(kwargs)
+            if kwargs["target"] == SyncJobStatus.CANCELLING:
+                raise InvalidTransitionError(
+                    SyncJobStatus.PENDING, SyncJobStatus.CANCELLING
+                )
+            return MagicMock(applied=True)
+
+    orch, sm = _make_orchestrator(state_machine=PendingStateMachine())
+
+    with patch(f"{MODULE}.business_events"):
+        await orch._handle_cancellation()
+
+    targets = [c["target"] for c in sm.calls]
+    assert targets == [SyncJobStatus.CANCELLING, SyncJobStatus.CANCELLED]

--- a/backend/airweave/domains/syncs/service.py
+++ b/backend/airweave/domains/syncs/service.py
@@ -284,10 +284,12 @@ class SyncService(SyncServiceProtocol):
         job_id: UUID,
         ctx: ApiContext,
     ) -> schemas.SyncJob:
-        """Cancel a running sync job.
+        """Cancel a pending or running sync job.
 
-        Transitions to CANCELLING, sends cancel to Temporal, and handles
-        edge cases (workflow not found, Temporal failure with one retry).
+        PENDING jobs are transitioned directly to CANCELLED (the CANCELLING
+        intermediate state is only valid from RUNNING). RUNNING jobs go
+        through CANCELLING and rely on the Temporal workflow for the final
+        CANCELLED transition.
         """
         sync_job = await self._sync_job_repo.get(db, job_id, ctx)
         if not sync_job:
@@ -299,6 +301,23 @@ class SyncService(SyncServiceProtocol):
                 detail=f"Cannot cancel job in {sync_job.status} state",
             )
 
+        if sync_job.status == SyncJobStatus.PENDING:
+            # PENDING → CANCELLED directly (PENDING → CANCELLING is invalid)
+            await self._job_state_machine.transition(
+                sync_job_id=job_id, target=SyncJobStatus.CANCELLED, ctx=ctx
+            )
+            # Best-effort workflow cleanup — workflow may not exist yet for
+            # PENDING jobs, but if it does we need to stop it.
+            cancel_result = await self._cancel_temporal_workflow_with_retry(job_id, ctx)
+            if not cancel_result["success"] and cancel_result["workflow_found"]:
+                ctx.logger.warning(
+                    f"Temporal cancel failed for PENDING job {job_id}, "
+                    "workflow may continue running against cancelled job",
+                )
+            await db.refresh(sync_job)
+            return schemas.SyncJob.model_validate(sync_job, from_attributes=True)
+
+        # RUNNING → CANCELLING; workflow handles CANCELLING → CANCELLED
         await self._job_state_machine.transition(
             sync_job_id=job_id, target=SyncJobStatus.CANCELLING, ctx=ctx
         )

--- a/backend/airweave/domains/syncs/tests/test_service.py
+++ b/backend/airweave/domains/syncs/tests/test_service.py
@@ -550,10 +550,34 @@ async def test_cancel_job_success():
 
 
 @pytest.mark.asyncio
-async def test_cancel_job_workflow_not_found_marks_cancelled():
+async def test_cancel_pending_job_transitions_directly_to_cancelled():
     job_id = uuid4()
     job_repo = AsyncMock()
     job = _orm_sync_job(job_id=job_id, status=SyncJobStatus.PENDING)
+    job_repo.get.return_value = job
+
+    temporal = AsyncMock()
+    job_sm = AsyncMock()
+    db = AsyncMock()
+
+    svc = _build_svc(
+        sync_job_repo=job_repo,
+        temporal_workflow_service=temporal,
+        job_state_machine=job_sm,
+    )
+    await svc.cancel_job(db, job_id=job_id, ctx=_mock_ctx())
+
+    job_sm.transition.assert_awaited_once()
+    assert job_sm.transition.call_args.kwargs["target"] == SyncJobStatus.CANCELLED
+    temporal.cancel_sync_job_workflow.assert_awaited_once()
+    db.refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cancel_job_workflow_not_found_marks_cancelled():
+    job_id = uuid4()
+    job_repo = AsyncMock()
+    job = _orm_sync_job(job_id=job_id, status=SyncJobStatus.RUNNING)
     job_repo.get.return_value = job
 
     temporal = AsyncMock()
@@ -573,6 +597,8 @@ async def test_cancel_job_workflow_not_found_marks_cancelled():
     await svc.cancel_job(db, job_id=job_id, ctx=_mock_ctx())
 
     assert job_sm.transition.await_count == 2
+    first_call = job_sm.transition.call_args_list[0].kwargs
+    assert first_call["target"] == SyncJobStatus.CANCELLING
     second_call = job_sm.transition.call_args_list[1].kwargs
     assert second_call["target"] == SyncJobStatus.CANCELLED
 

--- a/backend/airweave/domains/temporal/activities/tests/test_transition_sync_job.py
+++ b/backend/airweave/domains/temporal/activities/tests/test_transition_sync_job.py
@@ -1,6 +1,6 @@
 """Tests for TransitionSyncJobActivity."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 from uuid import UUID
 
 import pytest
@@ -8,7 +8,6 @@ import pytest
 from airweave.core.shared_models import SyncJobStatus
 from airweave.domains.temporal.activities.transition_sync_job import (
     TransitionSyncJobActivity,
-    _STATUS_MAP,
 )
 
 from .conftest import ORG_ID, SYNC_ID, SYNC_JOB_ID, make_ctx_dict
@@ -98,6 +97,27 @@ async def test_failed_transition_with_error(activity, state_machine):
     call = state_machine.calls[0]
     assert call["target"] == SyncJobStatus.FAILED
     assert call["error"] == "Something went wrong"
+
+
+@pytest.mark.unit
+async def test_cancelling_transition(activity, state_machine):
+    lifecycle = {
+        "organization_id": ORG_ID,
+        "sync_id": SYNC_ID,
+        "sync_job_id": SYNC_JOB_ID,
+        "collection_id": "00000000-0000-0000-0000-000000000030",
+        "source_connection_id": "00000000-0000-0000-0000-000000000050",
+    }
+
+    await activity.run(
+        transition="cancelling",
+        sync_job_id=SYNC_JOB_ID,
+        ctx_dict=make_ctx_dict(),
+        lifecycle_data=lifecycle,
+    )
+
+    call = state_machine.calls[0]
+    assert call["target"] == SyncJobStatus.CANCELLING
 
 
 @pytest.mark.unit

--- a/backend/airweave/domains/temporal/activities/transition_sync_job.py
+++ b/backend/airweave/domains/temporal/activities/transition_sync_job.py
@@ -1,6 +1,6 @@
 """Transition sync job activity — thin Temporal wrapper over SyncJobStateMachine.
 
-Called by the workflow for COMPLETED, FAILED, and CANCELLED transitions.
+Called by the workflow for CANCELLING, COMPLETED, FAILED, and CANCELLED transitions.
 Deserializes Temporal payloads and delegates to the state machine.
 """
 
@@ -19,6 +19,7 @@ from airweave.domains.syncs.jobs.types import LifecycleData
 from airweave.domains.temporal.activities.context import build_activity_context
 
 _STATUS_MAP: dict[str, SyncJobStatus] = {
+    "cancelling": SyncJobStatus.CANCELLING,
     "completed": SyncJobStatus.COMPLETED,
     "failed": SyncJobStatus.FAILED,
     "cancelled": SyncJobStatus.CANCELLED,
@@ -46,10 +47,10 @@ class TransitionSyncJobActivity:
         stats_dict: Optional[Dict[str, Any]] = None,
         timestamp_iso: Optional[str] = None,
     ) -> None:
-        """Execute a terminal state transition via the state machine.
+        """Execute a state transition via the state machine.
 
         Args:
-            transition: One of "completed", "failed", "cancelled".
+            transition: One of "cancelling", "completed", "failed", "cancelled".
             sync_job_id: The sync job UUID as a string.
             ctx_dict: Serialized context dict (contains organization).
             lifecycle_data: Fields for building LifecycleData.

--- a/backend/airweave/domains/temporal/workflows/run_source_connection.py
+++ b/backend/airweave/domains/temporal/workflows/run_source_connection.py
@@ -1,6 +1,6 @@
 """Run source connection workflow — the sync state machine.
 
-Owns terminal state transitions (COMPLETED, FAILED, CANCELLED) via
+Owns state transitions (CANCELLING, COMPLETED, FAILED, CANCELLED) via
 TransitionSyncJobActivity. RUNNING is published by the orchestrator
 because only it knows when sync work actually begins.
 """
@@ -95,7 +95,9 @@ class RunSourceConnectionWorkflow:
             )
         except BaseException as e:
             if is_cancelled_exception(e):
-                await self._transition("cancelled", sync_job_dict, ctx_dict, lifecycle, shield=True)
+                cancel_args = (sync_job_dict, ctx_dict, lifecycle)
+                await self._transition("cancelling", *cancel_args, shield=True)
+                await self._transition("cancelled", *cancel_args, shield=True)
                 raise
             if self._is_orphaned_sync_error(e):
                 reason = self._extract_orphaned_reason(e)
@@ -203,7 +205,12 @@ class RunSourceConnectionWorkflow:
         error: Optional[str] = None,
         shield: bool = False,
     ) -> None:
-        """Call TransitionSyncJobActivity for a terminal state change."""
+        """Call TransitionSyncJobActivity for a state change.
+
+        Shielded transitions (cancel path) are best-effort retries — the
+        orchestrator already performed these transitions, so failures here
+        are expected and logged at debug level.
+        """
         timestamp = workflow.now().replace(tzinfo=None).isoformat()
         coro = workflow.execute_activity(
             transition_sync_job_activity,
@@ -227,9 +234,8 @@ class RunSourceConnectionWorkflow:
         try:
             await (asyncio.shield(coro) if shield else coro)
         except Exception:
-            workflow.logger.warning(
-                f"Failed to transition sync job {sync_job_dict.get('id')} to {transition}"
-            )
+            log = workflow.logger.debug if shield else workflow.logger.warning
+            log(f"Failed to transition sync job {sync_job_dict.get('id')} to {transition}")
 
     # ------------------------------------------------------------------
     # Self-destruct orphaned sync


### PR DESCRIPTION
The state machine forbids PENDING → CANCELLING, but the cancel flow assumed every job passed through CANCELLING on the way to CANCELLED. A PENDING job hitting the API `cancel_job` endpoint would attempt an invalid transition.

Split the cancel path by current status: PENDING jobs now go straight to CANCELLED, while RUNNING jobs keep the two-phase CANCELLING → CANCELLED flow. The orchestrator and workflow both attempt the same transitions defensively — the orchestrator acts eagerly inside the activity, the workflow retries via a shielded activity as a safety net. Duplicate arrivals are harmless because the state machine treats same-state writes as no-ops.

Shielded (cancel-path) transition failures are now logged at debug rather than warning, since the orchestrator already handled them. The CANCELLED transition failure in the orchestrator keeps warning level — it means the job reached an unexpected terminal state (COMPLETED/FAILED) during cancellation.