### PR TITLE
fix(sharepoint_online): correct SP site group expansion

### DIFF
--- a/backend/airweave/platform/sources/sharepoint_online/source.py
+++ b/backend/airweave/platform/sources/sharepoint_online/source.py
@@ -97,7 +97,7 @@ class SharePointOnlineBase(BaseSource):
     - create() — class constructor
     - _get_access_token() — return a valid Microsoft Graph token
     - _handle_401() — refresh/re-exchange on 401, return new token
-    - _make_sp_token_provider() — callable returning SP REST API token
+    - _make_sp_token_provider_for_site(site_url) — per-site SP REST token provider
     - _get_download_auth(url) — auth suitable for file download
     - _discover_sites(graph_client) — site discovery strategy
     """
@@ -127,14 +127,6 @@ class SharePointOnlineBase(BaseSource):
 
     async def _handle_401(self) -> str:
         """Handle a 401 by refreshing/re-exchanging. Returns new token."""
-        raise NotImplementedError
-
-    def _make_sp_token_provider(self) -> Optional[Callable]:
-        """Create an async callable returning a SharePoint REST API token, or None.
-
-        Legacy single-site provider that derives hostname from ``self._site_url``.
-        New code should use ``_make_sp_token_provider_for_site`` instead.
-        """
         raise NotImplementedError
 
     def _make_sp_token_provider_for_site(self, site_url: str) -> Optional[Callable]:
@@ -1351,10 +1343,6 @@ class SharePointOnlineSource(SharePointOnlineBase):
             return await self.auth.force_refresh()
         return await self.auth.get_token()
 
-    def _make_sp_token_provider(self) -> Optional[Callable]:
-        """Create SP token provider via OAuth scope exchange (config-site-bound)."""
-        return self._make_sp_token_provider_for_site(self._site_url)
-
     def _make_sp_token_provider_for_site(self, site_url: str) -> Optional[Callable]:
         """Create SP token provider for a specific site URL via OAuth scope exchange."""
         if not site_url:
@@ -1372,19 +1360,6 @@ class SharePointOnlineSource(SharePointOnlineBase):
             return token
 
         return _provider
-
-    def _derive_sp_resource_scope(self) -> Optional[str]:
-        """Derive the SharePoint resource scope from the site URL.
-
-        E.g. https://neenacorp.sharepoint.com/sites/JAman
-             -> https://neenacorp.sharepoint.com/.default
-        """
-        if not self._site_url:
-            return None
-        parsed = urlparse(self._site_url)
-        if not parsed.netloc:
-            return None
-        return f"https://{parsed.netloc}/.default"
 
     async def _discover_sites(self, graph_client: GraphClient) -> List[Dict[str, Any]]:
         """Discover sites via Graph search (delegated permissions).
@@ -1595,10 +1570,6 @@ class SharePointOnlineAppSource(SharePointOnlineBase):
     async def _handle_401(self) -> str:
         self._graph_token_expires = 0  # force re-exchange
         return await self._get_access_token()
-
-    def _make_sp_token_provider(self) -> Optional[Callable]:
-        """Create SP token provider via certificate exchange (config-site-bound)."""
-        return self._make_sp_token_provider_for_site(self._site_url)
 
     def _make_sp_token_provider_for_site(self, site_url: str) -> Optional[Callable]:
         """Create SP token provider for a specific site URL via certificate exchange."""

--- a/backend/airweave/platform/sources/sharepoint_online/source.py
+++ b/backend/airweave/platform/sources/sharepoint_online/source.py
@@ -27,8 +27,9 @@ Two source variants:
 from __future__ import annotations
 
 import asyncio
+import re
 from dataclasses import dataclass
-from typing import Any, AsyncGenerator, Callable, Dict, List, Optional
+from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 import httpx
@@ -105,8 +106,10 @@ class SharePointOnlineBase(BaseSource):
     _site_url: str
     _include_personal_sites: bool
     _include_pages: bool
-    _item_level_entra_groups: set
-    _item_level_sp_groups: set
+    _item_level_entra_groups: Set[str]
+    # Site-scoped SP group tracking: {site_url: {sp_group_name, ...}}
+    # Keyed by normalized site URL so multi-site syncs can expand SP groups per site.
+    _item_level_sp_groups: Dict[str, Set[str]]
 
     def _init_common(self, config: SharePointOnlineConfig) -> None:
         """Initialize fields shared by both OAuth and client-credentials sources."""
@@ -114,7 +117,7 @@ class SharePointOnlineBase(BaseSource):
         self._include_personal_sites = config.include_personal_sites
         self._include_pages = config.include_pages
         self._item_level_entra_groups = set()
-        self._item_level_sp_groups = set()
+        self._item_level_sp_groups = {}
 
     # -- Auth hooks (subclasses override) --
 
@@ -127,7 +130,19 @@ class SharePointOnlineBase(BaseSource):
         raise NotImplementedError
 
     def _make_sp_token_provider(self) -> Optional[Callable]:
-        """Create an async callable returning a SharePoint REST API token, or None."""
+        """Create an async callable returning a SharePoint REST API token, or None.
+
+        Legacy single-site provider that derives hostname from ``self._site_url``.
+        New code should use ``_make_sp_token_provider_for_site`` instead.
+        """
+        raise NotImplementedError
+
+    def _make_sp_token_provider_for_site(self, site_url: str) -> Optional[Callable]:
+        """Create an SP REST token provider scoped to a specific site URL.
+
+        Subclasses must override. Returns None if a token cannot be obtained
+        for the given site (e.g., malformed URL).
+        """
         raise NotImplementedError
 
     async def _get_download_auth(self, url: str) -> Any:
