### PR TITLE
fix(sharepoint_online): organization-scoped sharing links no longer bypass access control

### DIFF
--- a/backend/airweave/platform/sources/sharepoint_online/acl.py
+++ b/backend/airweave/platform/sources/sharepoint_online/acl.py
@@ -6,7 +6,11 @@ Graph permission model:
 - grantedToV2.user → user:{email}
 - grantedToV2.group (Entra ID) → group:entra:{group_id}
 - grantedToV2.siteGroup → group:sp:{site_group_name}
-- link with scope "organization" → is_public (org-wide access)
+- link with scope "anonymous" → is_public (true tenant-wide / internet-wide access)
+
+Organization-scoped sharing links ("anyone in your org with the link") are NOT
+treated as public. Possession of the link URL is required, so the audience is
+captured via the per-link SharingLinks.* SP site group rather than is_public.
 """
 
 from typing import Any, Dict, List, Optional
@@ -76,14 +80,6 @@ def has_read_permission(permission: Dict[str, Any]) -> bool:
     return any(r in ("read", "write", "owner", "sp.full control") for r in roles)
 
 
-def is_org_wide_link(permission: Dict[str, Any]) -> bool:
-    """Check if a permission is an organization-wide sharing link."""
-    link = permission.get("link")
-    if not link:
-        return False
-    return link.get("scope", "") == "organization"
-
-
 def is_anonymous_link(permission: Dict[str, Any]) -> bool:
     """Check if a permission is an anonymous sharing link."""
     link = permission.get("link")
@@ -122,7 +118,7 @@ async def extract_access_control(
         if not has_read_permission(perm):
             continue
 
-        if is_org_wide_link(perm) or is_anonymous_link(perm):
+        if is_anonymous_link(perm):
             is_public = True
             continue
 

--- a/backend/tests/unit/platform/sources/test_sharepoint_online_acl.py
+++ b/backend/tests/unit/platform/sources/test_sharepoint_online_acl.py
@@ -1,0 +1,193 @@
+"""Unit tests for SharePoint Online ACL extraction.
+
+Covers ``extract_access_control`` and the rules around how Microsoft Graph
+sharing-link permissions map to ``AccessControl.is_public``.
+
+Background — bug fix:
+    Organization-scoped sharing links (``link.scope == "organization"``,
+    "anyone in your org with the link") used to set ``is_public = True``,
+    which made the search broker bypass all viewer checks. That mis-modeled
+    SharePoint semantics: an org-scoped link requires possession of the
+    link URL to grant access. Only ``link.scope == "anonymous"`` is true
+    public access.
+"""
+
+import pytest
+
+from airweave.platform.sources.sharepoint_online.acl import extract_access_control
+
+# ---------------------------------------------------------------------------
+# Helpers — build minimal Graph permission objects
+# ---------------------------------------------------------------------------
+
+
+def _link_perm(scope: str, roles=None) -> dict:
+    """Sharing-link permission with the given scope (no grantedTo principal)."""
+    return {
+        "id": f"link-{scope}",
+        "roles": roles if roles is not None else ["write"],
+        "link": {"scope": scope, "type": "edit"},
+        "grantedToIdentitiesV2": [],
+        "grantedToIdentities": [],
+    }
+
+
+def _site_group_perm(name: str, group_id: str = "5", roles=None) -> dict:
+    return {
+        "id": f"sg-{group_id}",
+        "roles": roles if roles is not None else ["write"],
+        "grantedToV2": {"siteGroup": {"displayName": name, "id": group_id}},
+    }
+
+
+def _user_perm(email: str, roles=None) -> dict:
+    return {
+        "id": f"u-{email}",
+        "roles": roles if roles is not None else ["read"],
+        "grantedToV2": {"user": {"email": email, "displayName": email}},
+    }
+
+
+def _entra_group_perm(group_id: str, roles=None) -> dict:
+    return {
+        "id": f"eg-{group_id}",
+        "roles": roles if roles is not None else ["read"],
+        "grantedToV2": {"group": {"id": group_id}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Sharing-link scope handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_organization_scoped_link_does_not_set_is_public():
+    """Org-scoped link by itself must not flip is_public.
+
+    Regression: the previous behavior treated organization-scoped links as
+    fully public, bypassing all viewer checks at search time.
+    """
+    ac = await extract_access_control([_link_perm("organization")])
+    assert ac.is_public is False
+    assert ac.viewers == []
+
+
+@pytest.mark.asyncio
+async def test_anonymous_link_sets_is_public():
+    ac = await extract_access_control([_link_perm("anonymous")])
+    assert ac.is_public is True
+
+
+@pytest.mark.asyncio
+async def test_org_and_anonymous_links_together_still_public_via_anonymous():
+    ac = await extract_access_control([_link_perm("organization"), _link_perm("anonymous")])
+    assert ac.is_public is True
+
+
+@pytest.mark.asyncio
+async def test_users_scoped_link_does_not_set_is_public():
+    """``users``-scoped links target named recipients, not the org."""
+    ac = await extract_access_control([_link_perm("users")])
+    assert ac.is_public is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_link_scope_does_not_set_is_public():
+    """Future / unrecognized scopes default to non-public."""
+    ac = await extract_access_control([_link_perm("someFutureScope")])
+    assert ac.is_public is False
+
+
+# ---------------------------------------------------------------------------
+# Mixed permissions — the realistic case
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_org_link_alongside_explicit_grants_extracts_only_grants():
+    """Org-link permission is skipped; explicit grants populate viewers.
+
+    Mirrors the Mistral bug-report payload: a file with one organization-
+    scoped sharing link plus the inherited site-group grants. The fix must
+    keep is_public false while still extracting Owners / Members / Visitors.
+    """
+    perms = [
+        _link_perm("organization"),
+        _site_group_perm("Access Control Tests Owners", group_id="3", roles=["owner"]),
+        _site_group_perm("Access Control Tests Members", group_id="5", roles=["write"]),
+        _site_group_perm("Access Control Tests Visitors", group_id="4", roles=["read"]),
+    ]
+    ac = await extract_access_control(perms)
+    assert ac.is_public is False
+    assert set(ac.viewers) == {
+        "group:sp:access_control_tests_owners",
+        "group:sp:access_control_tests_members",
+        "group:sp:access_control_tests_visitors",
+    }
+
+
+@pytest.mark.asyncio
+async def test_user_and_entra_group_grants_extracted():
+    perms = [
+        _user_perm("alice@example.com"),
+        _entra_group_perm("11111111-2222-3333-4444-555555555555"),
+    ]
+    ac = await extract_access_control(perms)
+    assert ac.is_public is False
+    assert set(ac.viewers) == {
+        "user:alice@example.com",
+        "group:entra:11111111-2222-3333-4444-555555555555",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_permissions_returns_empty_access_control():
+    ac = await extract_access_control([])
+    assert ac.is_public is False
+    assert ac.viewers == []
+
+
+@pytest.mark.asyncio
+async def test_permission_without_read_role_is_ignored():
+    """Roles other than read/write/owner/sp.full control don't grant viewing."""
+    perms = [
+        {
+            "id": "restricted",
+            "roles": ["restricted"],
+            "grantedToV2": {"user": {"email": "alice@example.com"}},
+        },
+    ]
+    ac = await extract_access_control(perms)
+    assert ac.is_public is False
+    assert ac.viewers == []
+
+
+@pytest.mark.asyncio
+async def test_org_link_without_read_role_is_ignored_entirely():
+    """A link without a read-equivalent role doesn't even reach scope check."""
+    perms = [
+        {
+            "id": "link-restricted",
+            "roles": ["restricted"],
+            "link": {"scope": "organization"},
+        }
+    ]
+    ac = await extract_access_control(perms)
+    assert ac.is_public is False
+    assert ac.viewers == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_principal_only_added_once():
+    perms = [
+        _user_perm("alice@example.com", roles=["read"]),
+        _user_perm("alice@example.com", roles=["write"]),
+    ]
+    ac = await extract_access_control(perms)
+    assert ac.viewers == ["user:alice@example.com"]


