### PR TITLE
fix(teams): strip non-printable control characters from message body

### DIFF
--- a/backend/airweave/platform/entities/teams.py
+++ b/backend/airweave/platform/entities/teams.py
@@ -14,6 +14,7 @@ Reference:
   https://learn.microsoft.com/en-us/graph/api/resources/chatmessage
 """
 
+import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -21,6 +22,19 @@ from pydantic import computed_field
 
 from airweave.platform.entities._airweave_field import AirweaveField
 from airweave.platform.entities._base import BaseEntity, Breadcrumb
+
+# Matches non-printable ASCII control characters, excluding the common whitespace
+# characters \t (\x09), \n (\x0a), and \r (\x0d) which are safe for text fields.
+# This prevents Vespa and other strict destinations from rejecting documents that
+# contain characters such as ESC (\x1b) pasted from terminal output or rich text.
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def _sanitize_text(value: Optional[str]) -> Optional[str]:
+    """Remove non-printable ASCII control characters from a string."""
+    if value is None:
+        return None
+    return _CONTROL_CHAR_RE.sub("", value)
 
 
 def _parse_dt(value: Optional[str]) -> Optional[datetime]:
@@ -374,7 +388,7 @@ class TeamsMessageEntity(BaseEntity):
         message_id = data["id"]
         from_info = data.get("from", {})
         body = data.get("body", {})
-        body_content = body.get("content", "")
+        body_content = _sanitize_text(body.get("content", ""))
 
         subject = data.get("subject")
         if subject:

--- a/backend/tests/unit/platform/sources/test_teams_entity.py
+++ b/backend/tests/unit/platform/sources/test_teams_entity.py
@@ -1,0 +1,81 @@
+"""Unit tests for Microsoft Teams entity sanitization.
+
+Covers the control-character stripping added to fix Vespa ingestion failures
+caused by non-printable characters (e.g. ESC/0x1B) in message bodies.
+See: https://github.com/airweave-ai/airweave/issues/1269
+"""
+
+import pytest
+
+from airweave.platform.entities.teams import TeamsMessageEntity, _sanitize_text
+
+
+class TestSanitizeText:
+    """Tests for the _sanitize_text helper."""
+
+    def test_returns_none_for_none(self):
+        assert _sanitize_text(None) is None
+
+    def test_passes_through_plain_text(self):
+        assert _sanitize_text("Hello, world!") == "Hello, world!"
+
+    def test_preserves_newline_tab_carriage_return(self):
+        text = "line1\nline2\ttabbed\r\n"
+        assert _sanitize_text(text) == text
+
+    def test_removes_escape_character(self):
+        assert _sanitize_text("text\x1bmore") == "textmore"
+
+    def test_removes_nul_character(self):
+        assert _sanitize_text("a\x00b") == "ab"
+
+    def test_removes_multiple_control_chars(self):
+        # ESC (\x1b), BEL (\x07), DEL (\x7f) should all be stripped
+        assert _sanitize_text("\x1b[31mred\x07\x7f") == "[31mred"
+
+    def test_removes_ansi_escape_sequence_control_byte(self):
+        # Real-world case: ANSI colour reset pasted from a terminal
+        assert _sanitize_text("normal \x1b[0m text") == "normal [0m text"
+
+    def test_empty_string(self):
+        assert _sanitize_text("") == ""
+
+
+class TestTeamsMessageEntityFromApi:
+    """Tests for TeamsMessageEntity.from_api with sanitization."""
+
+    _BASE_DATA = {
+        "id": "msg-001",
+        "messageType": "message",
+        "createdDateTime": "2024-01-15T10:00:00Z",
+        "lastModifiedDateTime": "2024-01-15T10:00:00Z",
+        "subject": None,
+        "importance": "normal",
+        "from": {"user": {"displayName": "Alice"}},
+        "mentions": [],
+        "attachments": [],
+        "reactions": [],
+        "webUrl": "https://teams.microsoft.com/",
+    }
+
+    def _make_data(self, content: str, content_type: str = "text") -> dict:
+        return {**self._BASE_DATA, "body": {"content": content, "contentType": content_type}}
+
+    def test_control_chars_stripped_from_body_content(self):
+        data = self._make_data("Hello \x1b[31mworld\x1b[0m")
+        entity = TeamsMessageEntity.from_api(data, breadcrumbs=[])
+        assert "\x1b" not in (entity.body_content or "")
+        assert "Hello [31mworld[0m" == entity.body_content
+
+    def test_clean_body_content_unchanged(self):
+        data = self._make_data("Plain text with\nnewlines\tand tabs")
+        entity = TeamsMessageEntity.from_api(data, breadcrumbs=[])
+        assert entity.body_content == "Plain text with\nnewlines\tand tabs"
+
+    def test_name_derived_from_sanitized_body(self):
+        # When subject is absent, name is derived from body_content;
+        # ensure the name preview also does not contain control chars.
+        long_body = "A" * 40 + "\x1b" + "B" * 20
+        data = self._make_data(long_body)
+        entity = TeamsMessageEntity.from_api(data, breadcrumbs=[])
+        assert "\x1b" not in entity.name


### PR DESCRIPTION
Fixes #1269

## Problem

Microsoft Teams messages can contain non-printable ASCII control characters such as ESC (`\x1b`) when users paste terminal output, ANSI colour codes, or certain rich-text artifacts. Vespa (and other strict destinations) reject these bytes with the error:

```
Could not parse field 'textual_representation' of type string:
The string field value contains illegal code point 0x1B
```

This causes the entire sync to fail during the ingestion stage with zero entities synced from the affected message onward.

## Solution

Add a `_sanitize_text()` helper in `platform/entities/teams.py` that removes all non-printable control characters in the range `\x00–\x1f` (excluding the common whitespace characters `\t`, `\n`, `\r`) and `\x7f` (DEL). The sanitizer is applied to `body_content` in `TeamsMessageEntity.from_api()` before the entity is yielded, so the cleaned text flows through to `textual_representation`.

## Testing

- Added 11 unit tests in `tests/unit/platform/sources/test_teams_entity.py` covering:
  - `_sanitize_text()` helper: `None` passthrough, plain text, preserved whitespace, ESC/NUL/DEL removal, ANSI escape sequences, empty string
  - `TeamsMessageEntity.from_api()`: control chars stripped from body, clean body unchanged, name preview free of control chars
- All 11 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes Microsoft Teams message bodies by stripping non-printable control characters to prevent Vespa ingestion failures and sync stoppages. The sanitizer runs in `TeamsMessageEntity.from_api()` so `textual_representation` stays clean even when users paste ANSI-colored terminal output.

<sup>Written for commit bd5a24c124015aa9544132b2e2f0117f9543af68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

