### PR TITLE
fix(outlook_mail): set required file_type field

### DIFF
--- a/backend/airweave/platform/sources/outlook_mail.py
+++ b/backend/airweave/platform/sources/outlook_mail.py
@@ -9,6 +9,7 @@ Follows the same structure as the Gmail connector implementation.
 """
 
 import base64
+import os
 from datetime import datetime
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
@@ -621,12 +622,20 @@ class OutlookMailSource(BaseSource):
                     return None
 
             composite_id = f"{message_id}_attachment_{attachment_id}"
+            mime_type = attachment.get("contentType") or "application/octet-stream"
+            if "/" in mime_type:
+                file_type = mime_type.split("/")[0]
+            else:
+                ext = os.path.splitext(attachment_name)[1].lower().lstrip(".")
+                file_type = ext if ext else "file"
+
             file_entity = OutlookAttachmentEntity(
                 composite_id=composite_id,
                 breadcrumbs=breadcrumbs,
                 name=attachment_name,
                 url=f"outlook://attachment/{message_id}/{attachment_id}",
-                mime_type=attachment.get("contentType"),
+                file_type=file_type,
+                mime_type=mime_type,
                 size=attachment.get("size", 0),
                 message_id=message_id,
                 attachment_id=attachment_id,


### PR DESCRIPTION
`OutlookAttachmentEntity` inherits from `FileEntity`, where `file_type` is required. The attachment-entity construction in `_process_single_attachment` omitted the field, so every attachment emitted a Pydantic validation error
(`1 validation error for OutlookAttachmentEntity ... file_type field required`) that cascaded into a sync-pipeline failure for the affected message.

Mirror the convention established in `outlook_calendar.py` (`Entity.from_api_data`, lines 427–431): derive `file_type` from the MIME top-level when available, fall back to the filename extension, and finally to the literal `"file"`. Default `mime_type` to `application/octet-stream` when the Graph response omits it so downstream consumers always have a non-null hint.