### PR TITLE
fix(sharepoint_online): expand "Everyone except external users" claim into per-user memberships

### DIFF
--- a/backend/airweave/platform/sources/sharepoint_online/client.py
+++ b/backend/airweave/platform/sources/sharepoint_online/client.py
@@ -303,6 +303,30 @@ class GraphClient:
                 return []
             raise
 
+    async def list_internal_tenant_users(self) -> AsyncGenerator[Dict[str, str], None]:
+        """Yield internal tenant members (``userType eq 'Member'``).
+
+        Used to expand the SharePoint "Everyone except external users" claim
+        into per-user memberships of the synthetic claim group. The Graph
+        filter excludes guests (``userType eq 'Guest'``), preserving the
+        claim's "except external" semantics.
+
+        Yields:
+            Dicts with at least ``email`` (mail or userPrincipalName,
+            lowercased) and ``display_name``. Users without any addressable
+            identifier are skipped.
+        """
+        url = (
+            f"{GRAPH_BASE_URL}/users"
+            "?$filter=userType eq 'Member'"
+            "&$select=id,mail,userPrincipalName,displayName"
+        )
+        async for u in self.get_paginated(url):
+            email = (u.get("mail") or u.get("userPrincipalName") or "").strip().lower()
+            if not email:
+                continue
+            yield {"email": email, "display_name": u.get("displayName") or email}
+
     async def get_item_sp_unique_id(
         self,
         drive_id: str,

--- a/backend/airweave/platform/sources/sharepoint_online/source.py
+++ b/backend/airweave/platform/sources/sharepoint_online/source.py
@@ -75,6 +75,14 @@ from airweave.schemas.source_connection import AuthenticationMethod, OAuthType
 MAX_CONCURRENT_FILE_DOWNLOADS = 10
 ITEM_BATCH_SIZE = 50
 
+# Synthetic principal representing the SharePoint "Everyone except external users"
+# claim. SP exposes this claim as a member of site groups but our membership
+# table only handles real users / Entra groups / SP groups. We translate the
+# claim into a synthetic group, populate it with the tenant's internal members
+# at sync time, and let the broker's recursive expansion do the rest.
+EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL = "claim:everyone_except_external"
+EVERYONE_EXCEPT_EXTERNAL_DISPLAY_NAME = "Everyone except external users (synthetic)"
+
 
 @dataclass
 class PendingFileDownload:
@@ -110,6 +118,10 @@ class SharePointOnlineBase(BaseSource):
     # Site-scoped SP group tracking: {site_url: {sp_group_name, ...}}
     # Keyed by normalized site URL so multi-site syncs can expand SP groups per site.
     _item_level_sp_groups: Dict[str, Set[str]]
+    # Set to True during membership extraction when an SP group contains the
+    # "Everyone except external users" claim, so we know to enumerate internal
+    # tenant users once at the end.
+    _needs_internal_user_enum: bool
 
     def _init_common(self, config: SharePointOnlineConfig) -> None:
         """Initialize fields shared by both OAuth and client-credentials sources."""
@@ -118,6 +130,7 @@ class SharePointOnlineBase(BaseSource):
         self._include_pages = config.include_pages
         self._item_level_entra_groups = set()
         self._item_level_sp_groups = {}
+        self._needs_internal_user_enum = False
 
     # -- Auth hooks (subclasses override) --
 
@@ -234,6 +247,14 @@ class SharePointOnlineBase(BaseSource):
         r"(?P<guid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
         r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(_o)?$"
     )
+    # Match the "Everyone except external users" claim:
+    #   "c:0-.f|rolemanager|spo-grid-all-users/<tenantId>"
+    # PrincipalType=4 (SecurityGroup), but the claim provider is `rolemanager`
+    # rather than `federateddirectoryclaimprovider`. Represents all tenant
+    # users with userType=Member; excludes B2B guests by definition.
+    _EVERYONE_EXCEPT_EXTERNAL_LOGIN_RE = re.compile(
+        r"^c:0-\.f\|rolemanager\|spo-grid-all-users/[0-9a-fA-F-]+$"
+    )
 
     @classmethod
     def _email_from_membership_login(cls, login: str) -> Optional[str]:
