### PR TITLE
Pr/1758

### DIFF
--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -1,7 +1,7 @@
 """Configuration classes for platform components."""
 
 from datetime import datetime
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import Field, field_validator
 
@@ -355,7 +355,7 @@ class GoogleDriveConfig(SourceConfig):
 
     @field_validator("drive_id", mode="before")
     @classmethod
-    def _normalize_drive_id(cls, value):
+    def _normalize_drive_id(cls, value: Any) -> Any:
         """Treat empty strings as None so defaults kick in."""
         if isinstance(value, str):
             stripped = value.strip()

--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -332,6 +332,17 @@ class GoogleDocsConfig(SourceConfig):
 class GoogleDriveConfig(SourceConfig):
     """Google Drive configuration schema."""
 
+    drive_id: Optional[str] = Field(
+        default=None,
+        title="Shared Drive ID",
+        description=(
+            "If set, only sync files from this specific shared drive "
+            "(and skip 'My Drive'). You can find the drive ID in the Google Drive URL "
+            "when viewing a shared drive. Leave empty to sync all drives the account "
+            "has access to, plus 'My Drive'."
+        ),
+    )
+
     include_patterns: list[str] = Field(
         default=[],
         title="Include Patterns",
@@ -341,6 +352,15 @@ class GoogleDriveConfig(SourceConfig):
             "Separate multiple patterns with commas. If empty, all files are included."
         ),
     )
+
+    @field_validator("drive_id", mode="before")
+    @classmethod
+    def _normalize_drive_id(cls, value):
+        """Treat empty strings as None so defaults kick in."""
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
 
     @field_validator("include_patterns", mode="before")
     @classmethod