### PR DESCRIPTION
## Summary

SharePoint Online's connector mapped `link.scope == "organization"` sharing-link permissions to `AccessControl.is_public = True`. The search broker then short-circuits all viewer / group checks for any entity with `is_public`, so **any file that ever had an "anyone in your organization with the link" share created became visible in search to every authenticated user in the tenant** — even files on private sites with restricted folder permissions.

This was reported by Mistral on a private SharePoint site whose files surfaced for unrelated tenant users.

## Why "organization" scope is not public

SharePoint sharing links have three scopes:

| Scope | SharePoint meaning | Requires possession of the link URL? |
| --- | --- | --- |
| `anonymous` | Anyone on the internet | No |
| `organization` | Anyone in the org **who has the link URL** | **Yes** |
| `users` | Specific named recipients | Yes |

An organization-scoped link is a *capability*, not a tenant-wide ACL. A user must possess (or be sent) the link URL to gain access. Treating it as public was an over-approximation that collapsed the entire access model on affected files.

## Fix

`backend/airweave/platform/sources/sharepoint_online/acl.py`:

- `is_public` is now set **only** for `link.scope == "anonymous"`.
- The `is_org_wide_link` helper is deleted (single-use, no longer needed).
- Org-scoped link permissions are skipped without losing fidelity — their audience is captured via the `SharingLinks.<itemId>.<scope><role>.<linkId>` SP site group that SharePoint auto-creates per link. The connector already tracks those groups via `_fetch_sp_group_viewers` / `_expand_sp_site_groups`, so users who actually redeem a link continue to see the file via membership.
- Module docstring updated to reflect the new mapping.