@@ -255,16 +276,26 @@ class SharePointOnlineBase(BaseSource):
         """Parse one entry from /_api/web/sitegroups({id})/users into (member_id, member_type).
 
         Returns None for entries that should not become memberships:
-        - Role principals (PrincipalType=16, e.g. "Everyone except external users")
-        - Catch-all "All" principals (PrincipalType=15)
-        - DistList, SPGroup, unknown types (skipped; rare in practice)
+        - Catch-all "All" / "Everyone" principals (PrincipalType=15)
+        - DistList, SPGroup, RoleManager (other than the recognized claim below)
         - Unparseable entries (no email for users, no GUID for groups)
+
+        Recognized PrincipalType=4 shapes:
+        - Entra federated group: ``c:0o.c|federateddirectoryclaimprovider|<guid>[_o]``
+          → returns ``("entra:<guid>", "group")``.
+        - "Everyone except external users" claim:
+          ``c:0-.f|rolemanager|spo-grid-all-users/<tenantId>`` → returns the
+          synthetic ``(EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL, "group")`` sentinel.
+          The caller (``_expand_sp_site_groups``) then enumerates internal
+          tenant users once per sync to populate the synthetic group.
+        - Any other PT=4 LoginName: returns None. The caller logs the raw
+          shape at info-level so unknown claim shapes show up in operator
+          logs and can be wired up explicitly later.
 
         PrincipalType reference:
             1  = User
             2  = DistList
-            4  = SecurityGroup (Entra group when LoginName uses
-                 federateddirectoryclaimprovider)
+            4  = SecurityGroup (Entra group OR rolemanager claim)
             8  = SPGroup
             15 = All
             16 = RoleManager
@@ -285,14 +316,31 @@ class SharePointOnlineBase(BaseSource):
 
         if ptype == 4:
             m = cls._ENTRA_GROUP_LOGIN_RE.match(login)
-            if not m:
-                return None
-            guid = m.group("guid").lower()
-            return (f"entra:{guid}", "group")
+            if m:
+                return (f"entra:{m.group('guid').lower()}", "group")
+            if cls._EVERYONE_EXCEPT_EXTERNAL_LOGIN_RE.match(login):
+                return (EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL, "group")
+            return None
 
         # PrincipalType 2 (DistList), 8 (SPGroup), 15 (All), 16 (RoleManager),
         # and unknown types are intentionally skipped.
         return None
+
+    @classmethod
+    def _is_unrecognized_pt4_login(cls, user: Dict[str, Any]) -> bool:
+        """Return True for a PT=4 entry whose LoginName matches none of our patterns.
+
+        Used at the call site to emit a one-line diagnostic so that unknown
+        claim shapes (rare custom rolemanager roles, legacy Windows claims,
+        etc.) surface in operator logs without breaking sync.
+        """
+        if user.get("PrincipalType") != 4:
+            return False
+        login = user.get("LoginName", "") or ""
+        return not (
+            cls._ENTRA_GROUP_LOGIN_RE.match(login)
+            or cls._EVERYONE_EXCEPT_EXTERNAL_LOGIN_RE.match(login)
+        )
 
     # -- Browse Tree --
 
@@ -1248,6 +1296,12 @@ class SharePointOnlineBase(BaseSource):
                 for user in users:
                     parsed = self._parse_sp_group_member(user)
                     if parsed is None:
+                        if self._is_unrecognized_pt4_login(user):
+                            self.logger.info(
+                                "Unrecognized PrincipalType=4 SP group member; skipped. "
+                                f"LoginName={user.get('LoginName', '')!r} "
+                                f"Title={user.get('Title', '')!r}"
+                            )
                         continue
                     member_id, member_type = parsed
                     yield MembershipTuple(
@@ -1256,6 +1310,42 @@ class SharePointOnlineBase(BaseSource):
                         group_id=sp_name,
                         group_name=user.get("Title") or sp_name,
                     )
+                    if member_id == EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL:
+                        self._needs_internal_user_enum = True
+
+    async def _expand_everyone_except_external(
+        self,
+    ) -> AsyncGenerator[MembershipTuple, None]:
+        """Populate the synthetic ``EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL`` group.
+
+        Called once per sync, only when the SP group expansion observed at
+        least one occurrence of the claim. Enumerates internal tenant users
+        via Graph (``userType eq 'Member'`` filter excludes B2B guests) and
+        yields one user → claim membership per user. The broker's recursive
+        group expansion then chains user → claim → SP group at search time.
+        """
+        graph_client = self._create_graph_client()
+        count = 0
+        try:
+            async for u in graph_client.list_internal_tenant_users():
+                count += 1
+                yield MembershipTuple(
+                    member_id=u["email"],
+                    member_type="user",
+                    group_id=EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL,
+                    group_name=EVERYONE_EXCEPT_EXTERNAL_DISPLAY_NAME,
+                )
+        except SourceAuthError:
+            raise
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to enumerate internal tenant users for "
+                f"'{EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL}': {e}"
+            )
+        self.logger.info(
+            f"Populated synthetic '{EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL}' group "
+            f"with {count} internal tenant users"
+        )
 
     async def generate_access_control_memberships(
         self,
@@ -1263,6 +1353,7 @@ class SharePointOnlineBase(BaseSource):
         """Expand Entra ID groups and SP site groups into user memberships."""
         self.logger.info("Starting access control membership extraction")
         membership_count = 0
+        self._needs_internal_user_enum = False
         group_expander = self._create_group_expander()
 
         async for m in self._expand_entra_groups(group_expander):
@@ -1277,6 +1368,14 @@ class SharePointOnlineBase(BaseSource):
             raise
         except Exception as e:
             self.logger.warning(f"SP site group expansion failed: {e}")
+
+        # If any SP site group contained the "Everyone except external users"
+        # claim, populate the synthetic claim group with internal tenant users
+        # exactly once. Skipped entirely when no group used the claim.
+        if self._needs_internal_user_enum:
+            async for m in self._expand_everyone_except_external():
+                yield m
+                membership_count += 1
 
         group_expander.log_stats()
         self.logger.info(f"Access control extraction complete: {membership_count} memberships")

--- a/backend/tests/unit/platform/sources/test_sharepoint_online_group_expansion.py
+++ b/backend/tests/unit/platform/sources/test_sharepoint_online_group_expansion.py
@@ -6,7 +6,10 @@ migration path for tracked_sp_groups.
 
 from unittest.mock import MagicMock
 
-from airweave.platform.sources.sharepoint_online.source import SharePointOnlineBase
+from airweave.platform.sources.sharepoint_online.source import (
+    EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL,
+    SharePointOnlineBase,
+)
 
 # ---------------------------------------------------------------------------
 # _email_from_membership_login
@@ -179,6 +182,69 @@ def test_parse_security_group_non_federated_returns_none():
         "Title": "On-prem Group",
     }
     assert SharePointOnlineBase._parse_sp_group_member(user) is None
+
+
+def test_parse_everyone_except_external_claim_returns_synthetic_sentinel():
+    """The rolemanager/spo-grid-all-users claim → synthetic group sentinel."""
+    user = {
+        "PrincipalType": 4,
+        "LoginName": (
+            "c:0-.f|rolemanager|spo-grid-all-users/26adf163-2699-4d04-a0ad-3d935411bf45"
+        ),
+        "Title": "Everyone except external users",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) == (
+        EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL,
+        "group",
+    )
+
+
+def test_parse_everyone_except_external_uppercase_tenant_id():
+    """Tenant ID GUIDs may be upper- or lowercase; both should match."""
+    user = {
+        "PrincipalType": 4,
+        "LoginName": (
+            "c:0-.f|rolemanager|spo-grid-all-users/26ADF163-2699-4D04-A0AD-3D935411BF45"
+        ),
+        "Title": "Everyone except external users",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) == (
+        EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL,
+        "group",
+    )
+
+
+def test_parse_other_rolemanager_claim_skipped_and_flagged_as_unrecognized():
+    """A different rolemanager claim shouldn't match; should be flagged for logging."""
+    user = {
+        "PrincipalType": 4,
+        "LoginName": "c:0-.f|rolemanager|some-future-claim",
+        "Title": "Custom Role",
+    }
+    assert SharePointOnlineBase._parse_sp_group_member(user) is None
+    assert SharePointOnlineBase._is_unrecognized_pt4_login(user) is True
+
+
+def test_is_unrecognized_pt4_login_false_for_known_shapes():
+    """Known PT=4 shapes (Entra group, claim) must NOT be flagged as unrecognized."""
+    entra = {
+        "PrincipalType": 4,
+        "LoginName": (
+            "c:0o.c|federateddirectoryclaimprovider|7d344400-39bc-4ee7-aa6e-437bd8de85c0"
+        ),
+    }
+    claim = {
+        "PrincipalType": 4,
+        "LoginName": "c:0-.f|rolemanager|spo-grid-all-users/26adf163-2699-4d04-a0ad-3d935411bf45",
+    }
+    assert SharePointOnlineBase._is_unrecognized_pt4_login(entra) is False
+    assert SharePointOnlineBase._is_unrecognized_pt4_login(claim) is False
+
+
+def test_is_unrecognized_pt4_login_false_for_non_pt4():
+    """The flag is scoped to PT=4 only; other PrincipalTypes are skipped silently."""
+    user = {"PrincipalType": 1, "LoginName": "i:0#.f|membership|alice@example.com"}
+    assert SharePointOnlineBase._is_unrecognized_pt4_login(user) is False
 
 
 def test_parse_distlist_skipped():