--- a/backend/airweave/platform/sources/google_drive.py
+++ b/backend/airweave/platform/sources/google_drive.py
@@ -214,8 +214,9 @@ class GoogleDriveSource(BaseSource):
         params: Dict[str, Any] = {
             "pageToken": start_token,
             "includeRemoved": "true",
-            # When scoped to a single drive, only emit changes from that drive.
-            "includeItemsFromAllDrives": "false" if drive_id_filter else "true",
+            # Must be "true" even when driveId is set — otherwise the API omits
+            # shared-drive items entirely. driveId alone scopes changes to that drive.
+            "includeItemsFromAllDrives": "true",
             "supportsAllDrives": "true",
             "pageSize": 1000,
             "fields": (

--- a/backend/airweave/platform/sources/google_drive.py
+++ b/backend/airweave/platform/sources/google_drive.py
@@ -77,6 +77,8 @@ class GoogleDriveSource(BaseSource):
     while maintaining proper organization and access permissions.
     """
 
+    drive_id_filter: Optional[str] = None
+
     @classmethod
     async def create(
         cls,
@@ -195,7 +197,7 @@ class GoogleDriveSource(BaseSource):
         params: Dict[str, Any] = {
             "supportsAllDrives": "true",
         }
-        if getattr(self, "drive_id_filter", None):
+        if self.drive_id_filter:
             params["driveId"] = self.drive_id_filter
         data = await self._get(url, params=params)
         token = data.get("startPageToken")
@@ -210,7 +212,7 @@ class GoogleDriveSource(BaseSource):
         for use after the stream completes.
         """
         url = "https://www.googleapis.com/drive/v3/changes"
-        drive_id_filter = getattr(self, "drive_id_filter", None)
+        drive_id_filter = self.drive_id_filter
         params: Dict[str, Any] = {
             "pageToken": start_token,
             "includeRemoved": "true",
@@ -1027,7 +1029,7 @@ class GoogleDriveSource(BaseSource):
             patterns: List[str] = getattr(self, "include_patterns", []) or []
             self.logger.debug(f"Include patterns: {patterns}")
 
-            drive_id_filter: Optional[str] = getattr(self, "drive_id_filter", None)
+            drive_id_filter: Optional[str] = self.drive_id_filter
 
             drive_objs: List[Dict[str, Any]] = []
             try:

--- a/backend/airweave/platform/sources/google_drive.py
+++ b/backend/airweave/platform/sources/google_drive.py
@@ -89,6 +89,7 @@ class GoogleDriveSource(BaseSource):
         """Create a new Google Drive source instance."""
         instance = cls(auth=auth, logger=logger, http_client=http_client)
         instance.include_patterns = config.include_patterns if config else []
+        instance.drive_id_filter = config.drive_id if config else None
         instance.batch_size = 30
         instance.batch_generation = True
         instance.max_queue_size = 200
@@ -191,9 +192,11 @@ class GoogleDriveSource(BaseSource):
     # --- Changes API helpers ---
     async def _get_start_page_token(self) -> str:
         url = "https://www.googleapis.com/drive/v3/changes/startPageToken"
-        params = {
+        params: Dict[str, Any] = {
             "supportsAllDrives": "true",
         }
+        if getattr(self, "drive_id_filter", None):
+            params["driveId"] = self.drive_id_filter
         data = await self._get(url, params=params)
         token = data.get("startPageToken")
         if not token:
@@ -207,10 +210,12 @@ class GoogleDriveSource(BaseSource):
         for use after the stream completes.
         """
         url = "https://www.googleapis.com/drive/v3/changes"
+        drive_id_filter = getattr(self, "drive_id_filter", None)
         params: Dict[str, Any] = {
             "pageToken": start_token,
             "includeRemoved": "true",
-            "includeItemsFromAllDrives": "true",
+            # When scoped to a single drive, only emit changes from that drive.
+            "includeItemsFromAllDrives": "false" if drive_id_filter else "true",
             "supportsAllDrives": "true",
             "pageSize": 1000,
             "fields": (
@@ -221,6 +226,8 @@ class GoogleDriveSource(BaseSource):
                 ")"
             ),
         }
+        if drive_id_filter:
+            params["driveId"] = drive_id_filter
 
         latest_new_start: Optional[str] = None
 
@@ -1019,15 +1026,26 @@ class GoogleDriveSource(BaseSource):
             patterns: List[str] = getattr(self, "include_patterns", []) or []
             self.logger.debug(f"Include patterns: {patterns}")
 
+            drive_id_filter: Optional[str] = getattr(self, "drive_id_filter", None)
+
             drive_objs: List[Dict[str, Any]] = []
             try:
                 async for drive_obj in self._list_drives():
+                    if drive_id_filter and drive_obj.get("id") != drive_id_filter:
+                        continue
                     drive_objs.append(drive_obj)
                     yield self._build_drive_entity(drive_obj)
             except SourceAuthError:
                 raise
             except Exception as e:
                 self.logger.warning(f"Error generating drive entities: {str(e)}")
+
+            if drive_id_filter and not drive_objs:
+                self.logger.warning(
+                    f"Configured drive_id '{drive_id_filter}' was not found among the shared "
+                    "drives accessible to this account. Nothing will be synced. Verify the "
+                    "drive ID and that the authenticated user has access."
+                )
 
             self._setup_breadcrumbs(drive_objs)
             drive_breadcrumbs = self._drive_breadcrumbs
@@ -1070,19 +1088,20 @@ class GoogleDriveSource(BaseSource):
                             )
                             continue
 
-                    try:
-                        async for mydrive_file_entity in self._generate_file_entities(
-                            corpora="user",
-                            include_all_drives=False,
-                            context="MY DRIVE",
-                            parent_breadcrumb=self._my_drive_breadcrumb,
-                            files=files,
-                        ):
-                            yield mydrive_file_entity
-                    except SourceAuthError:
-                        raise
-                    except Exception as e:
-                        self.logger.warning(f"Error processing My Drive files: {str(e)}")
+                    if not drive_id_filter:
+                        try:
+                            async for mydrive_file_entity in self._generate_file_entities(
+                                corpora="user",
+                                include_all_drives=False,
+                                context="MY DRIVE",
+                                parent_breadcrumb=self._my_drive_breadcrumb,
+                                files=files,
+                            ):
+                                yield mydrive_file_entity
+                        except SourceAuthError:
+                            raise
+                        except Exception as e:
+                            self.logger.warning(f"Error processing My Drive files: {str(e)}")
 
                 # INCLUDE MODE: Resolve patterns and traverse only matched subtrees
                 # Shared drives first
@@ -1216,9 +1235,13 @@ class GoogleDriveSource(BaseSource):
                     except Exception as e:
                         self.logger.warning(f"Include mode error for drive {drive_id}: {str(e)}")
 
-                # My Drive include patterns
+                # My Drive include patterns (skipped when scoped to a specific shared drive)
                 try:
-                    for p in patterns:
+                    if drive_id_filter:
+                        patterns_for_mydrive: List[str] = []
+                    else:
+                        patterns_for_mydrive = patterns
+                    for p in patterns_for_mydrive:
                         roots, fname_glob = await self._resolve_pattern_to_roots(
                             corpora="user",
                             include_all_drives=False,
@@ -1281,7 +1304,7 @@ class GoogleDriveSource(BaseSource):
                                         )
                                         continue
 
-                    filename_only_patterns = [p for p in patterns if "/" not in p]
+                    filename_only_patterns = [p for p in patterns_for_mydrive if "/" not in p]
                     import fnmatch as _fn
 
                     for pat in filename_only_patterns:

--- a/backend/tests/unit/platform/sources/test_google_drive.py
+++ b/backend/tests/unit/platform/sources/test_google_drive.py
@@ -74,7 +74,8 @@ class TestChangesApiScoping:
         _, kwargs = source._get.call_args
         params = kwargs["params"]
         assert params["driveId"] == "0ABCdef"
-        assert params["includeItemsFromAllDrives"] == "false"
+        # Must stay "true" even when scoped — otherwise shared-drive changes are omitted.
+        assert params["includeItemsFromAllDrives"] == "true"
 
     async def test_iterate_changes_unscoped_includes_all_drives(self):
         source = await _make_source(GoogleDriveConfig())

--- a/backend/tests/unit/platform/sources/test_google_drive.py
+++ b/backend/tests/unit/platform/sources/test_google_drive.py
@@ -1,0 +1,190 @@
+"""Tests for GoogleDriveSource — drive_id filtering behavior."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from airweave.platform.configs.config import GoogleDriveConfig
+from airweave.platform.sources.google_drive import GoogleDriveSource
+
+
+def _mock_auth():
+    auth = AsyncMock()
+    auth.get_token = AsyncMock(return_value="test-token")
+    auth.force_refresh = AsyncMock(return_value="refreshed-token")
+    auth.supports_refresh = True
+    auth.provider_kind = "oauth"
+    return auth
+
+
+async def _make_source(config: GoogleDriveConfig | None = None):
+    return await GoogleDriveSource.create(
+        auth=_mock_auth(),
+        logger=MagicMock(),
+        http_client=AsyncMock(),
+        config=config if config is not None else GoogleDriveConfig(),
+    )
+
+
+class TestCreate:
+    async def test_default_no_drive_filter(self):
+        source = await _make_source(GoogleDriveConfig())
+        assert source.drive_id_filter is None
+        assert source.include_patterns == []
+
+    async def test_drive_id_stored_on_instance(self):
+        source = await _make_source(GoogleDriveConfig(drive_id="0ABCdef"))
+        assert source.drive_id_filter == "0ABCdef"
+
+    async def test_whitespace_drive_id_normalized_to_none(self):
+        source = await _make_source(GoogleDriveConfig(drive_id="   "))
+        assert source.drive_id_filter is None
+
+
+class TestChangesApiScoping:
+    """drive_id_filter should scope Changes API requests to that drive only."""
+
+    async def test_start_page_token_includes_drive_id(self):
+        source = await _make_source(GoogleDriveConfig(drive_id="0ABCdef"))
+        source._get = AsyncMock(return_value={"startPageToken": "tok-1"})
+
+        token = await source._get_start_page_token()
+
+        assert token == "tok-1"
+        source._get.assert_awaited_once()
+        _, kwargs = source._get.call_args
+        params = kwargs["params"]
+        assert params["driveId"] == "0ABCdef"
+        assert params["supportsAllDrives"] == "true"
+
+    async def test_start_page_token_omits_drive_id_when_unscoped(self):
+        source = await _make_source(GoogleDriveConfig())
+        source._get = AsyncMock(return_value={"startPageToken": "tok-2"})
+
+        await source._get_start_page_token()
+
+        _, kwargs = source._get.call_args
+        assert "driveId" not in kwargs["params"]
+
+    async def test_iterate_changes_scopes_to_drive(self):
+        source = await _make_source(GoogleDriveConfig(drive_id="0ABCdef"))
+        source._get = AsyncMock(return_value={"changes": [], "newStartPageToken": "tok-n"})
+
+        async for _ in source._iterate_changes("start-tok"):
+            pass
+
+        _, kwargs = source._get.call_args
+        params = kwargs["params"]
+        assert params["driveId"] == "0ABCdef"
+        assert params["includeItemsFromAllDrives"] == "false"
+
+    async def test_iterate_changes_unscoped_includes_all_drives(self):
+        source = await _make_source(GoogleDriveConfig())
+        source._get = AsyncMock(return_value={"changes": [], "newStartPageToken": "tok-n"})
+
+        async for _ in source._iterate_changes("start-tok"):
+            pass
+
+        _, kwargs = source._get.call_args
+        params = kwargs["params"]
+        assert "driveId" not in params
+        assert params["includeItemsFromAllDrives"] == "true"
+
+
+class TestGenerateEntitiesDriveFilter:
+    """generate_entities should filter drive list and skip My Drive when scoped."""
+
+    async def test_filters_drives_to_configured_drive_id(self):
+        """Only the matching drive should be emitted; others skipped."""
+        source = await _make_source(GoogleDriveConfig(drive_id="drive-b"))
+
+        async def fake_list_drives():
+            for d in [
+                {"id": "drive-a", "name": "A", "createdTime": None},
+                {"id": "drive-b", "name": "B", "createdTime": None},
+                {"id": "drive-c", "name": "C", "createdTime": None},
+            ]:
+                yield d
+
+        source._list_drives = fake_list_drives
+        # No files needed for this assertion; stub the per-drive file generator to be empty.
+        source._generate_file_entities = lambda **kwargs: _aiter_empty()
+        source._store_next_start_page_token = AsyncMock()
+
+        drive_entities = []
+        async for ent in source.generate_entities(cursor=None, files=None):
+            drive_entities.append(ent)
+
+        drive_ids = [
+            getattr(e, "entity_id", None) or getattr(e, "drive_id", None) for e in drive_entities
+        ]
+        assert "drive-b" in drive_ids
+        assert "drive-a" not in drive_ids
+        assert "drive-c" not in drive_ids
+
+    async def test_unknown_drive_id_warns_and_yields_no_drives(self):
+        source = await _make_source(GoogleDriveConfig(drive_id="missing"))
+        logger_warning = source.logger.warning = MagicMock()
+
+        async def fake_list_drives():
+            yield {"id": "drive-x", "name": "X", "createdTime": None}
+
+        source._list_drives = fake_list_drives
+        source._generate_file_entities = lambda **kwargs: _aiter_empty()
+        source._store_next_start_page_token = AsyncMock()
+
+        entities = [e async for e in source.generate_entities(cursor=None, files=None)]
+        assert entities == []
+
+        warnings = [call.args[0] for call in logger_warning.call_args_list]
+        assert any("missing" in msg and "not found" in msg for msg in warnings)
+
+    async def test_my_drive_skipped_when_drive_id_set(self):
+        """corpora='user' branch should not be visited when scoped to a shared drive."""
+        source = await _make_source(GoogleDriveConfig(drive_id="drive-b"))
+
+        async def fake_list_drives():
+            yield {"id": "drive-b", "name": "B", "createdTime": None}
+
+        source._list_drives = fake_list_drives
+
+        calls = []
+
+        def fake_generate_file_entities(**kwargs):
+            calls.append(kwargs)
+            return _aiter_empty()
+
+        source._generate_file_entities = fake_generate_file_entities
+        source._store_next_start_page_token = AsyncMock()
+
+        [_ async for _ in source.generate_entities(cursor=None, files=None)]
+
+        corpora_seen = [c["corpora"] for c in calls]
+        assert "drive" in corpora_seen, "expected shared-drive iteration"
+        assert "user" not in corpora_seen, "My Drive must be skipped when drive_id is set"
+
+    async def test_my_drive_included_when_no_drive_id(self):
+        source = await _make_source(GoogleDriveConfig())
+
+        async def fake_list_drives():
+            yield {"id": "drive-a", "name": "A", "createdTime": None}
+
+        source._list_drives = fake_list_drives
+
+        calls = []
+
+        def fake_generate_file_entities(**kwargs):
+            calls.append(kwargs)
+            return _aiter_empty()
+
+        source._generate_file_entities = fake_generate_file_entities
+        source._store_next_start_page_token = AsyncMock()
+
+        [_ async for _ in source.generate_entities(cursor=None, files=None)]
+
+        corpora_seen = [c["corpora"] for c in calls]
+        assert "user" in corpora_seen, "My Drive should be iterated when unscoped"
+
+
+async def _aiter_empty():
+    """Async generator that yields nothing — used as a stub for file entity generators."""
+    if False:
+        yield  # pragma: no cover

--- a/examples/Untitled-1.ipynb
+++ b/examples/Untitled-1.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2a3e55f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1e36aa1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e21ef448",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/frontend/src/pages/coherent_ui.md
+++ b/frontend/src/pages/coherent_ui.md
@@ -1,7 +1,7 @@
 # UI Coherence Plan for CollectionDetailView
 
 ## Overview
-After analyzing the CollectionDetailView, Search, SearchProcess, SearchResponse, and SourceConnectionStateView components, I've identified several inconsistencies in styling, spacing, colors, and component organization that need to be addressed for a cohesive, modern 2025 design aesthetic.
+After analyzing the CollectionDetailView, Search, SearchProcess, SearchResponse, and SourceConnectionStateView components, I've identified several inconsistencies in styling, spacing, colors, and component organization that need to be addressed for a cohesive, modern 2026 design aesthetic.
 
 ## Current Issues Analysis
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an optional drive_id to the Google Drive source so you can sync a single shared drive and skip “My Drive”. Changes API requests are correctly scoped to that drive to avoid missed updates.

- **New Features**
  - Add drive_id to `GoogleDriveConfig`; only the matching shared drive is synced, and “My Drive” is skipped (also in include-pattern paths).
  - Normalize blank drive_id to None; warn clearly if the drive ID is not accessible.

- **Bug Fixes**
  - Keep includeItemsFromAllDrives="true" when a driveId is set for the Changes API, ensuring shared-drive changes are returned.

<sup>Written for commit 710dbd54a8dfd26abc3c54da97ab1973d72c28bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

