### PR TITLE
fix(sharepoint_online): scope sharing-link viewers per-file, drop blanket-attach

### DIFF
--- a/backend/airweave/platform/sources/sharepoint_online/acl.py
+++ b/backend/airweave/platform/sources/sharepoint_online/acl.py
@@ -7,10 +7,12 @@ Graph permission model:
 - grantedToV2.group (Entra ID) → group:entra:{group_id}
 - grantedToV2.siteGroup → group:sp:{site_group_name}
 - link with scope "anonymous" → is_public (true tenant-wide / internet-wide access)
-
-Organization-scoped sharing links ("anyone in your org with the link") are NOT
-treated as public. Possession of the link URL is required, so the audience is
-captured via the per-link SharingLinks.* SP site group rather than is_public.
+- link with scope "organization" or "users" → group:sp:sharinglinks.{itemId}.{scopeRole}.{linkId}
+  derived from the permission and the file's SP UniqueId. Microsoft represents
+  these links as a ``link`` permission rather than a ``siteGroup`` grant, but
+  internally tracks redeemers as members of a ``SharingLinks.<itemId>.<scopeRole>.<linkId>``
+  SP site group. We translate so that membership intersection at search time
+  works for users who have actually redeemed the link.
 """
 
 from typing import Any, Dict, List, Optional
@@ -88,6 +90,60 @@ def is_anonymous_link(permission: Dict[str, Any]) -> bool:
     return link.get("scope", "") == "anonymous"
 
 
+# Mapping from Graph (link.scope, link.type) to SharePoint's SharingLinks group
+# suffix. Verified empirically against neenacorp.sharepoint.com:
+#   organization+edit → OrganizationEdit
+#   organization+view → OrganizationView
+#   users+edit / users+view → Flexible  (both collapse; SP stores role separately)
+# Anonymous is handled by ``is_public`` and does not need a derived group.
+_SCOPE_ROLE_MAP: Dict[tuple, str] = {
+    ("organization", "edit"): "OrganizationEdit",
+    ("organization", "view"): "OrganizationView",
+    ("users", "edit"): "Flexible",
+    ("users", "view"): "Flexible",
+}
+
+
+def link_permission_to_sp_group_viewer(
+    permission: Dict[str, Any], sp_unique_id: Optional[str]
+) -> Optional[str]:
+    """Derive the SharingLinks SP site group viewer for a non-anonymous link permission.
+
+    SharePoint creates an internal site group named
+    ``SharingLinks.<fileSpUniqueId>.<ScopeRole>.<linkId>`` for each sharing
+    link, whose members are the users who have redeemed the link. The Graph
+    per-item permissions response represents the link itself but does *not*
+    return that site group as a separate ``siteGroup`` grant, so we translate.
+
+    Args:
+        permission: A Graph permission with a ``link`` block.
+        sp_unique_id: The file's SharePoint UniqueId (lowercase GUID, no
+            braces). Pass ``None`` for site/drive-level permissions, where
+            sharing-link translation does not apply.
+
+    Returns:
+        ``group:sp:sharinglinks.<id>.<scoperole>.<linkid>`` viewer string, or
+        ``None`` if the permission isn't a translatable link or required
+        fields are missing.
+    """
+    if not sp_unique_id:
+        return None
+    link = permission.get("link")
+    if not link:
+        return None
+    scope = link.get("scope", "")
+    if scope == "anonymous":
+        return None  # handled by is_public
+    scope_role = _SCOPE_ROLE_MAP.get((scope, link.get("type", "")))
+    if not scope_role:
+        return None  # unknown scope/type combination — be conservative
+    link_id = permission.get("id", "")
+    if not link_id:
+        return None
+    title = f"SharingLinks.{sp_unique_id}.{scope_role}.{link_id}"
+    return f"group:sp:{title.lower()}"
+
+
 def _extract_identity_principals(perm: Dict[str, Any], viewers: List[str]) -> None:
     """Extract user principals from grantedToIdentitiesV2/grantedToIdentities."""
     for identities_key in ("grantedToIdentitiesV2", "grantedToIdentities"):
@@ -102,11 +158,17 @@ def _extract_identity_principals(perm: Dict[str, Any], viewers: List[str]) -> No
 
 async def extract_access_control(
     permissions: List[Dict[str, Any]],
+    sp_unique_id: Optional[str] = None,
 ) -> AccessControl:
     """Build AccessControl from Graph API permissions.
 
     Args:
         permissions: List of permission objects from Graph API.