### PR DESCRIPTION
> Stacked on top of #1775 (PR #2, blanket-attach). Set the base back to \`main\` once #1775 merges.

## Summary

The SharePoint claim **"Everyone except external users"** — the default audience SharePoint adds to most sites' Members and Visitors groups, representing all internal tenant members and excluding B2B guests — was being silently dropped during membership extraction.

SharePoint returns it as a member of site groups with `PrincipalType=4` (same as Entra federated groups) but with the `rolemanager` claim provider rather than `federateddirectoryclaimprovider`:

```
PrincipalType: 4
LoginName: c:0-.f|rolemanager|spo-grid-all-users/<tenantId>
Title: Everyone except external users
```

The existing `_parse_sp_group_member` regex only matched the Entra shape, so the claim hit `return None` with no log line. Any file accessible only via a site group that contained the claim was invisible in search to internal users without an alternate access path.

This is a high-impact gap because the claim is the **default** audience on:
- Classic team sites (non-M365-group-backed)
- Communication sites
- Hub sites
- Migrated SharePoint Server sites
- Effectively most enterprise SharePoint deployments

Reported by Mistral on a customer tenant.

## Fix

Translate the claim into a synthetic group `claim:everyone_except_external`, populated once per sync with the tenant's internal members fetched via Graph (`/users?$filter=userType eq 'Member'`). The broker's existing recursive group expansion then chains:

```
user → claim:everyone_except_external → sp:<groupContainingClaim> → file viewers
```

at search time, with no broker, schema, or search-path changes.

The `userType eq 'Member'` filter is what preserves the "except external" semantics: Graph excludes B2B guests automatically, so guest users do NOT pick up the claim membership. Verified against the live tenant (49 Member rows, 0 Guest rows in this tenant — the filter is correct).

### Why a synthetic group, not `is_public` or search-time resolution

| Approach | Why we didn't pick it |
|---|---|
| Treat the claim like `link.scope=anonymous` (`is_public=True`) | Would over-grant to guests — the claim's whole point is to exclude them |
| Synthetic group resolved at search time | Requires a Graph call per search to determine `userType`; new principal-type concept; broker complexity |
| **Synthetic group with sync-time enumeration** | No broker changes, no schema changes, composes with existing recursive expansion. Same staleness model as every other membership we sync. **Picked.** |

## Code changes

- **`source.py`**:
  - `EVERYONE_EXCEPT_EXTERNAL_PRINCIPAL = "claim:everyone_except_external"` constant.
  - New `_EVERYONE_EXCEPT_EXTERNAL_LOGIN_RE` matching `^c:0-\.f\|rolemanager\|spo-grid-all-users/[0-9a-fA-F-]+$`.
  - `_parse_sp_group_member` recognizes the claim and returns the synthetic sentinel. Docstring corrected (PT=4 with rolemanager, not PT=16 — Mistral's report flagged this too).
  - New `_is_unrecognized_pt4_login` classifier; the `_expand_sp_site_groups` call site logs a single info-level line for any unrecognized PT=4 shape so future unknown claim variants surface in operator logs without breaking sync.
  - `_expand_sp_site_groups` flips `_needs_internal_user_enum` when the sentinel is yielded.
  - New `_expand_everyone_except_external` enumerates internal users via Graph and yields per-user → claim memberships **once per sync**.
  - `generate_access_control_memberships` runs the enumeration only when the flag was set — zero cost on tenants whose sites don't use the claim.
- **`client.py`**: new `GraphClient.list_internal_tenant_users` paginates `/users?$filter=userType eq 'Member'&$select=id,mail,userPrincipalName,displayName`. Falls back to `userPrincipalName` when `mail` is empty (common for synthetic test users).

## Tests

6 new unit tests in `test_sharepoint_online_group_expansion.py`:
- The rolemanager/spo-grid-all-users claim → synthetic sentinel (lower- and uppercase tenant GUIDs).
- Other rolemanager LoginNames → `None` and flagged via `_is_unrecognized_pt4_login`.
- `_is_unrecognized_pt4_login` returns `False` for both known PT=4 shapes (Entra group, the claim).
- `_is_unrecognized_pt4_login` returns `False` for non-PT=4 entries.

All 488 existing source-unit tests still pass.

## End-to-end verification

The bug doesn't surface naturally on M365-group-backed team sites because the org policy *blocks adding the claim* there ("Your organizational policies doesn't allow Everyone except external users to be added to a group site marked as private."). So we manufactured the bug surface on a communication site instead — which is the same site type real customers hit it on.

### Setup

- Site: `https://neenacorp.sharepoint.com/sites/communication` (a communication site, no M365 group)
- New custom SP site group `claim-test-group`, containing only the "Everyone except external users" claim (added via SP REST POST `/sitegroups({id})/users`).
- New folder `Shared Documents/claim-only-folder` with broken inheritance, granted only to `claim-test-group`.
- File `claim-doc.txt` with canary `EXTERNALCLAIMCANARY42`.
- New airweave collection `claimtest-58i11d` and source connection scoped to that site only.

### Pre-fix observation

| Check | Result |
|---|---|
| Membership table for `claim-test-group` after sync | **0 rows** (silent drop confirmed) |
| Search-as-user `daan@` (direct grant) | 1 hit (legitimate) |
| Search-as-user `lennert@` (internal Member) | **0 hits — bug** |
| Search-as-user `acl_test_user1@` (internal Member) | **0 hits — bug** |
| Search-as-user `acl_test_user5@` (internal Member) | **0 hits — bug** |

### Post-fix observation

| Check | Result |
|---|---|
| Membership table — claim → SP group | 1 row (`claim:everyone_except_external` → `sp:claim-test-group`) |
| Membership table — user → claim | **49 rows** (matches tenant's `userType=Member` count from Graph) |
| Sync log line | "Populated synthetic 'claim:everyone_except_external' group with 49 internal tenant users" |
| Search-as-user `daan@` | 1 hit (unchanged) |
| Search-as-user `lennert@` | **1 hit ✓ (fixed)** |
| Search-as-user `acl_test_user1@` | **1 hit ✓ (fixed)** |
| Search-as-user `acl_test_user5@` | **1 hit ✓ (fixed)** |

### PR #2 regression check

Ran the full PR #2 search-as-user matrix on the `orglinktest-c0s3i0` collection after this fix landed. All cells unchanged from PR #2's post-fix state — no regression in either is_public handling (PR #1) or per-link translation / blanket-attach removal (PR #2).

### What was NOT verified end-to-end

- **Guest / external user blocked.** Tenant has 0 guests, so we couldn't validate that `userType=Guest` users don't pick up the claim. This guarantee is delegated to the Graph filter (`userType eq 'Member'`), which is well-documented to exclude guests. Mistral can verify on a tenant that has guests.
- **Diagnostic logging for unknown PT=4 shapes.** Covered by unit tests; not exercised end-to-end because adding an arbitrary fake LoginName to an SP group requires admin-level overrides that vary per tenant. The unit tests pin the classifier behavior.

## Performance note

Internal-user enumeration runs **only** if at least one SP site group encountered during sync contained the claim — tracked via the `_needs_internal_user_enum` flag. Tenants whose sites use only Entra groups or direct grants pay zero extra cost.

When triggered, it's a single paginated Graph call with `$top=200`. For Mistral's tenant scale (~50 internal members) that's one request. For a 10K-user tenant, ~50 paginated requests. The result is shared across all SP groups containing the claim within a single sync — no per-group fan-out.

## Test plan

- [x] Unit tests pass (6 new + 488 existing).
- [x] Lint/format clean on changed files.
- [x] End-to-end live tenant verification (above).
- [x] PR #2 regression matrix unchanged.
- [ ] Reviewer: confirm the connector's app credential has Graph `User.Read.All` (required for `/users?$filter=userType eq 'Member'`). If not, the enumeration will fail with a logged warning and the claim won't expand — fail-closed, no silent over-grant.
- [ ] Mistral: validate against a tenant with B2B guest users to confirm guests are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where the SharePoint “Everyone except external users” claim was dropped during sync. We now expand it into a synthetic group with per-user memberships so internal users can find content, while guests stay excluded.

- **Bug Fixes**
  - Recognize `c:0-.f|rolemanager|spo-grid-all-users/<tenantId>` and map it to `claim:everyone_except_external`.
  - Populate the synthetic group once per sync using Graph users filtered by `userType eq 'Member'` (excludes guests). No broker or schema changes.
  - Log unknown PrincipalType=4 shapes once for diagnostics.
  - Enumeration runs only if the claim is present; zero overhead otherwise.

- **Migration**
  - Ensure the connector app has Graph `User.Read.All`. Without it, the claim won’t expand (fail-closed with a warning).

<sup>Written for commit df2715d264f04d572dabcf9d4f641b6af586fef7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