@@ -191,16 +206,101 @@ class SharePointOnlineBase(BaseSource):
         parsed = urlparse(self._site_url)
         return parsed.netloc or None
 
-    def _track_entity_groups(self, entity: BaseEntity) -> None:
-        """Track Entra ID and SP site groups found in entity permissions."""
+    @staticmethod
+    def _normalize_site_url(site_url: str) -> str:
+        """Normalize a site URL for use as a dict key (strip trailing slash)."""
+        return (site_url or "").rstrip("/")
+
+    def _track_entity_groups(self, entity: BaseEntity, site_url: str = "") -> None:
+        """Track Entra ID and SP site groups found in entity permissions.
+
+        Args:
+            entity: The entity whose access viewers to inspect.
+            site_url: The site URL this entity belongs to. SP groups are keyed
+                by site URL so multi-site syncs can expand SP groups per-site.
+                May be empty for paths that lack site context (incremental /
+                targeted single-file); those SP groups won't expand.
+        """
         if not hasattr(entity, "access") or entity.access is None:
             return
+        norm_site = self._normalize_site_url(site_url)
         for viewer in entity.access.viewers or []:
             if viewer.startswith("group:entra:"):
                 group_id = viewer[len("group:") :]
                 self._item_level_entra_groups.add(group_id)
             elif viewer.startswith("group:sp:"):
-                self._item_level_sp_groups.add(viewer[len("group:") :])
+                sp_name = viewer[len("group:") :]
+                self._item_level_sp_groups.setdefault(norm_site, set()).add(sp_name)
+
+    # -- SP site group membership parsing --
+
+    # Match regular user logins: "i:0#.f|membership|<email>"
+    _MEMBERSHIP_LOGIN_RE = re.compile(r"^i:0#\.f\|membership\|(?P<email>[^|]+@[^|]+)$")
+    # Match Entra federated group logins: "c:0o.c|federateddirectoryclaimprovider|<guid>[_o]"
+    _ENTRA_GROUP_LOGIN_RE = re.compile(
+        r"^c:0o\.c\|federateddirectoryclaimprovider\|"
+        r"(?P<guid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+        r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(_o)?$"
+    )
+
+    @classmethod
+    def _email_from_membership_login(cls, login: str) -> Optional[str]:
+        """Extract email from SP user LoginName if it follows the membership pattern.
+
+        Only matches "i:0#.f|membership|<email>". Returns None for role principals
+        (e.g., "c:0-.f|rolemanager|spo-grid-all-users/...") and other shapes so
+        we don't pollute the membership table with fake email-like strings.
+        """
+        if not login:
+            return None
+        m = cls._MEMBERSHIP_LOGIN_RE.match(login)
+        if m:
+            return m.group("email").strip().lower() or None
+        return None
+
+    @classmethod
+    def _parse_sp_group_member(cls, user: Dict[str, Any]) -> Optional[Tuple[str, str]]:
+        """Parse one entry from /_api/web/sitegroups({id})/users into (member_id, member_type).
+
+        Returns None for entries that should not become memberships:
+        - Role principals (PrincipalType=16, e.g. "Everyone except external users")
+        - Catch-all "All" principals (PrincipalType=15)
+        - DistList, SPGroup, unknown types (skipped; rare in practice)
+        - Unparseable entries (no email for users, no GUID for groups)
+
+        PrincipalType reference:
+            1  = User
+            2  = DistList
+            4  = SecurityGroup (Entra group when LoginName uses
+                 federateddirectoryclaimprovider)
+            8  = SPGroup
+            15 = All
+            16 = RoleManager
+        """
+        ptype = user.get("PrincipalType")
+        login = user.get("LoginName", "") or ""
+
+        if ptype == 1:
+            email = user.get("Email") or ""
+            email = email.strip().lower()
+            if not email:
+                email = cls._email_from_membership_login(login) or ""
+            if not email:
+                return None
+            # Bare email (no "user:" prefix) matches the broker storage
+            # convention used by EntraGroupExpander and SP 2019 V2.
+            return (email, "user")
+
+        if ptype == 4:
+            m = cls._ENTRA_GROUP_LOGIN_RE.match(login)
+            if not m:
+                return None
+            guid = m.group("guid").lower()
+            return (f"entra:{guid}", "group")
+
+        # PrincipalType 2 (DistList), 8 (SPGroup), 15 (All), 16 (RoleManager),
+        # and unknown types are intentionally skipped.
+        return None
 
     # -- Browse Tree --
 
@@ -440,7 +540,7 @@ class SharePointOnlineBase(BaseSource):
 
     # -- Entity Generation --
 