Diff is tiny: **+10 / −10 production lines**.

## Tests

New file `backend/tests/unit/platform/sources/test_sharepoint_online_acl.py` (11 tests, all passing) covers `extract_access_control`:

- `organization`-scoped link alone → `is_public = False`, viewers `[]` (regression test for the bug).
- `anonymous`-scoped link → `is_public = True`.
- Both `organization` + `anonymous` together → `is_public = True` (anonymous wins).
- `users`-scoped link → not public.
- Unknown / future scope → not public (safe default).
- Org-link alongside site-group / user / Entra-group grants → grants extracted correctly, `is_public` stays false. Mirrors the Mistral payload shape exactly.
- Edge cases: empty permissions; permissions with no read-equivalent role; org-link without a read role; duplicate principals deduplicated.

Existing 474 tests in `backend/tests/unit/platform/sources/` still pass.

## How this was verified end-to-end

Set up against the live `neenacorp.onmicrosoft.com` tenant on the local stack:

1. Created `restricted-folder/org-link-test.txt` on the `Access Control Tests` site (3 M365 group members: lennert, rauf, daan; many `acl_test_*` users in the tenant who are not members).
2. Created an organization-scoped edit sharing link on the file.
3. Captured the raw Microsoft Graph permissions response — confirmed the link permission has `link.scope == "organization"` and **no** `grantedToV2` (no principal to lose by skipping it). The `SharingLinks.dd7691b0…OrganizationEdit…` SP site group appears in `/_api/web/sitegroups` but **not** in the per-item permissions response, validating the architectural claim.
4. Provisioned a `sharepoint_online_app` source connection scoped to that site, ran a full sync.

**Pre-fix observation:**

| User | Memberships | Search hit on `org-link-test.txt`? |
|---|---|---|
| `lennert@` | M365 group → site Members/Owners | ✓ (legitimate) |
| `acl_test_user1@` | none | ✓ — **bug**, only matched via `is_public: true` |

**Post-fix observation** (after edit + worker restart + cursor delete + full re-sync):

| User | Memberships | Search hit on `org-link-test.txt`? |
|---|---|---|
| `lennert@` | unchanged | ✓ — still finds it via group membership (no regression) |
| `acl_test_user1@` | none | ✗ — fixed |
| `acl_test_user1@` after being added to the `SharingLinks.…` SP site group (simulating link redemption) | now in the link's group | ✓ — link-redemption path still works |

Stored entity `access` field after fix: `is_public: false`; viewers list identical to before (Owners / Members / Visitors / Entra group / SharingLinks group).

## Side observation (out of scope, follow-up PR coming)

When `acl_test_user1` was added to the `SharingLinks.…` group as a redemption simulation, search returned **3 hits** instead of 1 — `org-link-test.txt`, plus two unrelated files on the same site. Root cause: `_fetch_sp_group_viewers` blanket-attaches every site group (including every `SharingLinks.*` system group) to every file in the site. That's a separate over-grant bug, fix forthcoming.

## Test plan

- [x] New unit tests pass (`pytest tests/unit/platform/sources/test_sharepoint_online_acl.py`)
- [x] Existing source unit tests pass (`pytest tests/unit/platform/sources/`)
- [x] Ruff lint + format clean on changed files
- [x] End-to-end verification against live tenant (described above)
- [ ] Reviewer: confirm the call sites in `source.py` (`_full_sync`, `_targeted_sync`, `_sync_drive`, `_incremental_sync`, `_resolve_unresolved_viewers`) are unaffected — they consume `AccessControl` opaquely, so behavior changes only via the new `is_public` value.
- [ ] After merge: re-sync existing customer SharePoint connections to refresh stored ACLs (entities are upserted with new `access` on each sync; no backfill script needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an access control bug in the SharePoint Online connector: organization-scoped sharing links no longer set `is_public`, preventing tenant-wide visibility of private files. Anonymous links still set `is_public`; access from org links flows through `SharingLinks.*` site groups as intended.

- **Bug Fixes**
  - Only `link.scope == "anonymous"` sets `is_public`; removed org-wide link handling.
  - Skip org-scoped link permissions; viewers resolved via existing `SharingLinks.*` SharePoint site groups.
  - Added unit tests for `extract_access_control`; updated module docs and minor cleanup.

- **Migration**
  - Re-sync existing SharePoint Online sources to refresh stored ACLs.

<sup>Written for commit 99ca0ed357c085fc760884cf8c99e00f08767eba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

