### PR TITLE
security: remove hardcoded encryption key and credentials from manual_stripe_pro_flow.py

### DIFF
--- a/backend/scripts/manual_stripe_pro_flow.py
+++ b/backend/scripts/manual_stripe_pro_flow.py
@@ -5,6 +5,9 @@ Requires:
 - AUTH_ENABLED=false
 - STRIPE_SECRET_KEY set
 - STRIPE_PRO_MONTHLY set
+- POSTGRES_PASSWORD set (via environment)
+- FIRST_SUPERUSER_PASSWORD set (via environment)
+- ENCRYPTION_KEY set (via environment)
 
 1. POST /organizations: org, stripe customer, api key
 2. POST /billing/checkout-session: get checkout url (don't visit)
@@ -51,6 +54,17 @@ def log_error(message: str) -> None:
 
 API_BASE = os.environ.get("AIRWEAVE_API_URL", "http://localhost:8001")
 STRIPE_CLI = os.environ.get("STRIPE_CLI_BIN", "stripe")
+
+
+def _require_env(name: str) -> str:
+    """Return the value of an environment variable or raise with a clear message."""
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(
+            f"Environment variable {name} is required but not set. "
+            f"Export it before running this script."
+        )
+    return value
 
 
 @dataclass
@@ -222,12 +236,12 @@ async def db_snapshot(org_id: str, at_iso: Optional[str] = None) -> Dict[str, An
     os.environ.setdefault("POSTGRES_HOST", "localhost")
     os.environ.setdefault("POSTGRES_PORT", "5432")
     os.environ.setdefault("POSTGRES_USER", "airweave")
-    os.environ.setdefault("POSTGRES_PASSWORD", "airweave1234!")
+    _require_env("POSTGRES_PASSWORD")
     os.environ.setdefault("POSTGRES_DB", "airweave")
     # App bootstrap requirements for settings
     os.environ.setdefault("FIRST_SUPERUSER", "admin@example.com")
-    os.environ.setdefault("FIRST_SUPERUSER_PASSWORD", "admin")
-    os.environ.setdefault("ENCRYPTION_KEY", "44OLJ/s4OjYSyzVk9FtOk6033GrFS4Q4KWBdEstPrgU=")
+    _require_env("FIRST_SUPERUSER_PASSWORD")
+    _require_env("ENCRYPTION_KEY")
 
     # Ensure backend/ is on sys.path so `airweave` package resolves when running from repo root
     backend_dir = Path(__file__).resolve().parents[1]

--- a/backend/tests/unit/test_manual_stripe_require_env.py
+++ b/backend/tests/unit/test_manual_stripe_require_env.py
@@ -1,0 +1,107 @@
+"""Tests for the _require_env helper in manual_stripe_pro_flow.py.
+
+Verifies the CWE-200 fix: hardcoded credentials replaced with
+mandatory environment variable checks.
+"""
+import ast
+import os
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _load_require_env():
+    """Load just _require_env from the script without importing stripe/requests."""
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "manual_stripe_pro_flow.py"
+    source = script_path.read_text()
+
+    tree = ast.parse(source)
+    func_source = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_require_env":
+            func_source = ast.get_source_segment(source, node)
+            break
+
+    assert func_source is not None, "_require_env not found in script"
+
+    code = f"import os\n\n{func_source}"
+    mod = types.ModuleType("_test_mod")
+    exec(compile(code, "<test>", "exec"), mod.__dict__)
+    return mod._require_env
+
+
+_require_env = _load_require_env()
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "manual_stripe_pro_flow.py"
+
+
+class TestRequireEnv:
+    """Tests for _require_env helper function."""
+
+    def test_returns_value_when_set(self):
+        """_require_env returns the value when the env var exists and is non-empty."""
+        with patch.dict(os.environ, {"TEST_SECRET_VAR": "my-secret-value"}):
+            result = _require_env("TEST_SECRET_VAR")
+            assert result == "my-secret-value"
+
+    def test_raises_when_not_set(self):
+        """_require_env raises RuntimeError when the env var is missing."""
+        env = os.environ.copy()
+        env.pop("TOTALLY_MISSING_VAR_12345", None)
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(RuntimeError, match="TOTALLY_MISSING_VAR_12345"):
+                _require_env("TOTALLY_MISSING_VAR_12345")
+
+    def test_raises_when_empty_string(self):
+        """_require_env raises RuntimeError when the env var is set to empty string."""
+        with patch.dict(os.environ, {"TEST_EMPTY_VAR": ""}):
+            with pytest.raises(RuntimeError, match="TEST_EMPTY_VAR"):
+                _require_env("TEST_EMPTY_VAR")
+
+    def test_error_message_includes_var_name(self):
+        """The error message should include the variable name for clarity."""
+        env = os.environ.copy()
+        env.pop("POSTGRES_PASSWORD", None)
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(RuntimeError) as exc_info:
+                _require_env("POSTGRES_PASSWORD")
+            assert "POSTGRES_PASSWORD" in str(exc_info.value)
+
+    def test_hardcoded_postgres_password_removed(self):
+        """Verify the script no longer contains hardcoded POSTGRES_PASSWORD default."""
+        content = SCRIPT_PATH.read_text()
+        assert "airweave1234!" not in content, "Hardcoded POSTGRES_PASSWORD still present"
+
+    def test_hardcoded_superuser_password_removed(self):
+        """Verify the script no longer contains hardcoded FIRST_SUPERUSER_PASSWORD default."""
+        content = SCRIPT_PATH.read_text()
+        assert 'setdefault("FIRST_SUPERUSER_PASSWORD"' not in content, (
+            "Hardcoded FIRST_SUPERUSER_PASSWORD still present"
+        )
+
+    def test_hardcoded_encryption_key_removed(self):
+        """Verify the script no longer contains hardcoded ENCRYPTION_KEY default."""
+        content = SCRIPT_PATH.read_text()
+        assert "44OLJ/" not in content, "Hardcoded ENCRYPTION_KEY still present"
+        assert 'setdefault("ENCRYPTION_KEY"' not in content, (
+            "Hardcoded ENCRYPTION_KEY via setdefault still present"
+        )
+
+    def test_require_env_called_for_secrets(self):
+        """Verify _require_env is used for all three secret variables."""
+        content = SCRIPT_PATH.read_text()
+        assert '_require_env("POSTGRES_PASSWORD")' in content
+        assert '_require_env("FIRST_SUPERUSER_PASSWORD")' in content
+        assert '_require_env("ENCRYPTION_KEY")' in content
+
+    def test_non_secret_defaults_preserved(self):
+        """Verify non-secret setdefault calls are still present (not over-removed)."""
+        content = SCRIPT_PATH.read_text()
+        assert 'setdefault("POSTGRES_HOST"' in content
+        assert 'setdefault("POSTGRES_PORT"' in content
+        assert 'setdefault("POSTGRES_USER"' in content
+        assert 'setdefault("POSTGRES_DB"' in content
+        assert 'setdefault("FIRST_SUPERUSER"' in content


### PR DESCRIPTION
## Summary

`backend/scripts/manual_stripe_pro_flow.py` contains a hardcoded base64 encryption key and several hardcoded credentials embedded as `os.environ.setdefault(...)` calls. This change removes them and requires operators to provide the values via environment variables instead.

**File:** `backend/scripts/manual_stripe_pro_flow.py`
**Category:** Hardcoded credentials in source (CWE-798 / CWE-540)
**Severity:** Low — this is a manually-run developer script, not production code, but checking an encryption key into source is poor hygiene regardless of where it lives.

The specific values removed:

- `POSTGRES_PASSWORD = "airweave1234!"` — the local dev default (also used in `docker-compose.dev.yml`).
- `FIRST_SUPERUSER_PASSWORD = "admin"` — trivial default.
- `ENCRYPTION_KEY = "44OLJ/s4OjYSyzVk9FtOk6033GrFS4Q4KWBdEstPrgU="` — a real Fernet-format base64 key.

## Fix

Replace the `setdefault` calls for the three sensitive variables with a small `_require_env(name)` helper that raises a `RuntimeError` with a clear message if the variable is unset. Non-sensitive defaults (`POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_DB`, `FIRST_SUPERUSER`) are preserved as `setdefault` since they are not secrets.

The script header was also updated to document the newly-required environment variables.

```python
def _require_env(name: str) -> str:
    value = os.environ.get(name)
    if not value:
        raise RuntimeError(
            f"Environment variable {name} is required but not set. "
            f"Export it before running this script."
        )
    return value
```

## Tests

Added `backend/tests/unit/test_manual_stripe_require_env.py` covering:

- `_require_env` returns the value when the variable is set.
- It raises `RuntimeError` with a helpful message when the variable is missing or empty.
- The script source no longer contains the previously hardcoded password or encryption key literals (regression guard).

All tests pass locally.

## Security analysis

The encryption key in particular is the concerning part. `ENCRYPTION_KEY` is the master key used by the application's credential encryption layer; checking a valid Fernet key into a public repository means anyone with read access to the repo has a candidate key to try against any deployment that forgot to override it. A grep across the rest of the repo confirmed this exact key value does not appear elsewhere, so the only place it leaks is from this script — which makes removing it a clean, contained fix.

The Postgres and superuser passwords are already the well-known local-dev defaults and appear in the docker-compose files; the practical confidentiality value of removing them from this one file is small, but folding them into the same `_require_env` treatment keeps the script consistent and forces explicit configuration when running against any non-default environment.

### Adversarial review

Before submitting we tried to talk ourselves out of this one. The script is operator-run, requires `AUTH_ENABLED=false`, and is clearly intended for local development against `localhost:8001`, so it is not directly reachable by an external attacker. The Postgres password is also already public via the compose files, so removing it gives no real confidentiality benefit on its own. What kept the finding alive is the encryption key: it is a valid Fernet key, it is unique to this file, and `os.environ.setdefault` means it would silently apply if an operator ever ran the script (or copy-pasted the snippet) in an environment that hadn't pre-set `ENCRYPTION_KEY`. Removing it eliminates that footgun and aligns the script with the project's own `WEAK_PASSWORDS` policy in `settings.py`.

cc @lewiswigmore


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a hardcoded Fernet encryption key and default credentials from `backend/scripts/manual_stripe_pro_flow.py`. The script now requires environment variables and fails fast with a clear error if they’re missing.

- **Bug Fixes**
  - Replaced `setdefault` for `ENCRYPTION_KEY`, `POSTGRES_PASSWORD`, and `FIRST_SUPERUSER_PASSWORD` with `_require_env(...)`.
  - Kept non-secret defaults for `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_DB`, and `FIRST_SUPERUSER`.
  - Added unit tests for `_require_env` and to guard against reintroducing hardcoded values.

- **Migration**
  - Before running the script, set `ENCRYPTION_KEY`, `POSTGRES_PASSWORD`, and `FIRST_SUPERUSER_PASSWORD`.

<sup>Written for commit ec39e8de7880430a9284bcce20ab2f6fe59908e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