-    async def generate_entities(
+    async def generate_entities(  # noqa: C901
         self,
         *,
         cursor: SyncCursor | None = None,
@@ -451,8 +551,19 @@ class SharePointOnlineBase(BaseSource):
         cursor_data = cursor.data if cursor else {}
         for g in cursor_data.get("tracked_entra_groups", []):
             self._item_level_entra_groups.add(g)
-        for g in cursor_data.get("tracked_sp_groups", []):
-            self._item_level_sp_groups.add(g)
+
+        # tracked_sp_groups format changed from List[str] (flat names) to
+        # Dict[site_url, List[str]] (site-scoped). Migrate defensively.
+        tracked_sp = cursor_data.get("tracked_sp_groups")
+        if isinstance(tracked_sp, dict):
+            for site_url, names in tracked_sp.items():
+                if isinstance(names, list):
+                    self._item_level_sp_groups[site_url] = set(names)
+        elif isinstance(tracked_sp, list):
+            self.logger.info(
+                "Legacy tracked_sp_groups list format detected; discarding — "
+                "will re-collect on next full sync"
+            )
 
         if node_selections:
             self.logger.info(f"Sync strategy: TARGETED ({len(node_selections)} node selections)")
@@ -495,10 +606,18 @@ class SharePointOnlineBase(BaseSource):
                 new_viewers.append(v)
         entity.access.viewers = new_viewers
 
-    async def _fetch_sp_group_viewers(self) -> List[str]:
-        """Fetch all SP site groups and return their viewer strings."""
-        sp_token_provider = self._make_sp_token_provider()
-        if not sp_token_provider or not self._site_url:
+    async def _fetch_sp_group_viewers(self, site_url: str) -> List[str]:
+        """Fetch all SP site groups for a site and return their viewer strings.
+
+        Args:
+            site_url: Full site URL (e.g. https://tenant.sharepoint.com/sites/X).
+                Required — without it we can't hit the SP REST endpoint.
+        """
+        norm_site = self._normalize_site_url(site_url)
+        if not norm_site:
+            return []
+        sp_token_provider = self._make_sp_token_provider_for_site(norm_site)
+        if not sp_token_provider:
             return []
         try:
             token = await sp_token_provider()
@@ -507,7 +626,7 @@ class SharePointOnlineBase(BaseSource):
                 "Accept": "application/json;odata=verbose",
             }
             resp = await self.http_client.get(
-                f"{self._site_url}/_api/web/sitegroups",
+                f"{norm_site}/_api/web/sitegroups",
                 headers=headers,
                 timeout=30.0,
             )
@@ -515,18 +634,19 @@ class SharePointOnlineBase(BaseSource):
             groups = resp.json().get("d", {}).get("results", [])
 
             viewers = []
+            site_bucket = self._item_level_sp_groups.setdefault(norm_site, set())
             for g in groups:
                 title = g.get("Title", "")
                 if title:
                     tag = f"group:sp:{title.lower().replace(' ', '_')}"
                     viewers.append(tag)
-                    self._item_level_sp_groups.add(tag[len("group:") :])
-            self.logger.info(f"Fetched {len(viewers)} SP site groups as viewers")
+                    site_bucket.add(tag[len("group:") :])
+            self.logger.info(f"Fetched {len(viewers)} SP site groups as viewers for {norm_site}")
             return viewers
         except SourceAuthError:
             raise
         except Exception as e:
-            self.logger.warning(f"SP group fetch failed: {e}")
+            self.logger.warning(f"SP group fetch failed for {norm_site}: {e}")
             return []
 
     async def _full_sync(  # noqa: C901
@@ -541,6 +661,7 @@ class SharePointOnlineBase(BaseSource):
 
         for site_data in sites:
             site_id = site_data.get("id", "")
+            site_url = self._normalize_site_url(site_data.get("webUrl", ""))
 
             # Collect all drives for this site (single API call)
             all_drives = []
@@ -560,7 +681,7 @@ class SharePointOnlineBase(BaseSource):
 
             try:
                 site_entity = await build_site_entity(site_data, [], access=site_access)
-                self._track_entity_groups(site_entity)
+                self._track_entity_groups(site_entity, site_url)
                 yield site_entity
                 entity_count += 1
 
@@ -574,7 +695,7 @@ class SharePointOnlineBase(BaseSource):
                 self.logger.warning(f"Skipping site {site_id}: {e}")
                 continue
 
-            sp_group_viewers = await self._fetch_sp_group_viewers()
+            sp_group_viewers = await self._fetch_sp_group_viewers(site_url)
 
             for drive_data in all_drives:
                 drive_id = drive_data.get("id", "")
@@ -593,7 +714,7 @@ class SharePointOnlineBase(BaseSource):
                     drive_entity = await build_drive_entity(
                         drive_data, site_id, site_breadcrumbs, access=drive_access
                     )
-                    self._track_entity_groups(drive_entity)
+                    self._track_entity_groups(drive_entity, site_url)
                     yield drive_entity
                     entity_count += 1
 
@@ -631,7 +752,7 @@ class SharePointOnlineBase(BaseSource):
                                     for spv in sp_group_viewers:
                                         if spv not in existing:
                                             file_entity.access.viewers.append(spv)
-                                self._track_entity_groups(file_entity)
+                                self._track_entity_groups(file_entity, site_url)
 
                                 if files:
                                     pending_files.append(
@@ -697,7 +818,7 @@ class SharePointOnlineBase(BaseSource):
                             page_entity = await build_page_entity(
                                 page_data, site_id, site_breadcrumbs, access=site_access
                             )
-                            self._track_entity_groups(page_entity)
+                            self._track_entity_groups(page_entity, site_url)
                             yield page_entity
                             entity_count += 1
                         except EntityProcessingError as e:
@@ -718,7 +839,9 @@ class SharePointOnlineBase(BaseSource):
                 full_sync_required=False,
                 total_entities_synced=entity_count,
                 tracked_entra_groups=list(self._item_level_entra_groups),
-                tracked_sp_groups=list(self._item_level_sp_groups),
+                tracked_sp_groups={
+                    site: sorted(names) for site, names in self._item_level_sp_groups.items()
+                },
             )
 
         self.logger.info(f"Full sync complete: {entity_count} entities")
@@ -850,6 +973,7 @@ class SharePointOnlineBase(BaseSource):
 
             try:
                 site_data = await graph_client.get_site(site_id)
+                targeted_site_url = self._normalize_site_url(site_data.get("webUrl", ""))
 
                 # Fetch site-level permissions from first drive root
                 targeted_site_access = None
@@ -862,7 +986,7 @@ class SharePointOnlineBase(BaseSource):
                     break
 
                 site_entity = await build_site_entity(site_data, [], access=targeted_site_access)
-                self._track_entity_groups(site_entity)
+                self._track_entity_groups(site_entity, targeted_site_url)
                 yield site_entity
                 entity_count += 1
             except SourceAuthError:
@@ -1069,51 +1193,85 @@ class SharePointOnlineBase(BaseSource):
             async for membership in group_expander.expand_group(group_id):
                 yield membership
 
-    async def _expand_sp_site_groups(self) -> AsyncGenerator[MembershipTuple, None]:
-        """Expand tracked SP site groups into user memberships."""
-        sp_group_names = list(self._item_level_sp_groups)
-        if not sp_group_names or not self._site_url:
-            return
-        sp_token_provider = self._make_sp_token_provider()
-        if not sp_token_provider:
-            self.logger.warning("No SP token provider for site group expansion")
+    async def _expand_sp_site_groups(  # noqa: C901
+        self,
+    ) -> AsyncGenerator[MembershipTuple, None]:
+        """Expand tracked SP site groups into user/group memberships.
+
+        Iterates per-site: for each site URL we've tracked SP group names against,
+        fetches that site's SP groups via the SharePoint REST API and resolves
+        their members.
+
+        Member types emitted:
+        - ``user`` for real users (PrincipalType=1). Role principals like
+          "Everyone except external users" are skipped.
+        - ``group`` for Entra security groups nested inside SP groups
+          (PrincipalType=4 with federateddirectoryclaimprovider). The broker's
+          recursive group expansion resolves these to individual users at
+          search time.
+        """
+        if not self._item_level_sp_groups:
             return
 
-        self.logger.info(f"Expanding {len(sp_group_names)} SP site groups")
+        total_groups = sum(len(v) for v in self._item_level_sp_groups.values())
+        self.logger.info(
+            f"Expanding {total_groups} SP site groups across "
+            f"{len(self._item_level_sp_groups)} site(s)"
+        )
+
         graph_client = self._create_graph_client()
 
-        sp_groups = await graph_client.get_site_groups(
-            self._site_url,
-            sp_token_provider=sp_token_provider,
-        )
-        sp_name_to_id = {
-            f"sp:{g['Title'].replace(' ', '_').lower()}": g.get("Id")
-            for g in sp_groups
-            if g.get("Title")
-        }
-
-        for sp_name in sp_group_names:
-            sp_id = sp_name_to_id.get(sp_name)
-            if not sp_id:
-                self.logger.debug(f"SP group '{sp_name}' not found in site")
+        for site_url, sp_group_names in self._item_level_sp_groups.items():
+            if not site_url or not sp_group_names:
                 continue
 
-            users = await graph_client.get_site_group_users(
-                self._site_url,
-                sp_id,
-                sp_token_provider=sp_token_provider,
-            )
-            for user in users:
-                email = user.get("Email", "")
-                login = user.get("LoginName", "")
-                if not email and login and "|" in login:
-                    email = login.split("|")[-1]
-                if email:
+            sp_token_provider = self._make_sp_token_provider_for_site(site_url)
+            if not sp_token_provider:
+                self.logger.warning(
+                    f"No SP token provider for site {site_url}; skipping SP group expansion"
+                )
+                continue
+
+            try:
+                sp_groups = await graph_client.get_site_groups(
+                    site_url, sp_token_provider=sp_token_provider
+                )
+            except Exception as e:
+                self.logger.warning(f"Failed to fetch SP groups for {site_url}: {e}")
+                continue
+
+            sp_name_to_id = {
+                f"sp:{g['Title'].replace(' ', '_').lower()}": g.get("Id")
+                for g in sp_groups
+                if g.get("Title")
+            }
+
+            for sp_name in sp_group_names:
+                sp_id = sp_name_to_id.get(sp_name)
+                if not sp_id:
+                    self.logger.debug(f"SP group '{sp_name}' not found in site {site_url}")
+                    continue
+
+                try:
+                    users = await graph_client.get_site_group_users(
+                        site_url, sp_id, sp_token_provider=sp_token_provider
+                    )
+                except Exception as e:
+                    self.logger.warning(
+                        f"Failed to fetch users for SP group {sp_name} in {site_url}: {e}"
+                    )
+                    continue
+
+                for user in users:
+                    parsed = self._parse_sp_group_member(user)
+                    if parsed is None:
+                        continue
+                    member_id, member_type = parsed
                     yield MembershipTuple(
-                        member_id=email.lower(),
-                        member_type="user",
+                        member_id=member_id,
+                        member_type=member_type,
                         group_id=sp_name,
-                        group_name=user.get("Title", sp_name),
+                        group_name=user.get("Title") or sp_name,
                     )
 
     async def generate_access_control_memberships(
@@ -1194,10 +1352,18 @@ class SharePointOnlineSource(SharePointOnlineBase):
         return await self.auth.get_token()
 
     def _make_sp_token_provider(self) -> Optional[Callable]:
-        """Create SP token provider via OAuth scope exchange."""
-        sp_scope = self._derive_sp_resource_scope()
-        if not sp_scope:
+        """Create SP token provider via OAuth scope exchange (config-site-bound)."""
+        return self._make_sp_token_provider_for_site(self._site_url)
+
+    def _make_sp_token_provider_for_site(self, site_url: str) -> Optional[Callable]:
+        """Create SP token provider for a specific site URL via OAuth scope exchange."""
+        if not site_url:
             return None
+        parsed = urlparse(site_url)
+        hostname = parsed.netloc
+        if not hostname:
+            return None
+        sp_scope = f"https://{hostname}/.default"
 
         async def _provider() -> str:
             token = await self.get_token_for_resource(sp_scope)
@@ -1431,8 +1597,15 @@ class SharePointOnlineAppSource(SharePointOnlineBase):
         return await self._get_access_token()
 
     def _make_sp_token_provider(self) -> Optional[Callable]:
-        """Create SP token provider via certificate exchange."""
-        hostname = self._derive_sp_hostname()
+        """Create SP token provider via certificate exchange (config-site-bound)."""
+        return self._make_sp_token_provider_for_site(self._site_url)
+
+    def _make_sp_token_provider_for_site(self, site_url: str) -> Optional[Callable]:
+        """Create SP token provider for a specific site URL via certificate exchange."""
+        if not site_url:
+            return None
+        parsed = urlparse(site_url)
+        hostname = parsed.netloc
         if not hostname:
             return None
 

--- a/backend/tests/unit/platform/sources/test_sharepoint_online_group_expansion.py
+++ b/backend/tests/unit/platform/sources/test_sharepoint_online_group_expansion.py
@@ -1,0 +1,340 @@
+"""Unit tests for SharePoint Online SP site group expansion helpers.
+
+Covers _parse_sp_group_member, _email_from_membership_login, and the cursor
+migration path for tracked_sp_groups.
+"""
+
+from unittest.mock import MagicMock
+
+from airweave.platform.sources.sharepoint_online.source import SharePointOnlineBase
+
+# ---------------------------------------------------------------------------
+# _email_from_membership_login
+# ---------------------------------------------------------------------------
+
+
+def test_email_from_membership_login_valid():
+    assert (
+        SharePointOnlineBase._email_from_membership_login("i:0#.f|membership|foo@bar.com")
+        == "foo@bar.com"
+    )
+
+
+def test_email_from_membership_login_uppercase_normalized():
+    assert (
+        SharePointOnlineBase._email_from_membership_login("i:0#.f|membership|Foo@BAR.com")
+        == "foo@bar.com"
+    )
+
+
+def test_email_from_membership_login_rejects_role_principal():
+    # Role principals would otherwise yield "spo-grid-all-users/..." — must reject.
+    assert (
+        SharePointOnlineBase._email_from_membership_login(
+            "c:0-.f|rolemanager|spo-grid-all-users/26adf163-2699-4d04-a0ad-3d935411bf45"
+        )
+        is None
+    )
+
+
+def test_email_from_membership_login_rejects_federated_group():
+    assert (
+        SharePointOnlineBase._email_from_membership_login(
+            "c:0o.c|federateddirectoryclaimprovider|58cb1814-203a-44d0-8578-b53f63860579"
+        )
+        is None
+    )
+
+
+def test_email_from_membership_login_rejects_empty():
+    assert SharePointOnlineBase._email_from_membership_login("") is None
+
+
+def test_email_from_membership_login_rejects_malformed():
+    assert SharePointOnlineBase._email_from_membership_login("i:0#.f|membership|noat") is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_sp_group_member
+# ---------------------------------------------------------------------------
+
+
+def test_parse_real_user_with_email():
+    user = {
+        "PrincipalType": 1,
+        "LoginName": "i:0#.f|membership|alice@contoso.com",
+        "Email": "alice@contoso.com",
+        "Title": "Alice",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) == (
+        "alice@contoso.com",
+        "user",
+    )
+
+
+def test_parse_real_user_uppercase_email_normalized():
+    user = {
+        "PrincipalType": 1,
+        "LoginName": "i:0#.f|membership|ALICE@CONTOSO.COM",
+        "Email": "ALICE@CONTOSO.COM",
+        "Title": "Alice",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) == (
+        "alice@contoso.com",
+        "user",
+    )
+
+
+def test_parse_real_user_email_empty_fallback_to_login():
+    # If Email is missing but LoginName has the membership pattern, use that.
+    user = {
+        "PrincipalType": 1,
+        "LoginName": "i:0#.f|membership|alice@contoso.com",
+        "Email": "",
+        "Title": "Alice",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) == (
+        "alice@contoso.com",
+        "user",
+    )
+
+
+def test_parse_real_user_no_email_no_parseable_login_returns_none():
+    # System Account and similar — no Email, no membership LoginName.
+    user = {
+        "PrincipalType": 1,
+        "LoginName": "SHAREPOINT\\system",
+        "Email": "",
+        "Title": "System Account",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) is None
+
+
+def test_parse_role_principal_skipped():
+    """Bug B regression test — 'Everyone except external users' must not become a fake user."""
+    user = {
+        "PrincipalType": 16,
+        "LoginName": "c:0-.f|rolemanager|spo-grid-all-users/26adf163-2699-4d04-a0ad-3d935411bf45",
+        "Email": "",
+        "Title": "Everyone except external users",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) is None
+
+
+def test_parse_entra_group_emits_group_membership():
+    """Bug C/D regression test — Entra group must be emitted as group-to-group."""
+    user = {
+        "PrincipalType": 4,
+        "LoginName": "c:0o.c|federateddirectoryclaimprovider|58cb1814-203a-44d0-8578-b53f63860579",
+        "Email": "neena@neenacorp.onmicrosoft.com",  # group's email, must NOT be used
+        "Title": "Neena Members",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) == (
+        "entra:58cb1814-203a-44d0-8578-b53f63860579",
+        "group",
+    )
+
+
+def test_parse_entra_group_owner_suffix_stripped():
+    """Owner-style claim has `_o` suffix — must strip it to get the bare GUID."""
+    login = "c:0o.c|federateddirectoryclaimprovider|58cb1814-203a-44d0-8578-b53f63860579_o"
+    user = {
+        "PrincipalType": 4,
+        "LoginName": login,
+        "Email": "neena@neenacorp.onmicrosoft.com",
+        "Title": "Neena Owners",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) == (
+        "entra:58cb1814-203a-44d0-8578-b53f63860579",
+        "group",
+    )
+
+
+def test_parse_entra_group_uppercase_guid_normalized():
+    user = {
+        "PrincipalType": 4,
+        "LoginName": "c:0o.c|federateddirectoryclaimprovider|58CB1814-203A-44D0-8578-B53F63860579",
+        "Title": "Neena Owners",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) == (
+        "entra:58cb1814-203a-44d0-8578-b53f63860579",
+        "group",
+    )
+
+
+def test_parse_entra_group_malformed_guid_returns_none():
+    user = {
+        "PrincipalType": 4,
+        "LoginName": "c:0o.c|federateddirectoryclaimprovider|not-a-guid",
+        "Title": "Bad Group",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) is None
+
+
+def test_parse_security_group_non_federated_returns_none():
+    # PrincipalType=4 but not federated — on-prem AD claim, skip.
+    user = {
+        "PrincipalType": 4,
+        "LoginName": "c:0-.f|adclaimprovider|S-1-5-21-...",
+        "Title": "On-prem Group",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) is None
+
+
+def test_parse_distlist_skipped():
+    user = {"PrincipalType": 2, "LoginName": "some-dl", "Title": "DL"}
+    assert SharePointOnlineBase._parse_sp_group_member(user) is None
+
+
+def test_parse_spgroup_skipped():
+    user = {"PrincipalType": 8, "LoginName": "some-sp", "Title": "SP"}
+    assert SharePointOnlineBase._parse_sp_group_member(user) is None
+
+
+def test_parse_all_catchall_skipped():
+    user = {"PrincipalType": 15, "LoginName": "everyone", "Title": "All"}
+    assert SharePointOnlineBase._parse_sp_group_member(user) is None
+
+
+def test_parse_unknown_principal_type_skipped():
+    user = {"PrincipalType": 99, "LoginName": "x", "Title": "X"}
+    assert SharePointOnlineBase._parse_sp_group_member(user) is None
+
+
+def test_parse_missing_principal_type_skipped():
+    user = {"LoginName": "x", "Title": "X", "Email": "x@y.z"}
+    assert SharePointOnlineBase._parse_sp_group_member(user) is None
+
+
+# ---------------------------------------------------------------------------
+# _normalize_site_url
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_site_url_strips_trailing_slash():
+    assert (
+        SharePointOnlineBase._normalize_site_url("https://contoso.sharepoint.com/sites/X/")
+        == "https://contoso.sharepoint.com/sites/X"
+    )
+
+
+def test_normalize_site_url_empty():
+    assert SharePointOnlineBase._normalize_site_url("") == ""
+    assert SharePointOnlineBase._normalize_site_url(None) == ""  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _track_entity_groups with site_url scoping
+# ---------------------------------------------------------------------------
+
+
+class _StubEntity:
+    def __init__(self, viewers):
+        self.access = MagicMock()
+        self.access.viewers = viewers
+
+
+def _bare_base() -> SharePointOnlineBase:
+    """Instantiate the base class just enough to exercise tracking logic.
+
+    We bypass the normal source creation path since we only need the tracking
+    state and its methods.
+    """
+    instance = SharePointOnlineBase.__new__(SharePointOnlineBase)
+    instance._site_url = ""
+    instance._include_personal_sites = False
+    instance._include_pages = False
+    instance._item_level_entra_groups = set()
+    instance._item_level_sp_groups = {}
+    return instance
+
+
+def test_track_entity_groups_scopes_sp_by_site():
+    base = _bare_base()
+    e = _StubEntity(
+        [
+            "group:sp:neena_members",
+            "group:sp:neena_owners",
+            "group:entra:58cb1814-203a-44d0-8578-b53f63860579",
+            "user:alice@contoso.com",
+        ]
+    )
+    base._track_entity_groups(e, "https://neenacorp.sharepoint.com/sites/Neena77")
+
+    assert base._item_level_sp_groups == {
+        "https://neenacorp.sharepoint.com/sites/Neena77": {
+            "sp:neena_members",
+            "sp:neena_owners",
+        }
+    }
+    assert base._item_level_entra_groups == {"entra:58cb1814-203a-44d0-8578-b53f63860579"}
+
+
+def test_track_entity_groups_multiple_sites_keep_separate():
+    base = _bare_base()
+    base._track_entity_groups(
+        _StubEntity(["group:sp:neena_members"]),
+        "https://neenacorp.sharepoint.com/sites/A",
+    )
+    base._track_entity_groups(
+        _StubEntity(["group:sp:access_control_tests_owners"]),
+        "https://neenacorp.sharepoint.com/sites/B",
+    )
+
+    assert base._item_level_sp_groups == {
+        "https://neenacorp.sharepoint.com/sites/A": {"sp:neena_members"},
+        "https://neenacorp.sharepoint.com/sites/B": {"sp:access_control_tests_owners"},
+    }
+
+
+def test_track_entity_groups_same_name_different_sites_do_not_collide():
+    base = _bare_base()
+    base._track_entity_groups(
+        _StubEntity(["group:sp:members"]),
+        "https://neenacorp.sharepoint.com/sites/A",
+    )
+    base._track_entity_groups(
+        _StubEntity(["group:sp:members"]),
+        "https://neenacorp.sharepoint.com/sites/B",
+    )
+
+    # Same group name but two different sites — must be tracked independently.
+    assert set(base._item_level_sp_groups.keys()) == {
+        "https://neenacorp.sharepoint.com/sites/A",
+        "https://neenacorp.sharepoint.com/sites/B",
+    }
+
+
+def test_track_entity_groups_normalizes_trailing_slash():
+    base = _bare_base()
+    base._track_entity_groups(
+        _StubEntity(["group:sp:x"]),
+        "https://neenacorp.sharepoint.com/sites/A/",
+    )
+    base._track_entity_groups(
+        _StubEntity(["group:sp:y"]),
+        "https://neenacorp.sharepoint.com/sites/A",
+    )
+    # Both should land under the same normalized key.
+    assert base._item_level_sp_groups == {
+        "https://neenacorp.sharepoint.com/sites/A": {"sp:x", "sp:y"}
+    }
+
+
+def test_track_entity_groups_no_access_noop():
+    base = _bare_base()
+    entity = MagicMock()
+    entity.access = None
+    base._track_entity_groups(entity, "https://neenacorp.sharepoint.com/sites/A")
+    assert base._item_level_sp_groups == {}
+
+
+def test_track_entity_groups_empty_site_url_still_stores_under_empty_key():
+    """Groups are still stored under the empty-string key when no site_url.
+
+    Expansion skips empty-key buckets, so this is effectively a no-op for
+    broker purposes but keeps the data structure consistent.
+    """
+    base = _bare_base()
+    base._track_entity_groups(_StubEntity(["group:sp:orphan"]), "")
+    assert base._item_level_sp_groups == {"": {"sp:orphan"}}


### PR DESCRIPTION
## Summary

Fixes 4 bugs in `SharePointOnlineBase._expand_sp_site_groups` and related ACL code, surfaced by the new `sharepoint_online_app` (client-credentials) connector. Before this change, multi-site syncs wrote **0** SP-group memberships to Postgres, polluted the membership table with fake users derived from role principals, and flattened nested Entra groups into unusable user rows.

## Bugs fixed

| # | Bug | Symptom | Fix |
|---|---|---|---|
| **A** | `_expand_sp_site_groups` and `_fetch_sp_group_viewers` early-returned when `self._site_url` was empty | Multi-site sync mode (`getAllSites`) silently wrote 0 SP-group memberships across all sites | Track SP groups keyed by site URL; iterate per-site in Phase 2.5 |
| **B** | Role principals (`c:0-.f\|rolemanager\|spo-grid-all-users/...`) parsed as users | Rows like `member_id='spo-grid-all-users/26adf163-...', member_type='user'` polluting the table; never matches real users | `_parse_sp_group_member` dispatches on `PrincipalType`; rejects 16 (RoleManager) and anything that isn't the strict `i:0#.f\|membership\|<email>` claim |
| **C** | Nested Entra groups (`c:0o.c\|federateddirectoryclaimprovider\|<guid>[_o]`) stored as fake users with the group's email | The 49 real members of an Entra group never got linked to the parent SP group; broker recursion couldn't traverse | Emit as `(member_id='entra:<guid>', member_type='group', group_id='sp:<name>')` — a proper group-to-group edge |
| **D** | `member_type` hardcoded to `"user"` | Prevented group-to-group relationships the broker needs for recursive expansion | Return `member_type` from `_parse_sp_group_member` |

### Bonus regression (caught & fixed during testing)

Initial fix emitted `member_id='user:<email>'` (with prefix). The broker queries with bare email (`broker.py:37-38`) and adds the `user:` prefix at search time, matching `EntraGroupExpander` and SP 2019 V2 convention. Fixed to emit bare email.

## What changed (single file: `backend/airweave/platform/sources/sharepoint_online/source.py`)

- **Data structure:** `_item_level_sp_groups: Set[str]` → `Dict[site_url, Set[str]]`, keyed by normalized site URL.
- **New helpers:**
  - `_parse_sp_group_member(user)` — `PrincipalType` dispatch returning `Optional[Tuple[member_id, member_type]]`.
  - `_email_from_membership_login(login)` — strict regex for the `i:0#.f|membership|<email>` claim only.
  - `_normalize_site_url(url)` — strips trailing slash.
  - `_make_sp_token_provider_for_site(site_url)` — per-site SP REST token provider (abstract on base, implemented in both OAuth + app-only subclasses).
- **`_track_entity_groups(entity, site_url)`** — takes a site URL, stores groups site-scoped.
- **`_fetch_sp_group_viewers(site_url)`** — takes a site URL (was reading `self._site_url`), no early-return.
- **`_expand_sp_site_groups()`** — rewritten to iterate over `_item_level_sp_groups.items()`, building a per-site SP REST token, fetching groups, and parsing members via `_parse_sp_group_member`.
- **Cursor format:** `tracked_sp_groups: List[str]` → `Dict[site_url, List[str]]`. Read path defensively migrates legacy list (discards + logs; re-collects on next full sync). Write path serializes the dict.

## Testing

All tests run against a neenacorp tenant with the app-only (client-credentials) connector over 15 sites / 47 SP groups / 22 Entra groups.

### Unit tests (29 new, all passing)
`backend/tests/unit/platform/sources/test_sharepoint_online_group_expansion.py`:
- `_email_from_membership_login` — valid emails, uppercase normalization, rejects role principals, federated groups, empty, malformed.
- `_parse_sp_group_member` — every `PrincipalType` branch, owner-suffix (`_o`) stripping, uppercase GUID normalization, malformed GUID, missing type, missing LoginName.
- `_track_entity_groups` — site scoping, same group name on different sites, trailing-slash normalization, no-access no-op, empty site_url bucketing.
- `_normalize_site_url`.

Ruff clean. Mypy has 27 errors across 4 files — **all pre-existing on `main`**; zero added by this PR (verified by running mypy on pristine `main` vs this branch).

### Full-sync path (collection `test3-k8tjv1`, no site_url, 15 sites)
- Phase 2.5 log: `Expanding 47 SP site groups across 15 site(s)` (was skipped entirely before fix)
- `ACL collection complete: 148 unique, 148 written to DB`
- Cursor written with new dict format: `tracked_sp_groups` = 15 sites / 47 groups; 17 `drive_delta_tokens`; `full_sync_required=false`
- Postgres breakdown: 121 bare-email users, 30 `entra:... → sp:...` group-to-group rows, **0** `spo-grid-all-users` rows, **0** `user:`-prefixed regressions

### Incremental-sync path
Verified on this same connection across multiple syncs:
- `Sync strategy: INCREMENTAL (valid delta tokens)` + per-drive `/root/delta?token=...` with `Prefer: deltashowsharingchanges, deltashowremovedasdeleted, deltatraversepermissiongaps`
- Cursor dict-format read re-expands SP groups correctly
- Phase 2.5 catches live SP group changes: added `acl_test_edge1@...` and later `acl_test_edge2@...` to `Neena Members` via `m365` CLI → both appeared in `access_control_membership` as bare emails within the next incremental sync
- Graceful handling of a transient `410 Gone` (`resyncRequired`) on one drive: logs warning, flips `full_sync_required=true`, next sync falls through to `_full_sync`, cursor recovers

### Broker recursion (end-to-end search)
Admin search endpoint `/admin/collections/{id}/search/as-user` with `user_principal=acl_test_user1@neenacorp.onmicrosoft.com`:
- Returned `ACL_TEST_TC-SG-002.txt` — a file whose viewers are **only** `group:sp:ja_man_*` (no matching Entra viewer). User is a direct member of `sp:ja_man_members` (bare-email format). Match required the parser to emit a bare-email user row that the broker can look up.
- Negative control: `acl_test_edge1@...` (not in `sp:ja_man_*`) searched the same query → ja_man files correctly excluded.

### Cursor migration
Legacy `tracked_sp_groups: List[str]` in cursor → read path logs `Legacy tracked_sp_groups list format; discarding — will re-collect on next full sync` and proceeds. Dict form reads through normally. (Pre-existing Pydantic `BaseCursor(extra="allow")` absorbs the schema change without a migration.)

## Known limitations (explicitly deferred to follow-up PR)

These are pre-existing gaps and **not** introduced by this PR — verified by reading the prior code and plan:

1. **`_incremental_sync` and `_targeted_sync` pass `site_url=\"\"` to `_track_entity_groups`.** Newly-observed SP groups during incremental/targeted runs bucket under an empty-key site. Expansion skips empty-key buckets, so those groups don't make it into the membership table until the next full sync.
2. **`_targeted_sync` uses full drive listing (`get_drive_items_recursive`), not delta.** Every UI-created SharePoint Online connection currently takes this path because the UI forces browse-selection. This is architectural and orthogonal to ACL correctness.
3. **UI flow: browse-selection is mandatory.** There's no "sync everything" default, so production users never hit `_full_sync`/`_incremental_sync` through the UI. This is a product change, not a backend fix.

A follow-up PR should:
- Thread `site_url` through incremental + targeted paths so SP groups track per-site there too.
- Make `_targeted_sync` persist per-drive delta tokens.
- Surface a full-sync-default option in the UI.

## Test plan
- [x] Ruff clean
- [x] 29 new unit tests pass
- [x] Full sync against multi-site connection writes 148 memberships (was 0)
- [x] Cursor written with new dict schema; verified by inspection
- [x] Incremental sync selects the correct strategy, runs delta queries, re-expands SP groups
- [x] Phase 2.5 picks up SP group membership changes on subsequent incremental sync
- [x] Broker recursion returns documents gated only by SP groups for the right user and excludes the wrong user
- [x] Legacy cursor format migrates defensively

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SharePoint Online site group expansion for multi-site syncs by tracking groups per site and using per-site SP REST tokens. Restores correct ACLs (no role-principal “fake users”; nested Entra groups emitted as groups) and prevents zero-membership writes; also removes the legacy single-site SP token provider in favor of the per-site method.

- **Bug Fixes**
  - Track SP groups per site URL and expand per site; no more early-returns based on `self._site_url`.
  - Use per-site SP token providers (OAuth and app-only) to fetch site groups/users per site.
  - Parse members by `PrincipalType`: users as bare emails; skip RoleManager/All/other non-user types; nested Entra groups emitted as `group` memberships (`entra:<guid>`).

- **Migration**
  - Cursor `tracked_sp_groups` now `Dict[site_url, List[str]]` (was `List[str]`).
  - Legacy list values are ignored and re-collected on the next full sync (no action needed).

<sup>Written for commit 89c6314a0d84567a7767976debdac19b1486ffe2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

