### PR TITLE
feat(collection-browse): tabular collection browse view behind feature flag

### DIFF
--- a/backend/airweave/api/v1/endpoints/search.py
+++ b/backend/airweave/api/v1/endpoints/search.py
@@ -83,7 +83,7 @@ async def instant_search(
 
 
 @router.post(
-    "/{readable_id}/browse",
+    "/{readable_id}/search/browse",
     response_model=BrowseResponse,
     summary="Browse Collection",
     description=(

--- a/backend/airweave/api/v1/endpoints/search.py
+++ b/backend/airweave/api/v1/endpoints/search.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 from collections.abc import AsyncGenerator
 
-from fastapi import Depends, Path, Query
+from fastapi import Depends, HTTPException, Path, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import StreamingResponse
 
@@ -23,8 +23,10 @@ from airweave.api.v1.endpoints.admin import _require_admin
 from airweave.core.events.search import SearchStartedEvent, SearchTier
 from airweave.core.protocols import EventBus, PubSub
 from airweave.core.protocols.pubsub import PubSubSubscription
+from airweave.core.shared_models import FeatureFlag
 from airweave.domains.search.protocols import (
     AgenticSearchServiceProtocol,
+    BrowseServiceProtocol,
     ClassicSearchServiceProtocol,
     InstantSearchServiceProtocol,
 )
@@ -32,6 +34,8 @@ from airweave.domains.usage.protocols import UsageLimitCheckerProtocol
 from airweave.domains.usage.types import ActionType
 from airweave.schemas.search_v2 import (
     AgenticSearchRequest,
+    BrowseRequest,
+    BrowseResponse,
     ClassicSearchRequest,
     InstantSearchRequest,
     InternalAgenticSearchRequest,
@@ -76,6 +80,30 @@ async def instant_search(
 
     results = await service.search(db, ctx, readable_id, request)
     return SearchV2Response(results=results.results)
+
+
+@router.post(
+    "/{readable_id}/browse",
+    response_model=BrowseResponse,
+    summary="Browse Collection",
+    description=(
+        "Paginated tabular listing of a collection (POC, flag-gated on the frontend). "
+        "No query, no embeddings, no ranking. Returns one row per source entity."
+    ),
+)
+async def browse_collection(
+    readable_id: str = Path(...),
+    request: BrowseRequest = ...,  # type: ignore[assignment]
+    db: AsyncSession = Depends(deps.get_db),
+    ctx: ApiContext = Depends(deps.get_context),
+    usage_checker: UsageLimitCheckerProtocol = Inject(UsageLimitCheckerProtocol),
+    service: BrowseServiceProtocol = Inject(BrowseServiceProtocol),
+) -> BrowseResponse:
+    """Browse a collection with offset/limit pagination."""
+    if not ctx.has_feature(FeatureFlag.COLLECTION_BROWSE):
+        raise HTTPException(status_code=404, detail="Not found")
+    await usage_checker.is_allowed(db, ctx.organization.id, ActionType.QUERIES)
+    return await service.browse(db, ctx, readable_id, request)
 
 
 @router.post(

--- a/backend/airweave/api/v1/endpoints/tests/test_search_browse.py
+++ b/backend/airweave/api/v1/endpoints/tests/test_search_browse.py
@@ -1,0 +1,97 @@
+"""Tests for the `browse_collection` endpoint handler.
+
+The handler itself is thin: feature-flag gate -> usage check -> delegate to
+BrowseService. We call it directly (bypassing FastAPI DI) and verify each
+branch.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from airweave.api.context import ApiContext
+from airweave.api.v1.endpoints.search import browse_collection
+from airweave.core.logging import logger
+from airweave.core.shared_models import AuthMethod, FeatureFlag
+from airweave.domains.search.fakes.browse import FakeBrowseService
+from airweave.domains.usage.types import ActionType
+from airweave.schemas.search_v2 import BrowseRequest, BrowseResponse
+
+
+def _make_ctx(features: list[FeatureFlag] | None = None) -> ApiContext:
+    from airweave.schemas.organization import Organization
+
+    now = datetime.now(timezone.utc)
+    org = Organization(
+        id=str(uuid4()),
+        name="Test Org",
+        created_at=now,
+        modified_at=now,
+        enabled_features=features or [],
+    )
+    return ApiContext(
+        request_id="test-req-001",
+        organization=org,
+        auth_method=AuthMethod.SYSTEM,
+        auth_metadata={},
+        logger=logger.with_context(request_id="test-req-001"),
+    )
+
+
+class TestBrowseCollectionEndpoint:
+    """Direct tests for the browse_collection handler."""
+
+    @pytest.mark.asyncio
+    async def test_returns_404_when_feature_flag_disabled(self) -> None:
+        ctx = _make_ctx(features=[])
+        usage_checker = AsyncMock()
+        service = FakeBrowseService()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await browse_collection(
+                readable_id="any",
+                request=BrowseRequest(),
+                db=AsyncMock(),
+                ctx=ctx,
+                usage_checker=usage_checker,
+                service=service,
+            )
+
+        assert exc_info.value.status_code == 404
+        # Service should not be called when flag is off.
+        assert service._calls == []
+        usage_checker.is_allowed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_calls_usage_checker_and_service_when_enabled(self) -> None:
+        ctx = _make_ctx(features=[FeatureFlag.COLLECTION_BROWSE])
+        usage_checker = AsyncMock()
+        service = FakeBrowseService()
+        service.seed_response(
+            BrowseResponse(results=[], total=7, limit=50, offset=0)
+        )
+
+        response = await browse_collection(
+            readable_id="my-col",
+            request=BrowseRequest(limit=50),
+            db=AsyncMock(),
+            ctx=ctx,
+            usage_checker=usage_checker,
+            service=service,
+        )
+
+        assert response.total == 7
+        # Usage check fired with the right args.
+        usage_checker.is_allowed.assert_awaited_once()
+        args = usage_checker.is_allowed.await_args.args
+        # signature: (db, org_id, action_type)
+        assert args[1] == ctx.organization.id
+        assert args[2] == ActionType.QUERIES
+        # Service was called with the readable_id.
+        assert len(service._calls) == 1
+        assert service._calls[0][1] == "my-col"

--- a/backend/airweave/core/container/container.py
+++ b/backend/airweave/core/container/container.py
@@ -76,6 +76,7 @@ from airweave.domains.organizations.protocols import (
 )
 from airweave.domains.search.protocols import (
     AgenticSearchServiceProtocol,
+    BrowseServiceProtocol,
     ClassicSearchServiceProtocol,
     InstantSearchServiceProtocol,
 )
@@ -253,6 +254,7 @@ class Container:
     instant_search: InstantSearchServiceProtocol
     classic_search: ClassicSearchServiceProtocol
     agentic_search: AgenticSearchServiceProtocol
+    browse_service: BrowseServiceProtocol
 
     # Storage domain — unified backend for file/object storage
     storage_backend: StorageBackend

--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -107,6 +107,7 @@ from airweave.domains.search.adapters.vector_db.filter_translator import FilterT
 from airweave.domains.search.adapters.vector_db.vespa_client import VespaVectorDB
 from airweave.domains.search.agentic.service import AgenticSearchService
 from airweave.domains.search.agentic.subscribers.stream_relay import SearchStreamRelay
+from airweave.domains.search.browse.service import BrowseService
 from airweave.domains.search.builders.collection_metadata import CollectionMetadataBuilder
 from airweave.domains.search.classic.service import ClassicSearchService
 from airweave.domains.search.config import SearchConfig
@@ -615,6 +616,7 @@ def create_container(settings: Settings) -> Container:
         instant_search=search_deps["instant_search"],
         classic_search=search_deps["classic_search"],
         agentic_search=search_deps["agentic_search"],
+        browse_service=search_deps["browse_service"],
     )
 
 
@@ -1355,11 +1357,16 @@ def _create_search_services(
         collection_repo=collection_repo,
         event_bus=event_bus,
     )
+    browse_service = BrowseService(
+        vector_db=vector_db,
+        collection_repo=collection_repo,
+    )
 
     return {
         "instant_search": instant_search,
         "classic_search": classic_search,
         "agentic_search": agentic_search,
+        "browse_service": browse_service,
     }
 
 

--- a/backend/airweave/core/shared_models.py
+++ b/backend/airweave/core/shared_models.py
@@ -110,6 +110,7 @@ class FeatureFlag(str, Enum):
     API_KEY_ADMIN_SYNC = "api_key_admin_sync"  # Allows resync operations via API key
     CONNECT = "connect"  # Enables the Connect playground and embeddable widget features
     CUSTOM_AUTH_PROVIDER = "custom_auth_provider"  # Enables the Custom auth provider
+    COLLECTION_BROWSE = "collection_browse"  # POC: tabular browse view on collections
 
 
 class AuthMethod(str, Enum):

--- a/backend/airweave/domains/search/adapters/vector_db/fakes/vector_db.py
+++ b/backend/airweave/domains/search/adapters/vector_db/fakes/vector_db.py
@@ -91,9 +91,10 @@ class FakeVectorDB:
         self,
         filter_groups: list[FilterGroup],
         collection_id: str,
+        name_substring: str | None = None,
     ) -> int:
         """Return seeded count, or raise seeded error."""
-        self._calls.append(("count", filter_groups, collection_id))
+        self._calls.append(("count", filter_groups, collection_id, name_substring))
         if self._count_error:
             err = self._count_error
             self._count_error = None
@@ -106,9 +107,12 @@ class FakeVectorDB:
         collection_id: str,
         limit: int = 50,
         offset: int = 0,
+        name_substring: str | None = None,
     ) -> list[SearchResult]:
         """Return seeded filter results, or raise seeded error."""
-        self._calls.append(("filter_search", filter_groups, collection_id, limit, offset))
+        self._calls.append(
+            ("filter_search", filter_groups, collection_id, limit, offset, name_substring)
+        )
         if self._filter_error:
             err = self._filter_error
             self._filter_error = None

--- a/backend/airweave/domains/search/adapters/vector_db/protocol.py
+++ b/backend/airweave/domains/search/adapters/vector_db/protocol.py
@@ -59,12 +59,15 @@ class VectorDBProtocol(Protocol):
         self,
         filter_groups: list[FilterGroup],
         collection_id: str,
+        name_substring: Optional[str] = None,
     ) -> int:
         """Count entities matching filters without retrieving content.
 
         Args:
             filter_groups: Filter groups to narrow the count.
             collection_id: Collection readable ID for tenant filtering.
+            name_substring: Optional case-insensitive substring match against
+                the entity name (proper substring, not token-match).
 
         Returns:
             Total number of matching entities.
@@ -77,6 +80,7 @@ class VectorDBProtocol(Protocol):
         collection_id: str,
         limit: int = 50,
         offset: int = 0,
+        name_substring: Optional[str] = None,
     ) -> list[SearchResult]:
         """Retrieve entities matching filters without embeddings or ranking.
 
@@ -85,6 +89,8 @@ class VectorDBProtocol(Protocol):
             collection_id: Collection readable ID for tenant filtering.
             limit: Maximum number of results to return.
             offset: Number of results to skip.
+            name_substring: Optional case-insensitive substring match against
+                the entity name (proper substring, not token-match).
 
         Returns:
             List of matching results (unranked).

--- a/backend/airweave/domains/search/adapters/vector_db/tests/test_vespa_client_name_substring.py
+++ b/backend/airweave/domains/search/adapters/vector_db/tests/test_vespa_client_name_substring.py
@@ -1,0 +1,115 @@
+"""Tests for VespaVectorDB.count/filter_search `name_substring` plumbing.
+
+We don't run a real Vespa here — we mock the `_app.query` call and assert the
+generated YQL contains the expected regex `matches` clause. The branches under
+test are:
+
+- `_build_name_substring_clause`: escapes special regex/YQL characters.
+- `count` and `filter_search` add the clause to YQL when `name_substring` is set.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from airweave.core.logging import logger
+from airweave.domains.search.adapters.vector_db.filter_translator import FilterTranslator
+from airweave.domains.search.adapters.vector_db.vespa_client import VespaVectorDB
+
+
+def _make_client() -> tuple[VespaVectorDB, MagicMock]:
+    """Build a VespaVectorDB with a MagicMock `_app` so no Vespa is needed."""
+    app = MagicMock()
+    response = MagicMock()
+    response.is_successful.return_value = True
+    response.json = {"root": {"fields": {"totalCount": 0}}}
+    response.hits = []
+    app.query.return_value = response
+
+    ctx_logger = logger.with_context(request_id="test")
+    client = VespaVectorDB(
+        app=app,
+        logger=ctx_logger,
+        filter_translator=FilterTranslator(logger=ctx_logger),
+    )
+    return client, app
+
+
+class TestBuildNameSubstringClause:
+    """Direct tests for the YQL regex clause builder."""
+
+    def test_simple_substring(self) -> None:
+        client, _ = _make_client()
+        clause = client._build_name_substring_clause("Quick")
+        assert clause == 'name matches "(?i).*Quick.*"'
+
+    def test_regex_chars_escaped(self) -> None:
+        client, _ = _make_client()
+        # `re.escape` escapes `+` and `.`; resulting backslashes must
+        # be doubled for the YQL literal.
+        clause = client._build_name_substring_clause("1.5+")
+        # `.` -> `\.`, `+` -> `\+`. After YQL-escaping each `\` becomes `\\`.
+        assert "1\\\\.5\\\\+" in clause
+        assert clause.startswith('name matches "(?i).*')
+        assert clause.endswith('.*"')
+
+    def test_single_quote_escaped(self) -> None:
+        client, _ = _make_client()
+        clause = client._build_name_substring_clause("O'Brien")
+        # Single quote in the input must be escaped for the YQL string literal.
+        assert "O\\'Brien" in clause
+
+
+class TestCountWithNameSubstring:
+    """`count()` includes the substring clause only when provided."""
+
+    @pytest.mark.asyncio
+    async def test_clause_present_when_name_substring_set(self) -> None:
+        client, app = _make_client()
+        await client.count(
+            filter_groups=[],
+            collection_id="col-123",
+            name_substring="Quick",
+        )
+        yql = app.query.call_args.kwargs["body"]["yql"]
+        assert 'name matches "(?i).*Quick.*"' in yql
+
+    @pytest.mark.asyncio
+    async def test_clause_absent_when_name_substring_none(self) -> None:
+        client, app = _make_client()
+        await client.count(filter_groups=[], collection_id="col-123")
+        yql = app.query.call_args.kwargs["body"]["yql"]
+        assert "name matches" not in yql
+
+    @pytest.mark.asyncio
+    async def test_clause_absent_when_name_substring_empty_string(self) -> None:
+        client, app = _make_client()
+        await client.count(
+            filter_groups=[], collection_id="col-123", name_substring=""
+        )
+        yql = app.query.call_args.kwargs["body"]["yql"]
+        assert "name matches" not in yql
+
+
+class TestFilterSearchWithNameSubstring:
+    """`filter_search()` includes the substring clause only when provided."""
+
+    @pytest.mark.asyncio
+    async def test_clause_present_when_name_substring_set(self) -> None:
+        client, app = _make_client()
+        await client.filter_search(
+            filter_groups=[],
+            collection_id="col-123",
+            name_substring="Quick",
+        )
+        yql = app.query.call_args.kwargs["body"]["yql"]
+        assert 'name matches "(?i).*Quick.*"' in yql
+
+    @pytest.mark.asyncio
+    async def test_clause_absent_when_name_substring_none(self) -> None:
+        client, app = _make_client()
+        await client.filter_search(filter_groups=[], collection_id="col-123")
+        yql = app.query.call_args.kwargs["body"]["yql"]
+        assert "name matches" not in yql

--- a/backend/airweave/domains/search/adapters/vector_db/tests/test_vespa_client_name_substring.py
+++ b/backend/airweave/domains/search/adapters/vector_db/tests/test_vespa_client_name_substring.py
@@ -55,11 +55,28 @@ class TestBuildNameSubstringClause:
         assert clause.startswith('name matches "(?i).*')
         assert clause.endswith('.*"')
 
-    def test_single_quote_escaped(self) -> None:
+    def test_single_quote_not_escaped(self) -> None:
+        """Single quote has no special meaning inside a double-quoted YQL literal."""
         client, _ = _make_client()
         clause = client._build_name_substring_clause("O'Brien")
-        # Single quote in the input must be escaped for the YQL string literal.
-        assert "O\\'Brien" in clause
+        assert "O'Brien" in clause
+
+    def test_double_quote_escaped(self) -> None:
+        """Double quote must be escaped — it is the literal delimiter in our YQL."""
+        client, _ = _make_client()
+        clause = client._build_name_substring_clause('"hi"')
+        # Each `"` in the input becomes `\"` in the YQL string literal.
+        # Strip the surrounding `name matches "(?i).*` ... `.*"` wrapper and
+        # check the inner escaped payload starts and ends with `\"`.
+        assert clause.startswith('name matches "(?i).*\\"')
+        assert clause.endswith('\\".*"')
+        # And the YQL literal has exactly one opening + one closing `"` that
+        # are not preceded by a backslash (i.e. exactly two unescaped quotes).
+        unescaped = 0
+        for i, ch in enumerate(clause):
+            if ch == '"' and (i == 0 or clause[i - 1] != "\\"):
+                unescaped += 1
+        assert unescaped == 2
 
 
 class TestCountWithNameSubstring:
@@ -86,9 +103,7 @@ class TestCountWithNameSubstring:
     @pytest.mark.asyncio
     async def test_clause_absent_when_name_substring_empty_string(self) -> None:
         client, app = _make_client()
-        await client.count(
-            filter_groups=[], collection_id="col-123", name_substring=""
-        )
+        await client.count(filter_groups=[], collection_id="col-123", name_substring="")
         yql = app.query.call_args.kwargs["body"]["yql"]
         assert "name matches" not in yql
 

--- a/backend/airweave/domains/search/adapters/vector_db/vespa_client.py
+++ b/backend/airweave/domains/search/adapters/vector_db/vespa_client.py
@@ -312,8 +312,11 @@ class VespaVectorDB:
         "1.5+ release" can't blow up the regex engine.
         """
         escaped_for_regex = re.escape(substring)
-        # YQL string literals: backslash and single quote need escaping.
-        escaped_for_yql = escaped_for_regex.replace("\\", "\\\\").replace("'", "\\'")
+        # YQL double-quoted string literal: escape backslashes first, then
+        # double quotes (the literal delimiter). `re.escape` does not escape
+        # `"` because it is not a regex metacharacter, so without this an
+        # input like `Quick "test"` would break the YQL parse.
+        escaped_for_yql = escaped_for_regex.replace("\\", "\\\\").replace('"', '\\"')
         return f'name matches "(?i).*{escaped_for_yql}.*"'
 
     def _build_retrieval_clause(

--- a/backend/airweave/domains/search/adapters/vector_db/vespa_client.py
+++ b/backend/airweave/domains/search/adapters/vector_db/vespa_client.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import time
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -160,8 +161,15 @@ class VespaVectorDB:
         self,
         filter_groups: list,
         collection_id: str,
+        name_substring: str | None = None,
     ) -> int:
-        """Count entities matching filters without retrieving content."""
+        """Count entities matching filters without retrieving content.
+
+        If `name_substring` is provided, an additional case-insensitive substring
+        match against the `name` attribute is AND-ed in. This uses Vespa's
+        regex `matches` operator, since `contains` on an attribute is a token
+        (whole-word) match, not a substring match.
+        """
         where_parts = [
             f"airweave_system_metadata_collection_id contains '{collection_id}'",
         ]
@@ -169,6 +177,9 @@ class VespaVectorDB:
         filter_yql = self._filter_translator.translate(filter_groups)
         if filter_yql:
             where_parts.append(f"({filter_yql})")
+
+        if name_substring:
+            where_parts.append(self._build_name_substring_clause(name_substring))
 
         all_schemas = ", ".join(ALL_VESPA_SCHEMAS)
         yql = f"select * from sources {all_schemas} where {' AND '.join(where_parts)}"
@@ -197,8 +208,14 @@ class VespaVectorDB:
         collection_id: str,
         limit: int = 50,
         offset: int = 0,
+        name_substring: str | None = None,
     ) -> list:
-        """Retrieve entities matching filters without embeddings or ranking."""
+        """Retrieve entities matching filters without embeddings or ranking.
+
+        If `name_substring` is provided, an additional case-insensitive substring
+        match against the `name` attribute is AND-ed in. See `count` for the
+        rationale (Vespa `contains` on an attribute is token-match, not substring).
+        """
         where_parts = [
             f"airweave_system_metadata_collection_id contains '{collection_id}'",
         ]
@@ -206,6 +223,9 @@ class VespaVectorDB:
         filter_yql = self._filter_translator.translate(filter_groups)
         if filter_yql:
             where_parts.append(f"({filter_yql})")
+
+        if name_substring:
+            where_parts.append(self._build_name_substring_clause(name_substring))
 
         all_schemas = ", ".join(ALL_VESPA_SCHEMAS)
         yql = f"select * from sources {all_schemas} where {' AND '.join(where_parts)}"
@@ -280,6 +300,21 @@ class VespaVectorDB:
             clauses.append(f"access_viewers contains '{escaped}'")
 
         return " OR ".join(clauses)
+
+    def _build_name_substring_clause(self, substring: str) -> str:
+        """Build a case-insensitive substring match against the `name` attribute.
+
+        Vespa's `contains` on an attribute field is a token (whole-word) match,
+        not a substring match — so a query like "Qui" misses "Quick…". We use
+        the `matches` regex operator instead, which scans the full string.
+
+        Special regex characters in the user input are escaped so a query like
+        "1.5+ release" can't blow up the regex engine.
+        """
+        escaped_for_regex = re.escape(substring)
+        # YQL string literals: backslash and single quote need escaping.
+        escaped_for_yql = escaped_for_regex.replace("\\", "\\\\").replace("'", "\\'")
+        return f'name matches "(?i).*{escaped_for_yql}.*"'
 
     def _build_retrieval_clause(
         self,

--- a/backend/airweave/domains/search/browse/__init__.py
+++ b/backend/airweave/domains/search/browse/__init__.py
@@ -1,0 +1,1 @@
+"""Browse domain — paginated tabular listing of a collection."""

--- a/backend/airweave/domains/search/browse/service.py
+++ b/backend/airweave/domains/search/browse/service.py
@@ -23,9 +23,10 @@ from airweave.domains.search.types.filters import (
     FilterGroup,
     FilterOperator,
 )
+from airweave.schemas.search_v2 import BrowseResponse
 
 if TYPE_CHECKING:
-    from airweave.schemas.search_v2 import BrowseRequest, BrowseResponse
+    from airweave.schemas.search_v2 import BrowseRequest
 
 
 class BrowseService(BrowseServiceProtocol):
@@ -48,8 +49,6 @@ class BrowseService(BrowseServiceProtocol):
         request: BrowseRequest,
     ) -> BrowseResponse:
         """Run a paginated unranked listing for the given collection."""
-        from airweave.schemas.search_v2 import BrowseResponse
-
         start = time.monotonic()
         ctx.logger.info(
             f"Browse started collection={readable_id} limit={request.limit} offset={request.offset}"

--- a/backend/airweave/domains/search/browse/service.py
+++ b/backend/airweave/domains/search/browse/service.py
@@ -1,0 +1,131 @@
+"""Browse service — paginated tabular listing of a collection.
+
+No query, no embeddings, no ranking. Hits Vespa's filter_search() and count()
+in parallel. Forces chunk_index = 0 so each source entity shows up as a single row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from airweave.api.context import ApiContext
+from airweave.domains.collections.protocols import CollectionRepositoryProtocol
+from airweave.domains.search.adapters.vector_db.protocol import VectorDBProtocol
+from airweave.domains.search.protocols import BrowseServiceProtocol
+from airweave.domains.search.types.filters import (
+    FilterableField,
+    FilterCondition,
+    FilterGroup,
+    FilterOperator,
+)
+
+if TYPE_CHECKING:
+    from airweave.schemas.search_v2 import BrowseRequest, BrowseResponse
+
+
+class BrowseService(BrowseServiceProtocol):
+    """Browse a collection as paginated rows."""
+
+    def __init__(
+        self,
+        vector_db: VectorDBProtocol,
+        collection_repo: CollectionRepositoryProtocol,
+    ) -> None:
+        """Initialize with vector DB and collection repository."""
+        self._vector_db = vector_db
+        self._collection_repo = collection_repo
+
+    async def browse(
+        self,
+        db: AsyncSession,
+        ctx: ApiContext,
+        readable_id: str,
+        request: BrowseRequest,
+    ) -> BrowseResponse:
+        """Run a paginated unranked listing for the given collection."""
+        from airweave.schemas.search_v2 import BrowseResponse
+
+        start = time.monotonic()
+        ctx.logger.info(
+            f"Browse started collection={readable_id} limit={request.limit} offset={request.offset}"
+        )
+
+        collection = await self._collection_repo.get_by_readable_id(db, readable_id, ctx)
+        if not collection:
+            raise HTTPException(status_code=404, detail=f"Collection '{readable_id}' not found")
+
+        filter_groups = self._build_filter_groups(request)
+        collection_id = str(collection.id)
+
+        results, total = await asyncio.gather(
+            self._vector_db.filter_search(
+                filter_groups=filter_groups,
+                collection_id=collection_id,
+                limit=request.limit,
+                offset=request.offset,
+            ),
+            self._vector_db.count(
+                filter_groups=filter_groups,
+                collection_id=collection_id,
+            ),
+        )
+
+        duration_ms = int((time.monotonic() - start) * 1000)
+        ctx.logger.info(
+            f"Browse completed collection={readable_id} "
+            f"rows={len(results)} total={total} duration_ms={duration_ms}"
+        )
+
+        return BrowseResponse(
+            results=results,
+            total=total,
+            limit=request.limit,
+            offset=request.offset,
+        )
+
+    def _build_filter_groups(self, request: BrowseRequest) -> list[FilterGroup]:
+        """Combine user filters with the chunk-index=0 row anchor and convenience filters.
+
+        chunk_index=0 collapses Vespa's per-chunk documents to one row per source entity.
+        Each FilterGroup is AND-internal; multiple groups are OR'd together. To preserve
+        AND semantics across user filters AND our forced conditions, we extend each user
+        group's conditions instead of appending a new group.
+        """
+        chunk_anchor = FilterCondition(
+            field=FilterableField.SYSTEM_METADATA_CHUNK_INDEX,
+            operator=FilterOperator.EQUALS,
+            value=0,
+        )
+
+        extra_conditions: list[FilterCondition] = [chunk_anchor]
+
+        if request.sync_ids:
+            extra_conditions.append(
+                FilterCondition(
+                    field=FilterableField.SYSTEM_METADATA_SYNC_ID,
+                    operator=FilterOperator.IN,
+                    value=list(request.sync_ids),
+                )
+            )
+
+        if request.entity_types:
+            extra_conditions.append(
+                FilterCondition(
+                    field=FilterableField.SYSTEM_METADATA_ENTITY_TYPE,
+                    operator=FilterOperator.IN,
+                    value=list(request.entity_types),
+                )
+            )
+
+        if not request.filter:
+            return [FilterGroup(conditions=extra_conditions)]
+
+        return [
+            FilterGroup(conditions=[*group.conditions, *extra_conditions])
+            for group in request.filter
+        ]

--- a/backend/airweave/domains/search/browse/service.py
+++ b/backend/airweave/domains/search/browse/service.py
@@ -61,6 +61,7 @@ class BrowseService(BrowseServiceProtocol):
 
         filter_groups = self._build_filter_groups(request)
         collection_id = str(collection.id)
+        name_substring = (request.name_query or "").strip() or None
 
         results, total = await asyncio.gather(
             self._vector_db.filter_search(
@@ -68,10 +69,12 @@ class BrowseService(BrowseServiceProtocol):
                 collection_id=collection_id,
                 limit=request.limit,
                 offset=request.offset,
+                name_substring=name_substring,
             ),
             self._vector_db.count(
                 filter_groups=filter_groups,
                 collection_id=collection_id,
+                name_substring=name_substring,
             ),
         )
 

--- a/backend/airweave/domains/search/browse/tests/test_service.py
+++ b/backend/airweave/domains/search/browse/tests/test_service.py
@@ -109,9 +109,7 @@ class TestBrowseService:
         svc, vector_db, repo = _make_service()
         repo.seed_readable(DEFAULT_READABLE_ID, _make_collection())
 
-        await svc.browse(
-            AsyncMock(), _make_ctx(), DEFAULT_READABLE_ID, BrowseRequest()
-        )
+        await svc.browse(AsyncMock(), _make_ctx(), DEFAULT_READABLE_ID, BrowseRequest())
 
         filter_call = next(c for c in vector_db._calls if c[0] == "filter_search")
         filter_groups = filter_call[1]
@@ -199,12 +197,10 @@ class TestBrowseService:
         assert len(filter_groups) == 2
         for group in filter_groups:
             anchor_present = any(
-                c.field == FilterableField.SYSTEM_METADATA_CHUNK_INDEX
-                for c in group.conditions
+                c.field == FilterableField.SYSTEM_METADATA_CHUNK_INDEX for c in group.conditions
             )
             source_present = any(
-                c.field == FilterableField.SYSTEM_METADATA_SOURCE_NAME
-                for c in group.conditions
+                c.field == FilterableField.SYSTEM_METADATA_SOURCE_NAME for c in group.conditions
             )
             assert anchor_present and source_present
 
@@ -241,3 +237,17 @@ class TestBrowseService:
 
         filter_call = next(c for c in vector_db._calls if c[0] == "filter_search")
         assert filter_call[5] is None
+
+    def test_name_query_rejects_single_character(self) -> None:
+        """Single-character `name_query` is rejected to avoid full-scan triggers."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            BrowseRequest(name_query="a")
+
+    def test_sync_ids_rejects_oversized_list(self) -> None:
+        """`sync_ids` is capped at 100 entries."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            BrowseRequest(sync_ids=[str(uuid4()) for _ in range(101)])

--- a/backend/airweave/domains/search/browse/tests/test_service.py
+++ b/backend/airweave/domains/search/browse/tests/test_service.py
@@ -1,0 +1,243 @@
+"""Tests for BrowseService."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from airweave.api.context import ApiContext
+from airweave.core.logging import logger
+from airweave.core.shared_models import AuthMethod
+from airweave.domains.collections.fakes.repository import FakeCollectionRepository
+from airweave.domains.search.adapters.vector_db.fakes.vector_db import FakeVectorDB
+from airweave.domains.search.agentic.tests.conftest import make_result
+from airweave.domains.search.browse.service import BrowseService
+from airweave.domains.search.types.filters import (
+    FilterCondition,
+    FilterGroup,
+    FilterOperator,
+    FilterableField,
+)
+from airweave.models.collection import Collection
+from airweave.schemas.search_v2 import BrowseRequest
+
+DEFAULT_ORG_ID = uuid4()
+DEFAULT_COLLECTION_ID = uuid4()
+DEFAULT_READABLE_ID = "test-col"
+
+
+def _make_ctx() -> ApiContext:
+    from airweave.schemas.organization import Organization
+
+    now = datetime.now(timezone.utc)
+    org = Organization(
+        id=str(DEFAULT_ORG_ID),
+        name="Test Org",
+        created_at=now,
+        modified_at=now,
+        enabled_features=[],
+    )
+    return ApiContext(
+        request_id="test-req-001",
+        organization=org,
+        auth_method=AuthMethod.SYSTEM,
+        auth_metadata={},
+        logger=logger.with_context(request_id="test-req-001"),
+    )
+
+
+def _make_collection() -> Collection:
+    now = datetime.now(timezone.utc)
+    col = Collection(
+        id=DEFAULT_COLLECTION_ID,
+        name="Test Collection",
+        readable_id=DEFAULT_READABLE_ID,
+        organization_id=DEFAULT_ORG_ID,
+        vector_db_deployment_metadata_id=uuid4(),
+    )
+    col.created_at = now
+    col.modified_at = now
+    return col
+
+
+def _make_service() -> tuple[BrowseService, FakeVectorDB, FakeCollectionRepository]:
+    vector_db = FakeVectorDB()
+    collection_repo = FakeCollectionRepository()
+    svc = BrowseService(vector_db=vector_db, collection_repo=collection_repo)
+    return svc, vector_db, collection_repo
+
+
+class TestBrowseService:
+    """Tests for BrowseService.browse()."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_response(self) -> None:
+        svc, vector_db, repo = _make_service()
+        repo.seed_readable(DEFAULT_READABLE_ID, _make_collection())
+
+        row = make_result(entity_id="ent-1", name="Row 1")
+        vector_db.seed_filter_results([row])
+        vector_db.seed_count(42)
+
+        response = await svc.browse(
+            AsyncMock(), _make_ctx(), DEFAULT_READABLE_ID, BrowseRequest(limit=10, offset=0)
+        )
+
+        assert response.total == 42
+        assert response.limit == 10
+        assert response.offset == 0
+        assert len(response.results) == 1
+        assert response.results[0].entity_id == "ent-1"
+
+    @pytest.mark.asyncio
+    async def test_collection_not_found_raises_404(self) -> None:
+        svc, _, _ = _make_service()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await svc.browse(AsyncMock(), _make_ctx(), "nonexistent", BrowseRequest())
+
+        assert exc_info.value.status_code == 404
+        assert "nonexistent" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_chunk_index_anchor_added_to_filter_groups(self) -> None:
+        """The chunk_index=0 anchor must be AND-ed into every filter group."""
+        svc, vector_db, repo = _make_service()
+        repo.seed_readable(DEFAULT_READABLE_ID, _make_collection())
+
+        await svc.browse(
+            AsyncMock(), _make_ctx(), DEFAULT_READABLE_ID, BrowseRequest()
+        )
+
+        filter_call = next(c for c in vector_db._calls if c[0] == "filter_search")
+        filter_groups = filter_call[1]
+        assert len(filter_groups) == 1
+        anchor_fields = [c.field for c in filter_groups[0].conditions]
+        assert FilterableField.SYSTEM_METADATA_CHUNK_INDEX in anchor_fields
+
+    @pytest.mark.asyncio
+    async def test_sync_ids_translated_to_filter(self) -> None:
+        svc, vector_db, repo = _make_service()
+        repo.seed_readable(DEFAULT_READABLE_ID, _make_collection())
+
+        sync_id = str(uuid4())
+        await svc.browse(
+            AsyncMock(),
+            _make_ctx(),
+            DEFAULT_READABLE_ID,
+            BrowseRequest(sync_ids=[sync_id]),
+        )
+
+        filter_call = next(c for c in vector_db._calls if c[0] == "filter_search")
+        conditions = filter_call[1][0].conditions
+        sync_conditions = [
+            c for c in conditions if c.field == FilterableField.SYSTEM_METADATA_SYNC_ID
+        ]
+        assert len(sync_conditions) == 1
+        assert sync_conditions[0].operator == FilterOperator.IN
+        assert sync_conditions[0].value == [sync_id]
+
+    @pytest.mark.asyncio
+    async def test_entity_types_translated_to_filter(self) -> None:
+        svc, vector_db, repo = _make_service()
+        repo.seed_readable(DEFAULT_READABLE_ID, _make_collection())
+
+        await svc.browse(
+            AsyncMock(),
+            _make_ctx(),
+            DEFAULT_READABLE_ID,
+            BrowseRequest(entity_types=["NotionPageEntity", "SlackMessageEntity"]),
+        )
+
+        filter_call = next(c for c in vector_db._calls if c[0] == "filter_search")
+        conditions = filter_call[1][0].conditions
+        et_conditions = [
+            c for c in conditions if c.field == FilterableField.SYSTEM_METADATA_ENTITY_TYPE
+        ]
+        assert len(et_conditions) == 1
+        assert et_conditions[0].value == ["NotionPageEntity", "SlackMessageEntity"]
+
+    @pytest.mark.asyncio
+    async def test_user_filter_combined_with_anchor(self) -> None:
+        """User-supplied filter groups should each get the anchor AND-ed in."""
+        svc, vector_db, repo = _make_service()
+        repo.seed_readable(DEFAULT_READABLE_ID, _make_collection())
+
+        user_filter = [
+            FilterGroup(
+                conditions=[
+                    FilterCondition(
+                        field=FilterableField.SYSTEM_METADATA_SOURCE_NAME,
+                        operator=FilterOperator.EQUALS,
+                        value="notion",
+                    )
+                ]
+            ),
+            FilterGroup(
+                conditions=[
+                    FilterCondition(
+                        field=FilterableField.SYSTEM_METADATA_SOURCE_NAME,
+                        operator=FilterOperator.EQUALS,
+                        value="slack",
+                    )
+                ]
+            ),
+        ]
+        await svc.browse(
+            AsyncMock(),
+            _make_ctx(),
+            DEFAULT_READABLE_ID,
+            BrowseRequest(filter=user_filter),
+        )
+
+        filter_call = next(c for c in vector_db._calls if c[0] == "filter_search")
+        filter_groups = filter_call[1]
+        assert len(filter_groups) == 2
+        for group in filter_groups:
+            anchor_present = any(
+                c.field == FilterableField.SYSTEM_METADATA_CHUNK_INDEX
+                for c in group.conditions
+            )
+            source_present = any(
+                c.field == FilterableField.SYSTEM_METADATA_SOURCE_NAME
+                for c in group.conditions
+            )
+            assert anchor_present and source_present
+
+    @pytest.mark.asyncio
+    async def test_name_query_passed_as_name_substring(self) -> None:
+        svc, vector_db, repo = _make_service()
+        repo.seed_readable(DEFAULT_READABLE_ID, _make_collection())
+
+        await svc.browse(
+            AsyncMock(),
+            _make_ctx(),
+            DEFAULT_READABLE_ID,
+            BrowseRequest(name_query="  Quick  "),
+        )
+
+        filter_call = next(c for c in vector_db._calls if c[0] == "filter_search")
+        count_call = next(c for c in vector_db._calls if c[0] == "count")
+        # filter_search signature: (op, filter_groups, collection_id, limit, offset, name_substring)
+        assert filter_call[5] == "Quick"
+        # count signature: (op, filter_groups, collection_id, name_substring)
+        assert count_call[3] == "Quick"
+
+    @pytest.mark.asyncio
+    async def test_blank_name_query_treated_as_none(self) -> None:
+        svc, vector_db, repo = _make_service()
+        repo.seed_readable(DEFAULT_READABLE_ID, _make_collection())
+
+        await svc.browse(
+            AsyncMock(),
+            _make_ctx(),
+            DEFAULT_READABLE_ID,
+            BrowseRequest(name_query="   "),
+        )
+
+        filter_call = next(c for c in vector_db._calls if c[0] == "filter_search")
+        assert filter_call[5] is None

--- a/backend/airweave/domains/search/fakes/browse.py
+++ b/backend/airweave/domains/search/fakes/browse.py
@@ -1,0 +1,36 @@
+"""In-memory fake for BrowseServiceProtocol."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from airweave.api.context import ApiContext
+from airweave.domains.search.protocols import BrowseServiceProtocol
+
+if TYPE_CHECKING:
+    from airweave.schemas.search_v2 import BrowseRequest, BrowseResponse
+
+
+class FakeBrowseService(BrowseServiceProtocol):
+    """Returns a seeded BrowseResponse. Records calls."""
+
+    def __init__(self) -> None:
+        from airweave.schemas.search_v2 import BrowseResponse
+
+        self._response: BrowseResponse = BrowseResponse(results=[], total=0, limit=50, offset=0)
+        self._calls: list[tuple] = []
+
+    def seed_response(self, response: BrowseResponse) -> None:
+        self._response = response
+
+    async def browse(
+        self,
+        db: AsyncSession,
+        ctx: ApiContext,
+        readable_id: str,
+        request: BrowseRequest,
+    ) -> BrowseResponse:
+        self._calls.append(("browse", readable_id, request))
+        return self._response

--- a/backend/airweave/domains/search/fakes/browse.py
+++ b/backend/airweave/domains/search/fakes/browse.py
@@ -8,17 +8,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from airweave.api.context import ApiContext
 from airweave.domains.search.protocols import BrowseServiceProtocol
+from airweave.schemas.search_v2 import BrowseResponse
 
 if TYPE_CHECKING:
-    from airweave.schemas.search_v2 import BrowseRequest, BrowseResponse
+    from airweave.schemas.search_v2 import BrowseRequest
 
 
 class FakeBrowseService(BrowseServiceProtocol):
     """Returns a seeded BrowseResponse. Records calls."""
 
     def __init__(self) -> None:
-        from airweave.schemas.search_v2 import BrowseResponse
-
         self._response: BrowseResponse = BrowseResponse(results=[], total=0, limit=50, offset=0)
         self._calls: list[tuple] = []
 

--- a/backend/airweave/domains/search/protocols.py
+++ b/backend/airweave/domains/search/protocols.py
@@ -17,6 +17,8 @@ from airweave.domains.search.types import (
 if TYPE_CHECKING:
     from airweave.schemas.search_v2 import (
         AgenticSearchRequest,
+        BrowseRequest,
+        BrowseResponse,
         ClassicSearchRequest,
         InstantSearchRequest,
     )
@@ -88,6 +90,21 @@ class ClassicSearchServiceProtocol(Protocol):
         user_principal_override: Optional[str] = None,
     ) -> SearchResults:
         """Execute classic search and return results."""
+        ...
+
+
+@runtime_checkable
+class BrowseServiceProtocol(Protocol):
+    """Browse — paginated tabular listing of a collection (no query, no ranking)."""
+
+    async def browse(
+        self,
+        db: AsyncSession,
+        ctx: ApiContext,
+        readable_id: str,
+        request: BrowseRequest,
+    ) -> BrowseResponse:
+        """Return a page of entities + total count for the collection."""
         ...
 
 

--- a/backend/airweave/schemas/search_v2.py
+++ b/backend/airweave/schemas/search_v2.py
@@ -157,20 +157,24 @@ class BrowseRequest(BaseModel):
     sync_ids: Optional[list[str]] = Field(
         default=None,
         description="Convenience: limit results to these sync_ids. Translated to a FilterGroup.",
+        max_length=100,
     )
     entity_types: Optional[list[str]] = Field(
         default=None,
         description=(
             "Convenience: limit results to these entity types. Translated to a FilterGroup."
         ),
+        max_length=100,
     )
     name_query: Optional[str] = Field(
         default=None,
         description=(
             "Case-insensitive substring search against the entity name. Bypasses the "
             "FilterCondition `contains` operator (which is token-match in Vespa) and "
-            "translates to a regex `matches` clause."
+            "translates to a regex `matches` clause. Min length 2 to prevent full-scan "
+            "triggers from a single character."
         ),
+        min_length=2,
         max_length=200,
     )
 

--- a/backend/airweave/schemas/search_v2.py
+++ b/backend/airweave/schemas/search_v2.py
@@ -127,6 +127,56 @@ class InternalAgenticSearchRequest(AgenticSearchRequest):
     )
 
 
+class BrowseRequest(BaseModel):
+    """Browse request — paginated tabular listing of a collection (POC, flag-gated).
+
+    No query, no embeddings, no ranking. Uses Vespa's filter_search() under the hood
+    and returns one row per source entity (filtered to chunk_index = 0).
+    """
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"limit": 50, "offset": 0},
+                {
+                    "limit": 50,
+                    "offset": 0,
+                    "sync_ids": ["d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80"],
+                },
+            ]
+        }
+    }
+
+    filter: Optional[list[FilterGroup]] = Field(
+        default=None,
+        description="Filter groups (combined with OR). Same shape as search filters.",
+    )
+    limit: int = Field(default=50, ge=1, le=200, description="Max rows per page.")
+    offset: int = Field(default=0, ge=0, description="Number of rows to skip.")
+
+    sync_ids: Optional[list[str]] = Field(
+        default=None,
+        description="Convenience: limit results to these sync_ids. Translated to a FilterGroup.",
+    )
+    entity_types: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Convenience: limit results to these entity types. Translated to a FilterGroup."
+        ),
+    )
+
+
+class BrowseResponse(BaseModel):
+    """Browse response — page of results plus total count for pagination."""
+
+    results: list[SearchResult] = Field(
+        default_factory=list, description="Rows on this page (one per source entity)."
+    )
+    total: int = Field(..., description="Total entity count matching the filter.")
+    limit: int = Field(..., description="Limit echoed back from the request.")
+    offset: int = Field(..., description="Offset echoed back from the request.")
+
+
 class SearchV2Response(BaseModel):
     """Unified response for all search tiers."""
 

--- a/backend/airweave/schemas/search_v2.py
+++ b/backend/airweave/schemas/search_v2.py
@@ -164,6 +164,15 @@ class BrowseRequest(BaseModel):
             "Convenience: limit results to these entity types. Translated to a FilterGroup."
         ),
     )
+    name_query: Optional[str] = Field(
+        default=None,
+        description=(
+            "Case-insensitive substring search against the entity name. Bypasses the "
+            "FilterCondition `contains` operator (which is token-match in Vespa) and "
+            "translates to a regex `matches` clause."
+        ),
+        max_length=200,
+    )
 
 
 class BrowseResponse(BaseModel):

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -656,6 +656,14 @@ def fake_agentic_search_v2():
 
 
 @pytest.fixture
+def fake_browse_service():
+    """Fake BrowseService."""
+    from airweave.domains.search.fakes.browse import FakeBrowseService
+
+    return FakeBrowseService()
+
+
+@pytest.fixture
 def fake_storage_backend():
     """Fake StorageBackend for testing storage consumers."""
     from airweave.domains.storage.fakes import FakeStorageBackend
@@ -737,6 +745,7 @@ def test_container(
     fake_instant_search,
     fake_classic_search,
     fake_agentic_search_v2,
+    fake_browse_service,
     fake_sync_factory,
     fake_entity_repo,
     fake_access_broker,
@@ -821,6 +830,7 @@ def test_container(
         instant_search=fake_instant_search,
         classic_search=fake_classic_search,
         agentic_search=fake_agentic_search_v2,
+        browse_service=fake_browse_service,
         sync_factory=fake_sync_factory,
         entity_repo=fake_entity_repo,
         access_broker=fake_access_broker,

--- a/frontend/src/components/collection/BrowseTable.tsx
+++ b/frontend/src/components/collection/BrowseTable.tsx
@@ -1,8 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
-import { ChevronLeft, ChevronRight, ExternalLink, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+    Check,
+    ChevronLeft,
+    ChevronRight,
+    Copy,
+    Download,
+    ExternalLink,
+    Loader2,
+    Search as SearchIcon,
+    X,
+} from "lucide-react";
 import { apiClient } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
     Table,
@@ -26,6 +37,15 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { getAppIconUrl } from "@/lib/utils/icons";
 import { useTheme } from "@/lib/theme-provider";
@@ -68,6 +88,23 @@ interface BrowseResponse {
     offset: number;
 }
 
+interface FilterCondition {
+    field: string;
+    operator: string;
+    value: string | number | boolean | string[] | number[];
+}
+
+interface FilterGroup {
+    conditions: FilterCondition[];
+}
+
+interface BrowseRequestBody {
+    limit: number;
+    offset: number;
+    sync_ids?: string[];
+    filter?: FilterGroup[];
+}
+
 interface BrowseTableProps {
     collectionReadableId: string;
     sourceConnections: Array<{
@@ -79,6 +116,8 @@ interface BrowseTableProps {
 }
 
 const PAGE_SIZE = 50;
+const SEARCH_DEBOUNCE_MS = 250;
+const EXPORT_MAX_ROWS = 1000;
 
 const ALL_SOURCES_VALUE = "__all__";
 
@@ -88,6 +127,69 @@ const formatTimestamp = (value: string | null | undefined): string => {
     if (Number.isNaN(date.getTime())) return value;
     return date.toLocaleString();
 };
+
+const buildBrowseBody = (
+    limit: number,
+    offset: number,
+    selectedSyncId: string,
+    nameQuery: string,
+): BrowseRequestBody => {
+    const body: BrowseRequestBody = { limit, offset };
+    if (selectedSyncId !== ALL_SOURCES_VALUE) {
+        body.sync_ids = [selectedSyncId];
+    }
+    const trimmed = nameQuery.trim();
+    if (trimmed) {
+        body.filter = [
+            {
+                conditions: [{ field: "name", operator: "contains", value: trimmed }],
+            },
+        ];
+    }
+    return body;
+};
+
+// ===== CSV / JSON helpers =====
+
+const CSV_COLUMNS: Array<{ header: string; pick: (r: BrowseRow) => unknown }> = [
+    { header: "entity_id", pick: (r) => r.entity_id },
+    { header: "name", pick: (r) => r.name ?? "" },
+    { header: "entity_type", pick: (r) => r.airweave_system_metadata?.entity_type ?? "" },
+    { header: "source_name", pick: (r) => r.airweave_system_metadata?.source_name ?? "" },
+    { header: "sync_id", pick: (r) => r.airweave_system_metadata?.sync_id ?? "" },
+    { header: "created_at", pick: (r) => r.created_at ?? "" },
+    { header: "updated_at", pick: (r) => r.updated_at ?? "" },
+    { header: "web_url", pick: (r) => r.web_url ?? "" },
+];
+
+const escapeCsv = (value: unknown): string => {
+    if (value === null || value === undefined) return "";
+    const s = typeof value === "string" ? value : JSON.stringify(value);
+    if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+    return s;
+};
+
+const rowsToCsv = (rows: BrowseRow[]): string => {
+    const head = CSV_COLUMNS.map((c) => c.header).join(",");
+    const body = rows
+        .map((r) => CSV_COLUMNS.map((c) => escapeCsv(c.pick(r))).join(","))
+        .join("\n");
+    return `${head}\n${body}\n`;
+};
+
+const triggerDownload = (filename: string, mime: string, content: string) => {
+    const blob = new Blob([content], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+};
+
+// ===== Component =====
 
 export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseTableProps) {
     const { resolvedTheme } = useTheme();
@@ -99,6 +201,58 @@ export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseT
     const [selectedSyncId, setSelectedSyncId] = useState<string>(ALL_SOURCES_VALUE);
     const [activeRow, setActiveRow] = useState<BrowseRow | null>(null);
 
+    // Reactive search bar
+    const [searchInput, setSearchInput] = useState("");
+    const [debouncedSearch, setDebouncedSearch] = useState("");
+
+    // Export state
+    const [isExporting, setIsExporting] = useState(false);
+
+    // Reset offset when filters change
+    useEffect(() => {
+        setOffset(0);
+    }, [selectedSyncId, debouncedSearch]);
+
+    // Debounce search input
+    useEffect(() => {
+        const t = setTimeout(() => setDebouncedSearch(searchInput), SEARCH_DEBOUNCE_MS);
+        return () => clearTimeout(t);
+    }, [searchInput]);
+
+    // Fetch page (abortable)
+    useEffect(() => {
+        const controller = new AbortController();
+        const run = async () => {
+            setIsLoading(true);
+            setError(null);
+            try {
+                const body = buildBrowseBody(PAGE_SIZE, offset, selectedSyncId, debouncedSearch);
+                const response = await apiClient.post(
+                    `/collections/${collectionReadableId}/browse`,
+                    body,
+                    { signal: controller.signal },
+                );
+                if (!response.ok) {
+                    const text = await response.text();
+                    throw new Error(text || `Browse failed (${response.status})`);
+                }
+                const data: BrowseResponse = await response.json();
+                if (!controller.signal.aborted) {
+                    setRows(data.results);
+                    setTotal(data.total);
+                }
+            } catch (e) {
+                if (controller.signal.aborted) return;
+                if (e instanceof Error && e.name === "AbortError") return;
+                setError(e instanceof Error ? e.message : "Failed to load");
+            } finally {
+                if (!controller.signal.aborted) setIsLoading(false);
+            }
+        };
+        void run();
+        return () => controller.abort();
+    }, [collectionReadableId, offset, selectedSyncId, debouncedSearch]);
+
     // sync_id → SourceConnection lookup
     const syncToConnection = useMemo(() => {
         const map = new Map<string, BrowseTableProps["sourceConnections"][number]>();
@@ -108,64 +262,75 @@ export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseT
         return map;
     }, [sourceConnections]);
 
-    // Reset pagination when filter changes
-    useEffect(() => {
-        setOffset(0);
-    }, [selectedSyncId]);
-
-    useEffect(() => {
-        let cancelled = false;
-        const run = async () => {
-            setIsLoading(true);
-            setError(null);
-            try {
-                const body: Record<string, unknown> = {
-                    limit: PAGE_SIZE,
-                    offset,
-                };
-                if (selectedSyncId !== ALL_SOURCES_VALUE) {
-                    body.sync_ids = [selectedSyncId];
-                }
-
-                const response = await apiClient.post(
-                    `/collections/${collectionReadableId}/browse`,
-                    body
-                );
-                if (!response.ok) {
-                    const text = await response.text();
-                    throw new Error(text || `Browse failed (${response.status})`);
-                }
-                const data: BrowseResponse = await response.json();
-                if (!cancelled) {
-                    setRows(data.results);
-                    setTotal(data.total);
-                }
-            } catch (e) {
-                if (!cancelled) {
-                    setError(e instanceof Error ? e.message : "Failed to load");
-                }
-            } finally {
-                if (!cancelled) setIsLoading(false);
-            }
-        };
-        run();
-        return () => {
-            cancelled = true;
-        };
-    }, [collectionReadableId, offset, selectedSyncId]);
-
     const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
     const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
     const canPrev = offset > 0;
     const canNext = offset + PAGE_SIZE < total;
 
+    const filteringApplied =
+        selectedSyncId !== ALL_SOURCES_VALUE || debouncedSearch.trim().length > 0;
+
+    // ===== Export =====
+
+    const fetchAllForExport = useCallback(async (): Promise<BrowseRow[]> => {
+        const cap = Math.min(total, EXPORT_MAX_ROWS);
+        const body = buildBrowseBody(cap, 0, selectedSyncId, debouncedSearch);
+        const response = await apiClient.post(
+            `/collections/${collectionReadableId}/browse`,
+            body,
+        );
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || `Export failed (${response.status})`);
+        }
+        const data: BrowseResponse = await response.json();
+        return data.results;
+    }, [collectionReadableId, selectedSyncId, debouncedSearch, total]);
+
+    const runExport = useCallback(
+        async (scope: "page" | "all", format: "csv" | "json") => {
+            setIsExporting(true);
+            try {
+                const data = scope === "page" ? rows : await fetchAllForExport();
+                const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+                const base = `${collectionReadableId}-browse-${stamp}`;
+                if (format === "csv") {
+                    triggerDownload(`${base}.csv`, "text/csv;charset=utf-8", rowsToCsv(data));
+                } else {
+                    triggerDownload(
+                        `${base}.json`,
+                        "application/json;charset=utf-8",
+                        JSON.stringify(data, null, 2),
+                    );
+                }
+                if (scope === "all" && total > EXPORT_MAX_ROWS) {
+                    toast.warning(
+                        `Exported first ${EXPORT_MAX_ROWS.toLocaleString()} of ${total.toLocaleString()} rows. Narrow the filter to capture more.`,
+                    );
+                } else {
+                    toast.success(`Exported ${data.length.toLocaleString()} rows`);
+                }
+            } catch (e) {
+                toast.error(e instanceof Error ? e.message : "Export failed");
+            } finally {
+                setIsExporting(false);
+            }
+        },
+        [collectionReadableId, rows, fetchAllForExport, total],
+    );
+
     return (
         <div className="w-full">
             {/* Toolbar */}
-            <div className="flex items-center justify-between gap-3 mb-3">
-                <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                    <SearchInput
+                        value={searchInput}
+                        onChange={setSearchInput}
+                        isPending={searchInput !== debouncedSearch || (isLoading && !!debouncedSearch)}
+                    />
                     <Select value={selectedSyncId} onValueChange={setSelectedSyncId}>
-                        <SelectTrigger className="h-8 w-[220px]">
+                        <SelectTrigger className="h-9 w-[200px] shrink-0">
                             <SelectValue placeholder="All sources" />
                         </SelectTrigger>
                         <SelectContent>
@@ -179,31 +344,74 @@ export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseT
                                 ))}
                         </SelectContent>
                     </Select>
-                    {isLoading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
                 </div>
-                <div className="text-xs text-muted-foreground">
-                    {total > 0 ? (
-                        <>
-                            {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
-                        </>
-                    ) : isLoading ? (
-                        <span>Loading…</span>
-                    ) : (
-                        <span>0 results</span>
-                    )}
+
+                <div className="flex items-center gap-2">
+                    <div className="text-xs text-muted-foreground tabular-nums">
+                        {total > 0 ? (
+                            <>
+                                {(offset + 1).toLocaleString()}–
+                                {Math.min(offset + PAGE_SIZE, total).toLocaleString()} of{" "}
+                                {total.toLocaleString()}
+                            </>
+                        ) : isLoading ? (
+                            <span>Loading…</span>
+                        ) : (
+                            <span>0 results</span>
+                        )}
+                    </div>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                className="h-9"
+                                disabled={isExporting || total === 0}
+                            >
+                                {isExporting ? (
+                                    <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                                ) : (
+                                    <Download className="h-3.5 w-3.5 mr-1.5" />
+                                )}
+                                Export
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-56">
+                            <DropdownMenuLabel className="text-xs text-muted-foreground">
+                                Current page ({rows.length.toLocaleString()})
+                            </DropdownMenuLabel>
+                            <DropdownMenuItem onClick={() => runExport("page", "csv")}>
+                                Export page as CSV
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => runExport("page", "json")}>
+                                Export page as JSON
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuLabel className="text-xs text-muted-foreground">
+                                {filteringApplied ? "All matching" : "Entire collection"} (max{" "}
+                                {EXPORT_MAX_ROWS.toLocaleString()})
+                            </DropdownMenuLabel>
+                            <DropdownMenuItem onClick={() => runExport("all", "csv")}>
+                                Export all as CSV
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => runExport("all", "json")}>
+                                Export all as JSON
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
                 </div>
             </div>
 
             {/* Table */}
-            <div className="rounded-md border">
+            <div className="rounded-md border bg-card">
                 <Table>
                     <TableHeader>
-                        <TableRow>
-                            <TableHead className="w-[40%]">Name</TableHead>
-                            <TableHead>Type</TableHead>
-                            <TableHead>Source</TableHead>
-                            <TableHead>Updated</TableHead>
-                            <TableHead className="text-right">Open</TableHead>
+                        <TableRow className="hover:bg-transparent">
+                            <TableHead className="w-[44%]">Name</TableHead>
+                            <TableHead className="w-[18%]">Type</TableHead>
+                            <TableHead className="w-[18%]">Source</TableHead>
+                            <TableHead className="w-[16%]">Updated</TableHead>
+                            <TableHead className="w-[4%] text-right" />
                         </TableRow>
                     </TableHeader>
                     <TableBody>
@@ -218,54 +426,69 @@ export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseT
                                 </TableRow>
                             ))
                         ) : rows.length === 0 ? (
-                            <TableRow>
-                                <TableCell colSpan={5} className="h-32 text-center text-muted-foreground">
-                                    {error ? `Error: ${error}` : "No entities to browse yet."}
+                            <TableRow className="hover:bg-transparent">
+                                <TableCell
+                                    colSpan={5}
+                                    className="h-32 text-center text-sm text-muted-foreground"
+                                >
+                                    {error
+                                        ? `Error: ${error}`
+                                        : filteringApplied
+                                          ? "No entities match these filters."
+                                          : "No entities to browse yet."}
                                 </TableCell>
                             </TableRow>
                         ) : (
                             rows.map((row) => {
                                 const meta = row.airweave_system_metadata ?? {};
-                                const conn = meta.sync_id ? syncToConnection.get(meta.sync_id) : undefined;
+                                const conn = meta.sync_id
+                                    ? syncToConnection.get(meta.sync_id)
+                                    : undefined;
                                 const sourceLabel = conn?.name ?? meta.source_name ?? "—";
                                 const shortName = conn?.short_name ?? meta.source_name;
                                 return (
                                     <TableRow
                                         key={row.entity_id}
-                                        className="cursor-pointer"
+                                        className="cursor-pointer group"
                                         onClick={() => setActiveRow(row)}
                                     >
-                                        <TableCell className="font-medium">
-                                            <div className="truncate max-w-[480px]" title={row.name ?? row.entity_id}>
+                                        <TableCell className="font-medium align-top">
+                                            <div
+                                                className="truncate max-w-[520px]"
+                                                title={row.name ?? row.entity_id}
+                                            >
                                                 {row.name || row.entity_id}
                                             </div>
                                             {row.textual_representation && (
-                                                <div className="text-xs text-muted-foreground truncate max-w-[480px]">
+                                                <div className="text-xs text-muted-foreground truncate max-w-[520px] mt-0.5">
                                                     {row.textual_representation}
                                                 </div>
                                             )}
                                         </TableCell>
-                                        <TableCell>
-                                            <Badge variant="secondary" className="font-mono text-[10px]">
+                                        <TableCell className="align-top">
+                                            <Badge
+                                                variant="secondary"
+                                                className="font-mono text-[10px] font-normal"
+                                            >
                                                 {meta.entity_type || "—"}
                                             </Badge>
                                         </TableCell>
-                                        <TableCell>
+                                        <TableCell className="align-top">
                                             <div className="flex items-center gap-2">
                                                 {shortName && (
                                                     <img
                                                         src={getAppIconUrl(shortName, resolvedTheme)}
                                                         alt={sourceLabel}
-                                                        className="h-4 w-4 object-contain"
+                                                        className="h-4 w-4 object-contain shrink-0"
                                                     />
                                                 )}
-                                                <span className="text-sm">{sourceLabel}</span>
+                                                <span className="text-sm truncate">{sourceLabel}</span>
                                             </div>
                                         </TableCell>
-                                        <TableCell className="text-sm text-muted-foreground">
+                                        <TableCell className="text-sm text-muted-foreground tabular-nums align-top">
                                             {formatTimestamp(row.updated_at ?? row.created_at)}
                                         </TableCell>
-                                        <TableCell className="text-right">
+                                        <TableCell className="text-right align-top">
                                             {row.web_url ? (
                                                 <a
                                                     href={row.web_url}
@@ -274,14 +497,17 @@ export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseT
                                                     onClick={(e) => e.stopPropagation()}
                                                     className={cn(
                                                         "inline-flex h-7 w-7 items-center justify-center rounded",
-                                                        "text-muted-foreground hover:text-foreground hover:bg-muted"
+                                                        "text-muted-foreground/60 group-hover:text-muted-foreground",
+                                                        "hover:!text-foreground hover:bg-muted",
                                                     )}
                                                     title="Open in source"
                                                 >
                                                     <ExternalLink className="h-3.5 w-3.5" />
                                                 </a>
                                             ) : (
-                                                <span className="text-xs text-muted-foreground">—</span>
+                                                <span className="text-xs text-muted-foreground/40">
+                                                    —
+                                                </span>
                                             )}
                                         </TableCell>
                                     </TableRow>
@@ -294,8 +520,8 @@ export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseT
 
             {/* Pagination */}
             <div className="flex items-center justify-between mt-3">
-                <div className="text-xs text-muted-foreground">
-                    Page {currentPage} of {totalPages}
+                <div className="text-xs text-muted-foreground tabular-nums">
+                    Page {currentPage.toLocaleString()} of {totalPages.toLocaleString()}
                 </div>
                 <div className="flex items-center gap-2">
                     <Button
@@ -319,79 +545,183 @@ export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseT
                 </div>
             </div>
 
-            {/* Row drawer */}
-            <Sheet open={!!activeRow} onOpenChange={(open) => !open && setActiveRow(null)}>
-                <SheetContent className="w-[600px] sm:max-w-[600px] overflow-y-auto">
-                    {activeRow && (
-                        <>
-                            <SheetHeader>
-                                <SheetTitle className="break-words">
-                                    {activeRow.name || activeRow.entity_id}
-                                </SheetTitle>
-                                <SheetDescription className="font-mono text-[11px] break-all">
-                                    {activeRow.entity_id}
-                                </SheetDescription>
-                            </SheetHeader>
-                            <div className="mt-4 space-y-4 text-sm">
-                                <DetailRow
-                                    label="Type"
-                                    value={activeRow.airweave_system_metadata?.entity_type}
-                                />
-                                <DetailRow
-                                    label="Source"
-                                    value={activeRow.airweave_system_metadata?.source_name}
-                                />
-                                <DetailRow label="Created" value={formatTimestamp(activeRow.created_at)} />
-                                <DetailRow label="Updated" value={formatTimestamp(activeRow.updated_at)} />
-                                {activeRow.breadcrumbs && activeRow.breadcrumbs.length > 0 && (
-                                    <div>
-                                        <div className="text-xs font-medium text-muted-foreground mb-1">Breadcrumbs</div>
-                                        <div className="text-xs">
-                                            {activeRow.breadcrumbs.map((b, i) => (
-                                                <span key={i}>
-                                                    {i > 0 && " / "}
-                                                    {b.name || b.entity_id}
-                                                </span>
-                                            ))}
-                                        </div>
-                                    </div>
-                                )}
-                                {activeRow.textual_representation && (
-                                    <div>
-                                        <div className="text-xs font-medium text-muted-foreground mb-1">
-                                            Content
-                                        </div>
-                                        <pre className="whitespace-pre-wrap break-words text-xs bg-muted rounded p-3 max-h-[40vh] overflow-auto">
-                                            {activeRow.textual_representation}
-                                        </pre>
-                                    </div>
-                                )}
-                                {activeRow.raw_source_fields &&
-                                    Object.keys(activeRow.raw_source_fields).length > 0 && (
-                                        <div>
-                                            <div className="text-xs font-medium text-muted-foreground mb-1">
-                                                Raw fields
-                                            </div>
-                                            <pre className="whitespace-pre-wrap break-words text-xs bg-muted rounded p-3 max-h-[30vh] overflow-auto">
-                                                {JSON.stringify(activeRow.raw_source_fields, null, 2)}
-                                            </pre>
-                                        </div>
-                                    )}
-                            </div>
-                        </>
-                    )}
-                </SheetContent>
-            </Sheet>
+            <RowDrawer row={activeRow} onClose={() => setActiveRow(null)} />
         </div>
     );
 }
 
-function DetailRow({ label, value }: { label: string; value?: string | null }) {
+// ===== Subcomponents =====
+
+function SearchInput({
+    value,
+    onChange,
+    isPending,
+}: {
+    value: string;
+    onChange: (v: string) => void;
+    isPending: boolean;
+}) {
+    const ref = useRef<HTMLInputElement>(null);
+    return (
+        <div className="relative flex-1 min-w-[180px] max-w-[420px]">
+            <SearchIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+            <Input
+                ref={ref}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                placeholder="Search by name…"
+                className="h-9 pl-8 pr-8"
+            />
+            {isPending && value && (
+                <Loader2 className="absolute right-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 animate-spin text-muted-foreground" />
+            )}
+            {!isPending && value && (
+                <button
+                    type="button"
+                    onClick={() => {
+                        onChange("");
+                        ref.current?.focus();
+                    }}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 h-5 w-5 inline-flex items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+                    aria-label="Clear search"
+                >
+                    <X className="h-3 w-3" />
+                </button>
+            )}
+        </div>
+    );
+}
+
+function RowDrawer({ row, onClose }: { row: BrowseRow | null; onClose: () => void }) {
+    const [copied, setCopied] = useState(false);
+    useEffect(() => {
+        if (!row) setCopied(false);
+    }, [row]);
+
+    const onCopy = useCallback((value: string) => {
+        navigator.clipboard.writeText(value).then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1200);
+        });
+    }, []);
+
+    return (
+        <Sheet open={!!row} onOpenChange={(open) => !open && onClose()}>
+            <SheetContent className="w-[640px] sm:max-w-[640px] p-0 overflow-hidden flex flex-col">
+                {row && (
+                    <>
+                        <SheetHeader className="px-6 pt-6 pb-4 border-b sticky top-0 bg-background z-10">
+                            <SheetTitle className="break-words text-base leading-snug">
+                                {row.name || row.entity_id}
+                            </SheetTitle>
+                            <SheetDescription className="flex items-center gap-2">
+                                <code className="font-mono text-[11px] break-all text-muted-foreground/80 leading-tight">
+                                    {row.entity_id}
+                                </code>
+                                <button
+                                    type="button"
+                                    onClick={() => onCopy(row.entity_id)}
+                                    className="shrink-0 inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground hover:bg-muted"
+                                    aria-label="Copy entity ID"
+                                >
+                                    {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                                </button>
+                            </SheetDescription>
+                        </SheetHeader>
+                        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5 text-sm">
+                            <div className="grid grid-cols-[80px_1fr] gap-y-2 gap-x-4 text-xs">
+                                <DetailRow
+                                    label="Type"
+                                    value={row.airweave_system_metadata?.entity_type}
+                                    mono
+                                />
+                                <DetailRow
+                                    label="Source"
+                                    value={row.airweave_system_metadata?.source_name}
+                                />
+                                <DetailRow label="Created" value={formatTimestamp(row.created_at)} />
+                                <DetailRow label="Updated" value={formatTimestamp(row.updated_at)} />
+                                {row.web_url && (
+                                    <>
+                                        <div className="text-muted-foreground">Link</div>
+                                        <a
+                                            href={row.web_url}
+                                            target="_blank"
+                                            rel="noreferrer noopener"
+                                            className="text-primary hover:underline truncate"
+                                        >
+                                            {row.web_url}
+                                        </a>
+                                    </>
+                                )}
+                            </div>
+
+                            {row.breadcrumbs && row.breadcrumbs.length > 0 && (
+                                <Section label="Breadcrumbs">
+                                    <div className="text-xs flex flex-wrap items-center gap-1">
+                                        {row.breadcrumbs.map((b, i) => (
+                                            <span key={i} className="flex items-center gap-1">
+                                                {i > 0 && (
+                                                    <span className="text-muted-foreground/50">/</span>
+                                                )}
+                                                <span className="text-foreground">
+                                                    {b.name || b.entity_id}
+                                                </span>
+                                            </span>
+                                        ))}
+                                    </div>
+                                </Section>
+                            )}
+
+                            {row.textual_representation && (
+                                <Section label="Content">
+                                    <pre className="whitespace-pre-wrap break-words text-xs bg-muted/50 rounded p-3 max-h-[40vh] overflow-auto leading-relaxed">
+                                        {row.textual_representation}
+                                    </pre>
+                                </Section>
+                            )}
+
+                            {row.raw_source_fields &&
+                                Object.keys(row.raw_source_fields).length > 0 && (
+                                    <Section label="Raw fields">
+                                        <pre className="whitespace-pre-wrap break-words text-xs bg-muted/50 rounded p-3 max-h-[30vh] overflow-auto leading-relaxed">
+                                            {JSON.stringify(row.raw_source_fields, null, 2)}
+                                        </pre>
+                                    </Section>
+                                )}
+                        </div>
+                    </>
+                )}
+            </SheetContent>
+        </Sheet>
+    );
+}
+
+function DetailRow({
+    label,
+    value,
+    mono,
+}: {
+    label: string;
+    value?: string | null;
+    mono?: boolean;
+}) {
     if (!value) return null;
     return (
-        <div className="flex items-baseline gap-3">
-            <div className="text-xs font-medium text-muted-foreground w-24 shrink-0">{label}</div>
-            <div className="text-sm break-all">{value}</div>
+        <>
+            <div className="text-muted-foreground">{label}</div>
+            <div className={cn("break-all", mono && "font-mono text-[11px]")}>{value}</div>
+        </>
+    );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div>
+            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground mb-2">
+                {label}
+            </div>
+            {children}
         </div>
     );
 }

--- a/frontend/src/components/collection/BrowseTable.tsx
+++ b/frontend/src/components/collection/BrowseTable.tsx
@@ -1,0 +1,397 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight, ExternalLink, Loader2 } from "lucide-react";
+import { apiClient } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from "@/components/ui/sheet";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { getAppIconUrl } from "@/lib/utils/icons";
+import { useTheme } from "@/lib/theme-provider";
+
+// ===== Types mirroring backend SearchResult =====
+// Kept loose on purpose: Vespa returns optional/varying fields per source.
+
+interface Breadcrumb {
+    entity_id?: string;
+    name?: string;
+    entity_type?: string;
+}
+
+interface SystemMetadata {
+    source_name?: string;
+    entity_type?: string;
+    original_entity_id?: string;
+    chunk_index?: number;
+    sync_id?: string;
+    sync_job_id?: string;
+}
+
+interface BrowseRow {
+    entity_id: string;
+    name?: string | null;
+    textual_representation?: string | null;
+    breadcrumbs?: Breadcrumb[] | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+    airweave_system_metadata?: SystemMetadata;
+    web_url?: string | null;
+    url?: string | null;
+    raw_source_fields?: Record<string, unknown> | null;
+}
+
+interface BrowseResponse {
+    results: BrowseRow[];
+    total: number;
+    limit: number;
+    offset: number;
+}
+
+interface BrowseTableProps {
+    collectionReadableId: string;
+    sourceConnections: Array<{
+        id: string;
+        name: string;
+        short_name: string;
+        sync_id?: string;
+    }>;
+}
+
+const PAGE_SIZE = 50;
+
+const ALL_SOURCES_VALUE = "__all__";
+
+const formatTimestamp = (value: string | null | undefined): string => {
+    if (!value) return "—";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString();
+};
+
+export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseTableProps) {
+    const { resolvedTheme } = useTheme();
+    const [rows, setRows] = useState<BrowseRow[]>([]);
+    const [total, setTotal] = useState(0);
+    const [offset, setOffset] = useState(0);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [selectedSyncId, setSelectedSyncId] = useState<string>(ALL_SOURCES_VALUE);
+    const [activeRow, setActiveRow] = useState<BrowseRow | null>(null);
+
+    // sync_id → SourceConnection lookup
+    const syncToConnection = useMemo(() => {
+        const map = new Map<string, BrowseTableProps["sourceConnections"][number]>();
+        for (const conn of sourceConnections) {
+            if (conn.sync_id) map.set(conn.sync_id, conn);
+        }
+        return map;
+    }, [sourceConnections]);
+
+    // Reset pagination when filter changes
+    useEffect(() => {
+        setOffset(0);
+    }, [selectedSyncId]);
+
+    useEffect(() => {
+        let cancelled = false;
+        const run = async () => {
+            setIsLoading(true);
+            setError(null);
+            try {
+                const body: Record<string, unknown> = {
+                    limit: PAGE_SIZE,
+                    offset,
+                };
+                if (selectedSyncId !== ALL_SOURCES_VALUE) {
+                    body.sync_ids = [selectedSyncId];
+                }
+
+                const response = await apiClient.post(
+                    `/collections/${collectionReadableId}/browse`,
+                    body
+                );
+                if (!response.ok) {
+                    const text = await response.text();
+                    throw new Error(text || `Browse failed (${response.status})`);
+                }
+                const data: BrowseResponse = await response.json();
+                if (!cancelled) {
+                    setRows(data.results);
+                    setTotal(data.total);
+                }
+            } catch (e) {
+                if (!cancelled) {
+                    setError(e instanceof Error ? e.message : "Failed to load");
+                }
+            } finally {
+                if (!cancelled) setIsLoading(false);
+            }
+        };
+        run();
+        return () => {
+            cancelled = true;
+        };
+    }, [collectionReadableId, offset, selectedSyncId]);
+
+    const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+    const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+    const canPrev = offset > 0;
+    const canNext = offset + PAGE_SIZE < total;
+
+    return (
+        <div className="w-full">
+            {/* Toolbar */}
+            <div className="flex items-center justify-between gap-3 mb-3">
+                <div className="flex items-center gap-2">
+                    <Select value={selectedSyncId} onValueChange={setSelectedSyncId}>
+                        <SelectTrigger className="h-8 w-[220px]">
+                            <SelectValue placeholder="All sources" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value={ALL_SOURCES_VALUE}>All sources</SelectItem>
+                            {sourceConnections
+                                .filter((c) => !!c.sync_id)
+                                .map((c) => (
+                                    <SelectItem key={c.id} value={c.sync_id as string}>
+                                        {c.name}
+                                    </SelectItem>
+                                ))}
+                        </SelectContent>
+                    </Select>
+                    {isLoading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                    {total > 0 ? (
+                        <>
+                            {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+                        </>
+                    ) : isLoading ? (
+                        <span>Loading…</span>
+                    ) : (
+                        <span>0 results</span>
+                    )}
+                </div>
+            </div>
+
+            {/* Table */}
+            <div className="rounded-md border">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="w-[40%]">Name</TableHead>
+                            <TableHead>Type</TableHead>
+                            <TableHead>Source</TableHead>
+                            <TableHead>Updated</TableHead>
+                            <TableHead className="text-right">Open</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {isLoading && rows.length === 0 ? (
+                            Array.from({ length: 8 }).map((_, i) => (
+                                <TableRow key={`skeleton-${i}`}>
+                                    {Array.from({ length: 5 }).map((__, j) => (
+                                        <TableCell key={j}>
+                                            <Skeleton className="h-4 w-full" />
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+                            ))
+                        ) : rows.length === 0 ? (
+                            <TableRow>
+                                <TableCell colSpan={5} className="h-32 text-center text-muted-foreground">
+                                    {error ? `Error: ${error}` : "No entities to browse yet."}
+                                </TableCell>
+                            </TableRow>
+                        ) : (
+                            rows.map((row) => {
+                                const meta = row.airweave_system_metadata ?? {};
+                                const conn = meta.sync_id ? syncToConnection.get(meta.sync_id) : undefined;
+                                const sourceLabel = conn?.name ?? meta.source_name ?? "—";
+                                const shortName = conn?.short_name ?? meta.source_name;
+                                return (
+                                    <TableRow
+                                        key={row.entity_id}
+                                        className="cursor-pointer"
+                                        onClick={() => setActiveRow(row)}
+                                    >
+                                        <TableCell className="font-medium">
+                                            <div className="truncate max-w-[480px]" title={row.name ?? row.entity_id}>
+                                                {row.name || row.entity_id}
+                                            </div>
+                                            {row.textual_representation && (
+                                                <div className="text-xs text-muted-foreground truncate max-w-[480px]">
+                                                    {row.textual_representation}
+                                                </div>
+                                            )}
+                                        </TableCell>
+                                        <TableCell>
+                                            <Badge variant="secondary" className="font-mono text-[10px]">
+                                                {meta.entity_type || "—"}
+                                            </Badge>
+                                        </TableCell>
+                                        <TableCell>
+                                            <div className="flex items-center gap-2">
+                                                {shortName && (
+                                                    <img
+                                                        src={getAppIconUrl(shortName, resolvedTheme)}
+                                                        alt={sourceLabel}
+                                                        className="h-4 w-4 object-contain"
+                                                    />
+                                                )}
+                                                <span className="text-sm">{sourceLabel}</span>
+                                            </div>
+                                        </TableCell>
+                                        <TableCell className="text-sm text-muted-foreground">
+                                            {formatTimestamp(row.updated_at ?? row.created_at)}
+                                        </TableCell>
+                                        <TableCell className="text-right">
+                                            {row.web_url ? (
+                                                <a
+                                                    href={row.web_url}
+                                                    target="_blank"
+                                                    rel="noreferrer noopener"
+                                                    onClick={(e) => e.stopPropagation()}
+                                                    className={cn(
+                                                        "inline-flex h-7 w-7 items-center justify-center rounded",
+                                                        "text-muted-foreground hover:text-foreground hover:bg-muted"
+                                                    )}
+                                                    title="Open in source"
+                                                >
+                                                    <ExternalLink className="h-3.5 w-3.5" />
+                                                </a>
+                                            ) : (
+                                                <span className="text-xs text-muted-foreground">—</span>
+                                            )}
+                                        </TableCell>
+                                    </TableRow>
+                                );
+                            })
+                        )}
+                    </TableBody>
+                </Table>
+            </div>
+
+            {/* Pagination */}
+            <div className="flex items-center justify-between mt-3">
+                <div className="text-xs text-muted-foreground">
+                    Page {currentPage} of {totalPages}
+                </div>
+                <div className="flex items-center gap-2">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={!canPrev || isLoading}
+                        onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}
+                    >
+                        <ChevronLeft className="h-4 w-4" />
+                        Prev
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={!canNext || isLoading}
+                        onClick={() => setOffset((o) => o + PAGE_SIZE)}
+                    >
+                        Next
+                        <ChevronRight className="h-4 w-4" />
+                    </Button>
+                </div>
+            </div>
+
+            {/* Row drawer */}
+            <Sheet open={!!activeRow} onOpenChange={(open) => !open && setActiveRow(null)}>
+                <SheetContent className="w-[600px] sm:max-w-[600px] overflow-y-auto">
+                    {activeRow && (
+                        <>
+                            <SheetHeader>
+                                <SheetTitle className="break-words">
+                                    {activeRow.name || activeRow.entity_id}
+                                </SheetTitle>
+                                <SheetDescription className="font-mono text-[11px] break-all">
+                                    {activeRow.entity_id}
+                                </SheetDescription>
+                            </SheetHeader>
+                            <div className="mt-4 space-y-4 text-sm">
+                                <DetailRow
+                                    label="Type"
+                                    value={activeRow.airweave_system_metadata?.entity_type}
+                                />
+                                <DetailRow
+                                    label="Source"
+                                    value={activeRow.airweave_system_metadata?.source_name}
+                                />
+                                <DetailRow label="Created" value={formatTimestamp(activeRow.created_at)} />
+                                <DetailRow label="Updated" value={formatTimestamp(activeRow.updated_at)} />
+                                {activeRow.breadcrumbs && activeRow.breadcrumbs.length > 0 && (
+                                    <div>
+                                        <div className="text-xs font-medium text-muted-foreground mb-1">Breadcrumbs</div>
+                                        <div className="text-xs">
+                                            {activeRow.breadcrumbs.map((b, i) => (
+                                                <span key={i}>
+                                                    {i > 0 && " / "}
+                                                    {b.name || b.entity_id}
+                                                </span>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                                {activeRow.textual_representation && (
+                                    <div>
+                                        <div className="text-xs font-medium text-muted-foreground mb-1">
+                                            Content
+                                        </div>
+                                        <pre className="whitespace-pre-wrap break-words text-xs bg-muted rounded p-3 max-h-[40vh] overflow-auto">
+                                            {activeRow.textual_representation}
+                                        </pre>
+                                    </div>
+                                )}
+                                {activeRow.raw_source_fields &&
+                                    Object.keys(activeRow.raw_source_fields).length > 0 && (
+                                        <div>
+                                            <div className="text-xs font-medium text-muted-foreground mb-1">
+                                                Raw fields
+                                            </div>
+                                            <pre className="whitespace-pre-wrap break-words text-xs bg-muted rounded p-3 max-h-[30vh] overflow-auto">
+                                                {JSON.stringify(activeRow.raw_source_fields, null, 2)}
+                                            </pre>
+                                        </div>
+                                    )}
+                            </div>
+                        </>
+                    )}
+                </SheetContent>
+            </Sheet>
+        </div>
+    );
+}
+
+function DetailRow({ label, value }: { label: string; value?: string | null }) {
+    if (!value) return null;
+    return (
+        <div className="flex items-baseline gap-3">
+            <div className="text-xs font-medium text-muted-foreground w-24 shrink-0">{label}</div>
+            <div className="text-sm break-all">{value}</div>
+        </div>
+    );
+}

--- a/frontend/src/components/collection/BrowseTable.tsx
+++ b/frontend/src/components/collection/BrowseTable.tsx
@@ -214,7 +214,7 @@ export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseT
             try {
                 const body = buildBrowseBody(PAGE_SIZE, offset, selectedSyncId, debouncedSearch);
                 const response = await apiClient.post(
-                    `/collections/${collectionReadableId}/browse`,
+                    `/collections/${collectionReadableId}/search/browse`,
                     body,
                     { signal: controller.signal },
                 );
@@ -262,7 +262,7 @@ export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseT
         const cap = Math.min(total, EXPORT_MAX_ROWS);
         const body = buildBrowseBody(cap, 0, selectedSyncId, debouncedSearch);
         const response = await apiClient.post(
-            `/collections/${collectionReadableId}/browse`,
+            `/collections/${collectionReadableId}/search/browse`,
             body,
         );
         if (!response.ok) {

--- a/frontend/src/components/collection/BrowseTable.tsx
+++ b/frontend/src/components/collection/BrowseTable.tsx
@@ -108,6 +108,10 @@ interface BrowseTableProps {
 const PAGE_SIZE = 50;
 const SEARCH_DEBOUNCE_MS = 250;
 const EXPORT_MAX_ROWS = 1000;
+// Backend caps `limit` at 200 (BrowseRequest in search_v2.py).
+const EXPORT_PAGE_SIZE = 200;
+// Backend requires `name_query` length >= 2 to avoid full-scan triggers on a single char.
+const NAME_QUERY_MIN_LENGTH = 2;
 
 const ALL_SOURCES_VALUE = "__all__";
 
@@ -129,7 +133,7 @@ const buildBrowseBody = (
         body.sync_ids = [selectedSyncId];
     }
     const trimmed = nameQuery.trim();
-    if (trimmed) {
+    if (trimmed.length >= NAME_QUERY_MIN_LENGTH) {
         body.name_query = trimmed;
     }
     return body;
@@ -254,23 +258,44 @@ export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseT
     const canNext = offset + PAGE_SIZE < total;
 
     const filteringApplied =
-        selectedSyncId !== ALL_SOURCES_VALUE || debouncedSearch.trim().length > 0;
+        selectedSyncId !== ALL_SOURCES_VALUE ||
+        debouncedSearch.trim().length >= NAME_QUERY_MIN_LENGTH;
+
+    const searchTrimmedLength = searchInput.trim().length;
+    const searchTooShort =
+        searchTrimmedLength > 0 && searchTrimmedLength < NAME_QUERY_MIN_LENGTH;
 
     // ===== Export =====
 
     const fetchAllForExport = useCallback(async (): Promise<BrowseRow[]> => {
+        // Backend caps a single page at 200, so loop in chunks until we hit the export cap.
         const cap = Math.min(total, EXPORT_MAX_ROWS);
-        const body = buildBrowseBody(cap, 0, selectedSyncId, debouncedSearch);
-        const response = await apiClient.post(
-            `/collections/${collectionReadableId}/search/browse`,
-            body,
-        );
-        if (!response.ok) {
-            const text = await response.text();
-            throw new Error(text || `Export failed (${response.status})`);
+        const accumulated: BrowseRow[] = [];
+        let pageOffset = 0;
+        while (accumulated.length < cap) {
+            const remaining = cap - accumulated.length;
+            const pageLimit = Math.min(EXPORT_PAGE_SIZE, remaining);
+            const body = buildBrowseBody(
+                pageLimit,
+                pageOffset,
+                selectedSyncId,
+                debouncedSearch,
+            );
+            const response = await apiClient.post(
+                `/collections/${collectionReadableId}/search/browse`,
+                body,
+            );
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(text || `Export failed (${response.status})`);
+            }
+            const data: BrowseResponse = await response.json();
+            if (data.results.length === 0) break;
+            accumulated.push(...data.results);
+            pageOffset += data.results.length;
+            if (data.results.length < pageLimit) break;
         }
-        const data: BrowseResponse = await response.json();
-        return data.results;
+        return accumulated;
     }, [collectionReadableId, selectedSyncId, debouncedSearch, total]);
 
     const runExport = useCallback(
@@ -314,6 +339,7 @@ export function BrowseTable({ collectionReadableId, sourceConnections }: BrowseT
                         value={searchInput}
                         onChange={setSearchInput}
                         isPending={searchInput !== debouncedSearch || (isLoading && !!debouncedSearch)}
+                        hint={searchTooShort ? "Type at least 2 characters" : null}
                     />
                     <Select value={selectedSyncId} onValueChange={setSelectedSyncId}>
                         <SelectTrigger className="h-9 w-[200px] shrink-0">
@@ -542,10 +568,12 @@ function SearchInput({
     value,
     onChange,
     isPending,
+    hint,
 }: {
     value: string;
     onChange: (v: string) => void;
     isPending: boolean;
+    hint?: string | null;
 }) {
     const ref = useRef<HTMLInputElement>(null);
     return (
@@ -573,6 +601,11 @@ function SearchInput({
                 >
                     <X className="h-3 w-3" />
                 </button>
+            )}
+            {hint && (
+                <div className="absolute left-0 top-full mt-1 text-[11px] text-muted-foreground">
+                    {hint}
+                </div>
             )}
         </div>
     );

--- a/frontend/src/components/collection/BrowseTable.tsx
+++ b/frontend/src/components/collection/BrowseTable.tsx
@@ -88,21 +88,11 @@ interface BrowseResponse {
     offset: number;
 }
 
-interface FilterCondition {
-    field: string;
-    operator: string;
-    value: string | number | boolean | string[] | number[];
-}
-
-interface FilterGroup {
-    conditions: FilterCondition[];
-}
-
 interface BrowseRequestBody {
     limit: number;
     offset: number;
     sync_ids?: string[];
-    filter?: FilterGroup[];
+    name_query?: string;
 }
 
 interface BrowseTableProps {
@@ -140,11 +130,7 @@ const buildBrowseBody = (
     }
     const trimmed = nameQuery.trim();
     if (trimmed) {
-        body.filter = [
-            {
-                conditions: [{ field: "name", operator: "contains", value: trimmed }],
-            },
-        ];
+        body.name_query = trimmed;
     }
     return body;
 };

--- a/frontend/src/lib/constants/feature-flags.ts
+++ b/frontend/src/lib/constants/feature-flags.ts
@@ -21,6 +21,9 @@ export const FeatureFlags = {
 
   // Auth Providers
   CUSTOM_AUTH_PROVIDER: 'custom_auth_provider',
+
+  // POC: tabular browse view on collections
+  COLLECTION_BROWSE: 'collection_browse',
 } as const;
 
 export type FeatureFlag = typeof FeatureFlags[keyof typeof FeatureFlags];

--- a/frontend/src/pages/CollectionDetailView.tsx
+++ b/frontend/src/pages/CollectionDetailView.tsx
@@ -29,8 +29,12 @@ import {
     TooltipTrigger,
 } from "@/components/ui/tooltip";
 import SourceConnectionStateView from "@/components/collection/SourceConnectionStateView";
+import { BrowseTable } from "@/components/collection/BrowseTable";
 import { emitCollectionEvent, onCollectionEvent, COLLECTION_DELETED, SOURCE_CONNECTION_UPDATED } from "@/lib/events";
 import { Search } from '@/search/Search';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useOrganizationStore } from "@/lib/stores/organizations";
+import { FeatureFlags } from "@/lib/constants/feature-flags";
 // import { DialogFlow } from '@/components/shared'; // TODO: Implement DialogFlow component
 import { protectedPaths } from "@/constants/paths";
 import { useEntityStateStore } from "@/stores/entityStateStore";
@@ -263,6 +267,10 @@ const Collections = () => {
 
     // Browse tree capability for selected connection
     const [selectedScSupportsBrowseTree, setSelectedScSupportsBrowseTree] = useState(false);
+
+    // Feature flag: tabular browse view (POC)
+    const hasFeature = useOrganizationStore(state => state.hasFeature);
+    const browseEnabled = hasFeature(FeatureFlags.COLLECTION_BROWSE);
 
     // Usage check from store (read-only, checking happens at app level)
     const actionChecks = useUsageStore(state => state.actionChecks);
@@ -907,13 +915,34 @@ const Collections = () => {
 
 
 
-                    {/* Add Search component when collection has any synced data */}
+                    {/* Search + (flag-gated) Browse */}
                     {collection?.readable_id && (
                         <div className="w-full max-w-[1000px] mt-10">
-                            <Search
-                                collectionReadableId={collection.readable_id}
-                                disabled={sourceConnections.length === 0}
-                            />
+                            {browseEnabled ? (
+                                <Tabs defaultValue="search" className="w-full">
+                                    <TabsList className="mb-4">
+                                        <TabsTrigger value="search">Search</TabsTrigger>
+                                        <TabsTrigger value="browse">Browse</TabsTrigger>
+                                    </TabsList>
+                                    <TabsContent value="search">
+                                        <Search
+                                            collectionReadableId={collection.readable_id}
+                                            disabled={sourceConnections.length === 0}
+                                        />
+                                    </TabsContent>
+                                    <TabsContent value="browse">
+                                        <BrowseTable
+                                            collectionReadableId={collection.readable_id}
+                                            sourceConnections={sourceConnections}
+                                        />
+                                    </TabsContent>
+                                </Tabs>
+                            ) : (
+                                <Search
+                                    collectionReadableId={collection.readable_id}
+                                    disabled={sourceConnections.length === 0}
+                                />
+                            )}
                         </div>
                     )}
 


### PR DESCRIPTION
## Summary

- Adds an unranked, paginated tabular browse view of a collection alongside the existing search experience, gated on a new `COLLECTION_BROWSE` org feature flag.
- Backend reuses `VespaVectorDB.filter_search() + count()` and forces `chunk_index = 0` so each source entity shows up as exactly one row. New `BrowseService` is exposed through the DI container and wired into `/collections/{readable_id}/search/browse`.
- Frontend ships a `BrowseTable` component (rows, sync/entity-type filters, debounced substring name search, offset/limit pagination, row drawer, CSV/JSON export) wired into `CollectionDetailView` as a Tabs sibling to Search.
- Name search uses a dedicated regex path on the vector-db protocol (`name matches "(?i).*<escaped>.*"`) rather than `contains`, because Vespa's `contains` operator on attribute fields is whole-token match — typing "Qui" wasn't matching "Quick process to debug" via the existing FilterCondition translator.

## CI status (verified locally on changed lines)

- ruff check + ruff-format: 100% clean (diff-quality)
- mypy: 100% clean on changed lines (diff-quality) — full-repo baseline is unchanged
- import-linter: 0 broken
- backend unit tests: 4201 passed (added `FakeBrowseService` + threaded it through the `test_container` fixture so existing tests don't break on the new required `Container.browse_service` field)
- ESLint: clean
- Frontend production build: clean

## Test plan

- [ ] Enable the `COLLECTION_BROWSE` feature flag on an org and open a collection — verify the Browse tab appears next to Search.
- [ ] Verify pagination, sync filter, entity-type filter all work independently and in combination.
- [ ] Type into the name search (e.g. partial token like "Qui") — confirm reactive results, that special characters (`.`, `+`, `(`) don't break the query, and that aborts work when typing fast.
- [ ] Export current page → CSV and JSON, then export "all matching" → confirm capped at 1000 rows.
- [ ] Click a row, confirm the drawer opens and entity_id copy-to-clipboard works.
- [ ] Disable the flag → Browse tab disappears and `/search/browse` returns 403/feature-disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a feature-flagged tabular browse view for collections with a new `POST /collections/{readable_id}/search/browse` endpoint and a Browse tab in the UI. It lists entities unranked with pagination, filters, case-insensitive substring name search (properly escaped), and CSV/JSON export.

- **New Features**
  - Backend: `POST /collections/{readable_id}/search/browse` gated by `FeatureFlag.COLLECTION_BROWSE`; uses `VectorDBProtocol.filter_search()` + `count()` in parallel with `chunk_index = 0`; supports `name_query` via a regex `matches` clause in `VespaVectorDB` (case-insensitive substring with escaping); adds `BrowseService`, DI wiring, and `BrowseRequest`/`BrowseResponse`.
  - Frontend: `BrowseTable` with source filter, debounced name search, offset/limit pagination, row drawer, open-in-source link, and CSV/JSON export (cap 1000 for “all matching”); added Tabs in `CollectionDetailView`; new `FeatureFlags.COLLECTION_BROWSE`.

- **Bug Fixes**
  - Moved route to `/search/browse` for consistency with other tiers.
  - Escaped double quotes in the YQL name-substring regex to prevent parse errors and injection; added tests for the clause, endpoint flag gate (404 when disabled), and service behavior.
  - Input and request bounds: `sync_ids`/`entity_types` capped at 100; `name_query` requires ≥2 chars (frontend hints and only sends when long enough); export fetches in 200-row chunks to respect the backend page limit.

<sup>Written for commit bcbf327c638d80c73c1243fe565be41e6cc25e75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