+        sp_unique_id: The SharePoint UniqueId of the item the permissions
+            belong to (lowercase GUID, no braces). Required to translate
+            non-anonymous sharing-link permissions into their corresponding
+            ``SharingLinks.*`` SP site group viewer. Pass ``None`` for
+            site/drive-level permission lists.
 
     Returns:
         AccessControl with viewers and is_public flag.
@@ -120,6 +182,13 @@ async def extract_access_control(
 
         if is_anonymous_link(perm):
             is_public = True
+            continue
+
+        # Non-anonymous sharing links: translate to the per-link SP site group.
+        link_viewer = link_permission_to_sp_group_viewer(perm, sp_unique_id)
+        if link_viewer:
+            if link_viewer not in viewers:
+                viewers.append(link_viewer)
             continue
 
         principal = extract_principal_from_permission(perm)

--- a/backend/airweave/platform/sources/sharepoint_online/builders.py
+++ b/backend/airweave/platform/sources/sharepoint_online/builders.py
@@ -96,8 +96,22 @@ async def build_file_entity(
     site_id: str,
     breadcrumbs: List[Breadcrumb],
     permissions: Optional[List[Dict[str, Any]]] = None,
+    sp_unique_id: Optional[str] = None,
 ) -> SharePointOnlineFileEntity:
-    """Build a file entity from Graph API drive item data."""
+    """Build a file entity from Graph API drive item data.
+
+    Args:
+        item_data: Graph drive item dict.
+        drive_id: Drive ID containing the item.
+        site_id: Site ID the drive belongs to.
+        breadcrumbs: Hierarchy breadcrumbs.
+        permissions: Optional permissions list from
+            ``/drives/{id}/items/{id}/permissions``.
+        sp_unique_id: Optional SharePoint ``listItemUniqueId`` for the item.
+            Required to translate sharing-link permissions; the caller should
+            fetch it via :meth:`GraphClient.get_item_sp_unique_id` when any
+            of the item's permissions has a ``link`` block.
+    """
     item_id = item_data.get("id")
     if not item_id:
         raise EntityProcessingError("Missing id for file item")
@@ -132,7 +146,7 @@ async def build_file_entity(
     download_url = item_data.get("@microsoft.graph.downloadUrl", "")
     spo_entity_id = f"spo:file:{drive_id}:{item_id}"
 
-    access = await extract_access_control(permissions or []) if permissions else None
+    access = await extract_access_control(permissions or [], sp_unique_id) if permissions else None
 
     return SharePointOnlineFileEntity(
         url=download_url or item_data.get("webUrl", ""),

--- a/backend/airweave/platform/sources/sharepoint_online/client.py
+++ b/backend/airweave/platform/sources/sharepoint_online/client.py
@@ -303,6 +303,29 @@ class GraphClient:
                 return []
             raise
 
+    async def get_item_sp_unique_id(
+        self,
+        drive_id: str,
+        item_id: str,
+    ) -> Optional[str]:
+        """Fetch the SharePoint ``listItemUniqueId`` (lowercase GUID) for a drive item.
+
+        Used to translate sharing-link permissions into the underlying
+        ``SharingLinks.<itemId>.<scopeRole>.<linkId>`` SP site group viewer.
+        Only worth calling when the item has at least one ``link`` permission;
+        for items with only direct grants there's nothing to translate.
+        """
+        url = f"{GRAPH_BASE_URL}/drives/{drive_id}/items/{item_id}?$select=sharepointIds"
+        try:
+            data = await self.get(url)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return None
+            raise
+        sp_ids = data.get("sharepointIds") or {}
+        luid = sp_ids.get("listItemUniqueId")
+        return luid.lower() if luid else None
+
     async def get_drive_root_permissions(
         self,
         drive_id: str,

--- a/backend/airweave/platform/sources/sharepoint_online/source.py
+++ b/backend/airweave/platform/sources/sharepoint_online/source.py
@@ -598,48 +598,10 @@ class SharePointOnlineBase(BaseSource):
                 new_viewers.append(v)
         entity.access.viewers = new_viewers
 
-    async def _fetch_sp_group_viewers(self, site_url: str) -> List[str]:
-        """Fetch all SP site groups for a site and return their viewer strings.
-
-        Args:
-            site_url: Full site URL (e.g. https://tenant.sharepoint.com/sites/X).
-                Required — without it we can't hit the SP REST endpoint.
-        """
-        norm_site = self._normalize_site_url(site_url)
-        if not norm_site:
-            return []
-        sp_token_provider = self._make_sp_token_provider_for_site(norm_site)
-        if not sp_token_provider:
-            return []
-        try:
-            token = await sp_token_provider()
-            headers = {
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/json;odata=verbose",
-            }
-            resp = await self.http_client.get(
-                f"{norm_site}/_api/web/sitegroups",
-                headers=headers,
-                timeout=30.0,
-            )
-            resp.raise_for_status()
-            groups = resp.json().get("d", {}).get("results", [])
-
-            viewers = []
-            site_bucket = self._item_level_sp_groups.setdefault(norm_site, set())
-            for g in groups:
-                title = g.get("Title", "")
-                if title:
-                    tag = f"group:sp:{title.lower().replace(' ', '_')}"
-                    viewers.append(tag)
-                    site_bucket.add(tag[len("group:") :])
-            self.logger.info(f"Fetched {len(viewers)} SP site groups as viewers for {norm_site}")
-            return viewers
-        except SourceAuthError:
-            raise
-        except Exception as e:
-            self.logger.warning(f"SP group fetch failed for {norm_site}: {e}")
-            return []
+    @staticmethod
+    def _has_link_permission(permissions: List[Dict[str, Any]]) -> bool:
+        """Return True if any permission carries a sharing-link block."""
+        return any(p.get("link") for p in (permissions or []))
 
     async def _full_sync(  # noqa: C901
         self,
@@ -687,8 +649,6 @@ class SharePointOnlineBase(BaseSource):
                 self.logger.warning(f"Skipping site {site_id}: {e}")
                 continue
 
-            sp_group_viewers = await self._fetch_sp_group_viewers(site_url)
-
             for drive_data in all_drives:
                 drive_id = drive_data.get("id", "")
                 try:
@@ -730,20 +690,25 @@ class SharePointOnlineBase(BaseSource):
                                     item_data["id"],
                                 )
 
+                                # Sharing-link permissions need the file's SP UniqueId
+                                # to translate into the SharingLinks.* SP site group.
+                                # Skip the extra fetch when the file has no sharing links.
+                                sp_unique_id = None
+                                if self._has_link_permission(permissions):
+                                    sp_unique_id = await graph_client.get_item_sp_unique_id(
+                                        drive_id, item_data["id"]
+                                    )
+
                                 file_entity = await build_file_entity(
                                     item_data,
                                     drive_id,
                                     site_id,
                                     drive_breadcrumbs,
                                     permissions,
+                                    sp_unique_id=sp_unique_id,
                                 )
 
                                 await self._resolve_unresolved_viewers(file_entity, graph_client)
-                                if sp_group_viewers and file_entity.access:
-                                    existing = set(file_entity.access.viewers or [])
-                                    for spv in sp_group_viewers:
-                                        if spv not in existing:
-                                            file_entity.access.viewers.append(spv)
                                 self._track_entity_groups(file_entity, site_url)
 
                                 if files:
@@ -893,12 +858,18 @@ class SharePointOnlineBase(BaseSource):
                 if item_data.get("file"):
                     try:
                         permissions = await graph_client.get_item_permissions(drive_id, item_id)
+                        sp_unique_id = None
+                        if self._has_link_permission(permissions):
+                            sp_unique_id = await graph_client.get_item_sp_unique_id(
+                                drive_id, item_id
+                            )
                         file_entity = await build_file_entity(
                             item_data,
                             drive_id,
                             "",
                             [],
                             permissions,
+                            sp_unique_id=sp_unique_id,
                         )
                         await self._resolve_unresolved_viewers(file_entity, graph_client)
                         self._track_entity_groups(file_entity)
@@ -1036,8 +1007,18 @@ class SharePointOnlineBase(BaseSource):
                     item_data = await graph_client.get(url)
                     if item_data.get("file"):
                         permissions = await graph_client.get_item_permissions(drive_id, item_id)
+                        sp_unique_id = None
+                        if self._has_link_permission(permissions):
+                            sp_unique_id = await graph_client.get_item_sp_unique_id(
+                                drive_id, item_id
+                            )
                         file_entity = await build_file_entity(
-                            item_data, drive_id, "", [], permissions
+                            item_data,
+                            drive_id,
+                            "",
+                            [],
+                            permissions,
+                            sp_unique_id=sp_unique_id,
                         )
                         await self._resolve_unresolved_viewers(file_entity, graph_client)
                         self._track_entity_groups(file_entity)
@@ -1117,7 +1098,7 @@ class SharePointOnlineBase(BaseSource):
         ):
             yield entity
 
-    async def _process_file_items(
+    async def _process_file_items(  # noqa: C901
         self,
         graph_client: GraphClient,
         item_stream: AsyncGenerator[Dict[str, Any], None],
@@ -1136,8 +1117,18 @@ class SharePointOnlineBase(BaseSource):
                 continue
             try:
                 permissions = await graph_client.get_item_permissions(drive_id, item_data["id"])
+                sp_unique_id = None
+                if self._has_link_permission(permissions):
+                    sp_unique_id = await graph_client.get_item_sp_unique_id(
+                        drive_id, item_data["id"]
+                    )
                 file_entity = await build_file_entity(
-                    item_data, drive_id, site_id, breadcrumbs, permissions
+                    item_data,
+                    drive_id,
+                    site_id,
+                    breadcrumbs,
+                    permissions,
+                    sp_unique_id=sp_unique_id,
                 )
                 if resolve_viewers:
                     await self._resolve_unresolved_viewers(file_entity, graph_client)

--- a/backend/tests/unit/platform/sources/test_sharepoint_online_acl.py
+++ b/backend/tests/unit/platform/sources/test_sharepoint_online_acl.py
@@ -1,32 +1,43 @@
 """Unit tests for SharePoint Online ACL extraction.
 
 Covers ``extract_access_control`` and the rules around how Microsoft Graph
-sharing-link permissions map to ``AccessControl.is_public``.
+sharing-link permissions map to ``AccessControl``.
 
-Background — bug fix:
-    Organization-scoped sharing links (``link.scope == "organization"``,
-    "anyone in your org with the link") used to set ``is_public = True``,
-    which made the search broker bypass all viewer checks. That mis-modeled
-    SharePoint semantics: an org-scoped link requires possession of the
-    link URL to grant access. Only ``link.scope == "anonymous"`` is true
-    public access.
+Background — two related bug fixes:
+
+1. Organization-scoped sharing links (``link.scope == "organization"``,
+   "anyone in your org with the link") used to set ``is_public = True``,
+   which made the search broker bypass all viewer checks. Only
+   ``link.scope == "anonymous"`` is genuine public access.
+
+2. The previous code attempted to recover sharing-link audience by
+   blanket-attaching every site group (including SharingLinks system
+   groups for unrelated files) to every file in the site. That over-granted
+   massively. The fix is to translate each link permission into the
+   specific ``SharingLinks.<itemId>.<scopeRole>.<linkId>`` SP site group
+   for that one file, scoped by the file's SharePoint UniqueId.
 """
 
 import pytest
 
-from airweave.platform.sources.sharepoint_online.acl import extract_access_control
+from airweave.platform.sources.sharepoint_online.acl import (
+    extract_access_control,
+    link_permission_to_sp_group_viewer,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers — build minimal Graph permission objects
 # ---------------------------------------------------------------------------
 
 
-def _link_perm(scope: str, roles=None) -> dict:
+def _link_perm(
+    scope: str, type_: str = "edit", roles=None, link_id: str = "link-1"
+) -> dict:
     """Sharing-link permission with the given scope (no grantedTo principal)."""
     return {
-        "id": f"link-{scope}",
+        "id": link_id,
         "roles": roles if roles is not None else ["write"],
-        "link": {"scope": scope, "type": "edit"},
+        "link": {"scope": scope, "type": type_},
         "grantedToIdentitiesV2": [],
         "grantedToIdentities": [],
     }
@@ -68,8 +79,51 @@ async def test_organization_scoped_link_does_not_set_is_public():
     Regression: the previous behavior treated organization-scoped links as
     fully public, bypassing all viewer checks at search time.
     """
+    # Without sp_unique_id the link cannot be translated into a SharingLinks
+    # site group viewer either — both halves of the fix combine to give
+    # "no public access, no viewer either".
     ac = await extract_access_control([_link_perm("organization")])
     assert ac.is_public is False
+    assert ac.viewers == []
+
+
+@pytest.mark.asyncio
+async def test_organization_edit_link_with_sp_unique_id_yields_per_link_viewer():
+    """When the file's SP UniqueId is known, an org+edit link translates."""
+    perm = _link_perm("organization", type_="edit", link_id="LINK0001")
+    ac = await extract_access_control(
+        [perm], sp_unique_id="dd7691b0-3468-446f-81b0-72f3bdab7d1f"
+    )
+    assert ac.is_public is False
+    assert ac.viewers == [
+        "group:sp:sharinglinks.dd7691b0-3468-446f-81b0-72f3bdab7d1f.organizationedit.link0001"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_organization_view_link_translates_to_organizationview_suffix():
+    perm = _link_perm("organization", type_="view", link_id="LINK0002")
+    ac = await extract_access_control([perm], sp_unique_id="aaaa-bbbb")
+    assert ac.viewers == ["group:sp:sharinglinks.aaaa-bbbb.organizationview.link0002"]
+
+
+@pytest.mark.asyncio
+async def test_users_scope_link_translates_to_flexible_suffix():
+    """Empirically verified: both users+edit and users+view collapse to Flexible."""
+    perm_edit = _link_perm("users", type_="edit", link_id="LINKE")
+    perm_view = _link_perm("users", type_="view", link_id="LINKV")
+    ac_e = await extract_access_control([perm_edit], sp_unique_id="ITEM1")
+    ac_v = await extract_access_control([perm_view], sp_unique_id="ITEM1")
+    assert ac_e.viewers == ["group:sp:sharinglinks.item1.flexible.linke"]
+    assert ac_v.viewers == ["group:sp:sharinglinks.item1.flexible.linkv"]
+
+
+@pytest.mark.asyncio
+async def test_anonymous_link_does_not_get_translated_to_viewer():
+    """Anonymous → is_public, never a SharingLinks viewer."""
+    perm = _link_perm("anonymous", type_="view", link_id="LINKA")
+    ac = await extract_access_control([perm], sp_unique_id="ITEM1")
+    assert ac.is_public is True
     assert ac.viewers == []
 
 
@@ -105,25 +159,27 @@ async def test_unknown_link_scope_does_not_set_is_public():
 
 
 @pytest.mark.asyncio
-async def test_org_link_alongside_explicit_grants_extracts_only_grants():
-    """Org-link permission is skipped; explicit grants populate viewers.
+async def test_org_link_alongside_explicit_grants_extracts_grants_and_link_group():
+    """Org-link plus explicit grants → both end up in viewers.
 
-    Mirrors the Mistral bug-report payload: a file with one organization-
-    scoped sharing link plus the inherited site-group grants. The fix must
-    keep is_public false while still extracting Owners / Members / Visitors.
+    Mirrors the Mistral bug-report payload shape: a file with one
+    organization-scoped sharing link plus inherited site-group grants.
+    Post-fix, is_public is False, all explicit grants are present, and
+    the per-link SharingLinks site group is included exactly once.
     """
     perms = [
-        _link_perm("organization"),
+        _link_perm("organization", link_id="LINK0001"),
         _site_group_perm("Access Control Tests Owners", group_id="3", roles=["owner"]),
         _site_group_perm("Access Control Tests Members", group_id="5", roles=["write"]),
         _site_group_perm("Access Control Tests Visitors", group_id="4", roles=["read"]),
     ]
-    ac = await extract_access_control(perms)
+    ac = await extract_access_control(perms, sp_unique_id="ITEM1")
     assert ac.is_public is False
     assert set(ac.viewers) == {
         "group:sp:access_control_tests_owners",
         "group:sp:access_control_tests_members",
         "group:sp:access_control_tests_visitors",
+        "group:sp:sharinglinks.item1.organizationedit.link0001",
     }
 
 
@@ -191,3 +247,40 @@ async def test_duplicate_principal_only_added_once():
     ]
     ac = await extract_access_control(perms)
     assert ac.viewers == ["user:alice@example.com"]
+
+
+# ---------------------------------------------------------------------------
+# link_permission_to_sp_group_viewer — None-return paths
+# ---------------------------------------------------------------------------
+
+
+def test_link_translation_returns_none_without_sp_unique_id():
+    """No SP UniqueId means we can't construct the group name — return None."""
+    perm = _link_perm("organization", link_id="L1")
+    assert link_permission_to_sp_group_viewer(perm, None) is None
+
+
+def test_link_translation_returns_none_for_non_link_perm():
+    """A non-link permission is not a sharing link — return None."""
+    perm = {"id": "x", "roles": ["read"], "grantedToV2": {"user": {"email": "a@b.com"}}}
+    assert link_permission_to_sp_group_viewer(perm, "ITEM1") is None
+
+
+def test_link_translation_returns_none_for_anonymous():
+    perm = _link_perm("anonymous", link_id="L1")
+    assert link_permission_to_sp_group_viewer(perm, "ITEM1") is None
+
+
+def test_link_translation_returns_none_for_unknown_scope():
+    """Unknown / future scope: be conservative, don't fabricate a viewer."""
+    perm = {
+        "id": "L1",
+        "roles": ["read"],
+        "link": {"scope": "future-scope", "type": "edit"},
+    }
+    assert link_permission_to_sp_group_viewer(perm, "ITEM1") is None
+
+
+def test_link_translation_returns_none_when_link_id_missing():
+    perm = {"id": "", "roles": ["read"], "link": {"scope": "organization", "type": "edit"}}
+    assert link_permission_to_sp_group_viewer(perm, "ITEM1") is None


### PR DESCRIPTION
> Stacked on top of #1774 (PR #1, organization-link `is_public` fix). Set the base back to `main` once #1774 is merged.

## Summary

The SharePoint Online connector copied **every** site group returned by `/_api/web/sitegroups` onto **every file in the site** (`_fetch_sp_group_viewers` + the merge block in `_full_sync`). That over-granted in three distinct ways:

1. **SharingLinks spillover.** A `SharingLinks.<itemId>.<scopeRole>.<linkId>` system group is created per sharing link. Blanket-attaching it to every file in the site meant a user who redeemed a link for one file gained access to *every* file in the site.
2. **Custom-group spillover.** An admin-created site group (e.g. `engineering-test`) intentionally granted on one subfolder was blanket-attached to every file, so members saw files outside the folder they were granted on.
3. **Broken-inheritance under-tightening.** Default `Members` / `Owners` / `Visitors` and `Limited Access System Group` entries were re-attached to files whose inheritance the admin had deliberately broken to remove those groups, undoing the access tightening.

## Why blanket-attach existed in the first place

Microsoft Graph's per-item `permissions` response represents a sharing link as a `link` permission block, **not** as a `siteGroup` grant — even though SharePoint internally tracks redeemers as members of a `SharingLinks.<itemId>.<scopeRole>.<linkId>` site group. So an item with a sharing link has a "link permission" in the API but no `siteGroup` viewer for the link's audience. The blanket-attach was a sledgehammer fix to close that gap, but it took every other site group along with it.

## The fix

Trust the per-item Graph permissions response — for both intact and broken inheritance it already returns the correct set of principals. Then, surgically translate the one thing Graph doesn't model as a `siteGroup`: derive the corresponding `SharingLinks.<itemId>.<scopeRole>.<linkId>` group viewer **on the one file the link is for**, scoped by the file's SharePoint UniqueId.

### Scope/type → group-suffix mapping (empirically verified on the live tenant)

| `link.scope` | `link.type` | SharePoint suffix |
|---|---|---|
| `organization` | `edit` | `OrganizationEdit` |
| `organization` | `view` | `OrganizationView` |
| `users` | `edit` | `Flexible` |
| `users` | `view` | `Flexible` (yes, same — SP stores the role separately) |
| `anonymous` | * | n/a — handled by `is_public` (see PR #1774) |

### Code changes

- **`acl.py`**: new `link_permission_to_sp_group_viewer(perm, sp_unique_id)` helper returning the `group:sp:sharinglinks.…` viewer string. `extract_access_control` grows an optional `sp_unique_id` parameter; when present, non-anonymous link permissions are appended as the per-link site-group viewer instead of being silently skipped.
- **`client.py`**: new `GraphClient.get_item_sp_unique_id(drive_id, item_id)` that fetches just `sharepointIds.listItemUniqueId` via `?$select=sharepointIds`.
- **`source.py`**: deletes `_fetch_sp_group_viewers` (the blanket-attach helper) and its call/merge block. Each file-build path (`_full_sync`, `_incremental_sync`, `_sync_drive`, `_targeted_sync` file branch, `_process_file_items`) does a conditional UniqueId lookup **only when** the item's permissions actually contain a `link` block. For files with no sharing link the per-file cost is zero — same as before.
- **`builders.py`**: `build_file_entity` plumbs `sp_unique_id` through to `extract_access_control`.

## Tests

`backend/tests/unit/platform/sources/test_sharepoint_online_acl.py` extended (20 tests total now, all passing). New cases:

- Org+edit, org+view, users+edit, users+view → derived `sharinglinks.<id>.<scoperole>.<linkid>` viewer present, lowercased.
- Anonymous link → `is_public = True`, **no** SharingLinks viewer added.
- Org-link alongside explicit site-group grants → all explicit grants present plus the per-link viewer.
- `link_permission_to_sp_group_viewer` returns `None` when: no `sp_unique_id`, no `link` block, anonymous scope, unknown/future scope, missing link id.

Existing 483 source unit tests still green.

## End-to-end verification

Set up against the live `neenacorp.sharepoint.com` tenant on the local stack, with five fixtures designed to expose each over-grant mode independently:

| Fixture | Setup | Purpose |
|---|---|---|
| `restricted-folder/org-link-test.txt` | inherits, has org-scoped sharing link; `acl_test_user1` is in the link's SharingLinks group | SharingLinks per-file translation + spillover regression |
| `no-link-file.txt` | inherits, no special perms | control: clean inherited state |
| `jean-only-folder/jean-doc.txt` | broken inheritance, granted only to `acl_test_user2` | broken-inheritance over-grant |
| `eng-only-folder/eng-doc.txt` | broken inheritance, granted only to custom site group `engineering-test`; `acl_test_user3` is in that group | custom-group spillover |
| `BartJ + Vitesse.docx` | inherits, no special perms | control |

### Stored-viewer shrink (pre vs. post fix)

| File | Pre-fix viewers | Post-fix viewers |
|---|---|---|
| `org-link-test.txt` | 7 (incl. unrelated `engineering-test` and the SharingLinks group via blanket) | **5** — site groups + M365 group + the file's own SharingLinks group via per-link translation |
| `no-link-file.txt` | 6 (incl. unrelated `engineering-test` and SharingLinks) | **4** — clean inherited state |
| `jean-doc.txt` | 8 (incl. blanket Members/Owners/Visitors/engineering-test/SharingLinks) | **3** — `daan`, `acl_test_user2`, M365 group |
| `eng-doc.txt` | 7 (incl. blanket site defaults + unrelated SharingLinks) | **3** — `daan`, `engineering-test`, M365 group |

### Search-as-user matrix

| Principal | Memberships | org-link | no-link | jean-doc | eng-doc | Δ vs. pre |
|---|---|---|---|---|---|---|
| `lennert@` | M365 group → site Owners | 1 | 1 | 1 | 1 | unchanged result, but now via legitimate paths only |
| `acl_test_user1@` | SharingLinks (org-link-test) | 1 | **0** | **0** | **0** | **was 1/1/1/1 — SharingLinks spillover closed** |
| `acl_test_user2@` | direct grant on jean-only | 0 | 0 | 1 | 0 | unchanged |
| `acl_test_user3@` | `engineering-test` group | **0** | **0** | **0** | 1 | **was 1/1/1/1 — custom-group spillover closed** |
| `acl_test_user4@` | none | 0 | 0 | 0 | 0 | unchanged (PR #1774 already fixed `is_public` bypass) |

### One subtle finding worth flagging

`lennert`'s post-fix hit count is unchanged (4/4) — but for a different reason than pre-fix. The Graph per-item permissions for `jean-only-folder` and `eng-only-folder` show that **SharePoint automatically retains the M365 group with `roles: ["owner"]` on broken-inheritance items**, even after `--clearExistingPermissions`. The site's owning M365 group keeps Owner role on every item in the site collection. `lennert` is an Owner of that M365 group, so they have legitimate Owner access to those files via the per-item permissions response — not via blanket-attach.

What this means: the "site Members can no longer see broken-inheritance files" outcome from Mistral's report depends on the M365 group's Owner role being managed properly. For users who are Members but not Owners of the M365 group, the fix should give the expected shrink. We don't have such a user in the test tenant to verify directly, but the viewer-list shrink (8 → 3 entries on `jean-doc.txt`) is empirical confirmation that the blanket pollution is gone.

## Performance note

For files without sharing links (the common case), behavior is identical to today — the conditional `if any(p.get("link") for p in permissions)` short-circuits the extra Graph call. For files **with** a sharing link, we make one additional `?$select=sharepointIds` call to fetch the SP UniqueId. On a site where many files have links, that's roughly 2x the permission-related Graph calls per such file. Acceptable, and explicit in `source.py` so the cost is visible.

## Test plan

- [x] Unit tests pass (20 new/updated in `test_sharepoint_online_acl.py`).
- [x] Existing source unit tests pass (483 total).
- [x] Lint/format clean (one `# noqa: C901` added on `_process_file_items`, in line with sibling functions).
- [x] End-to-end live tenant verification (above).
- [ ] Reviewer: confirm that customer SharePoint connections re-sync after this lands picks up clean ACLs (entities are upserted with new `access` per sync; no migration script required).
- [ ] Reviewer: spot-check a customer with `Limited Access System Group for Web/List/...` entries (didn't appear on our test tenant) — those should also disappear cleanly post-fix since they live only in `/_api/web/sitegroups`, not per-item permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes over-granted access in SharePoint Online by removing blanket site-group attachment and scoping sharing-link viewers to the specific file. Trusts per-item Graph permissions and derives a per-file `group:sp:sharinglinks.<itemId>.<scopeRole>.<linkId>` viewer when a non-anonymous link exists.

- Bug Fixes
  - Removed copying all site groups to every file to prevent spillover and undoing broken inheritance.
  - Translate non-anonymous `link` permissions into a per-file SharingLinks viewer using the file’s SharePoint UniqueId; anonymous links only set `is_public`.
  - Fetch the UniqueId only when a `link` permission is present to avoid extra calls.
  - Deleted the blanket-attach helper/merge. Added `get_item_sp_unique_id`, `link_permission_to_sp_group_viewer`, extended `extract_access_control(sp_unique_id)`, and plumbed the ID through file entity builders.

<sup>Written for commit fccafde91bfea31e46c59e6411ea36aaef59b535. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

