### PR TITLE
fix(pipedream): accept source_connection_id kwarg

### DIFF
--- a/backend/airweave/domains/auth_provider/providers/pipedream.py
+++ b/backend/airweave/domains/auth_provider/providers/pipedream.py
@@ -572,11 +572,22 @@ class PipedreamAuthProvider(BaseAuthProvider):
         source_auth_config_fields: List[str],
         optional_fields: Optional[Set[str]] = None,
         source_config_field_mappings: Optional[Dict[str, str]] = None,
+        source_connection_id: Optional[UUID] = None,
     ) -> AuthResult:
         """Get auth result for Pipedream.
 
         Only sources with custom OAuth clients are supported. Blocked sources
         and default OAuth clients raise errors.
+
+        Args:
+            source_short_name: The short name of the source to get credentials for
+            source_auth_config_fields: The fields required for the source auth config
+            optional_fields: Fields that can be skipped if not available in Pipedream
+            source_config_field_mappings: Mapping of config fields extractable from the
+                provider response
+            source_connection_id: UUID of the source connection. Accepted for parity
+                with the base contract; Pipedream identifies accounts by source slug
+                and project, so the value is forwarded but otherwise unused.
         """
         if source_short_name in self.BLOCKED_SOURCES:
             raise AuthProviderConfigError(
@@ -586,7 +597,10 @@ class PipedreamAuthProvider(BaseAuthProvider):
 
         try:
             credentials = await self.get_creds_for_source(
-                source_short_name, source_auth_config_fields, optional_fields
+                source_short_name,
+                source_auth_config_fields,
+                optional_fields,
+                source_connection_id=source_connection_id,
             )
             self.logger.info(
                 f"Custom OAuth client detected for {source_short_name} - using direct mode"

--- a/backend/airweave/domains/auth_provider/tests/test_pipedream.py
+++ b/backend/airweave/domains/auth_provider/tests/test_pipedream.py
@@ -2,6 +2,7 @@
 
 import json
 from unittest.mock import AsyncMock, patch
+from uuid import uuid4
 
 import httpx
 import pytest
@@ -645,6 +646,31 @@ async def test_get_auth_result_default_oauth_raises_config_error():
     with patch.object(provider, "_get_account_with_credentials", fake_get_account):
         with pytest.raises(AuthProviderConfigError, match="default OAuth client"):
             await provider.get_auth_result("slack", ["access_token"])
+
+
+@pytest.mark.asyncio
+async def test_get_auth_result_accepts_source_connection_id_kwarg():
+    """source_connection_id is part of the base contract; the override must accept it."""
+    provider = await PipedreamAuthProvider.create(
+        credentials={"client_id": "cid", "client_secret": "csec"},
+        config={"project_id": "proj", "account_id": "acc"},
+    )
+    account_data = {
+        "app": {"name_slug": "slack_v2"},
+        "name": "My Slack",
+        "credentials": {"oauth_access_token": "xoxb-tok"},
+    }
+
+    async def fake_get_account(client, slug, source):
+        return account_data
+
+    with patch.object(provider, "_get_account_with_credentials", fake_get_account):
+        result = await provider.get_auth_result(
+            "slack",
+            ["access_token"],
+            source_connection_id=uuid4(),
+        )
+    assert result.credentials == {"access_token": "xoxb-tok"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`PipedreamAuthProvider.get_auth_result` overrode the base method without accepting `source_connection_id`. The lifecycle caller in `domains/sources/lifecycle.py:393` always passes it (it's part of `BaseAuthProvider.get_auth_result`'s contract since the introduction of the Custom auth provider, which scopes credentials per connection), so every Pipedream-backed sync raised `TypeError: get_auth_result() got an unexpected keyword argument 'source_connection_id'` and failed before reaching the credential fetch.

Production saw ~44 of these per day, contributing to the chronic sync-worker failure rate. Pipedream identifies accounts by source slug and project rather than connection id, so the value is forwarded to `get_creds_for_source` (already accepted there) but otherwise unused. A regression test in `test_pipedream` exercises the kwarg path.