### PR TITLE
fix(schemas): accept expires_in alongside expires_at in OAuthTokenAuthentication (#1024)

### DIFF
--- a/backend/airweave/schemas/source_connection.py
+++ b/backend/airweave/schemas/source_connection.py
@@ -6,7 +6,7 @@ This module provides a clean schema hierarchy for source connections:
 - Builder classes with type-safe construction and validation
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, Optional, Union
 from uuid import UUID
@@ -80,6 +80,30 @@ class OAuthTokenAuthentication(BaseModel):
     access_token: str = Field(..., description="OAuth access token")
     refresh_token: Optional[str] = Field(None, description="OAuth refresh token")
     expires_at: Optional[datetime] = Field(None, description="Token expiry time")
+    expires_in: Optional[int] = Field(
+        None,
+        description=(
+            "Token lifetime in seconds (standard OAuth response field). "
+            "Converted to expires_at automatically; ignored when expires_at is also provided."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def coerce_expires_in_to_expires_at(cls, values: Any) -> Any:
+        """Convert expires_in (seconds) to expires_at when expires_at is absent.
+
+        OAuth providers return expires_in per RFC 6749 §5.1. This validator
+        accepts that standard field and derives the absolute expiry timestamp,
+        so callers never have to compute it themselves.
+        """
+        if not isinstance(values, dict):
+            return values
+        if values.get("expires_in") is not None and values.get("expires_at") is None:
+            values["expires_at"] = datetime.now(timezone.utc) + timedelta(
+                seconds=values["expires_in"]
+            )
+        return values
 
     @field_validator("access_token")
     @classmethod

--- a/backend/tests/unit/schemas/test_source_connection_schemas.py
+++ b/backend/tests/unit/schemas/test_source_connection_schemas.py
@@ -1,0 +1,54 @@
+"""Unit tests for source connection Pydantic schemas."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from airweave.schemas.source_connection import OAuthTokenAuthentication
+
+
+class TestOAuthTokenAuthenticationExpiresIn:
+    """Tests for expires_in → expires_at conversion on OAuthTokenAuthentication."""
+
+    def test_expires_in_converted_to_expires_at(self):
+        auth = OAuthTokenAuthentication(
+            access_token="tok",
+            expires_in=3600,
+        )
+        assert auth.expires_at is not None
+        expected = datetime.now(timezone.utc) + timedelta(seconds=3600)
+        delta = abs((auth.expires_at - expected).total_seconds())
+        assert delta < 2, f"expires_at off by {delta}s"
+
+    def test_expires_at_takes_precedence_over_expires_in(self):
+        explicit_expiry = datetime.now(timezone.utc) + timedelta(hours=2)
+        auth = OAuthTokenAuthentication(
+            access_token="tok",
+            expires_at=explicit_expiry,
+            expires_in=60,
+        )
+        # expires_at must not be overwritten by expires_in
+        assert auth.expires_at == explicit_expiry
+
+    def test_neither_expires_field_is_valid(self):
+        auth = OAuthTokenAuthentication(access_token="tok")
+        assert auth.expires_at is None
+        assert auth.expires_in is None
+
+    def test_expired_expires_in_raises(self):
+        with pytest.raises(ValidationError, match="Token has already expired"):
+            OAuthTokenAuthentication(
+                access_token="tok",
+                expires_in=-1,
+            )
+
+    def test_expires_at_backward_compatibility(self):
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        auth = OAuthTokenAuthentication(access_token="tok", expires_at=future)
+        assert auth.expires_at == future
+        assert auth.expires_in is None
+
+    def test_blank_access_token_still_rejected(self):
+        with pytest.raises(ValidationError, match="access_token cannot be empty"):
+            OAuthTokenAuthentication(access_token="   ", expires_in=3600)


### PR DESCRIPTION
## Summary

- Adds `expires_in: Optional[int]` field to `OAuthTokenAuthentication` so callers can pass the standard OAuth RFC 6749 §5.1 response field directly
- A `mode="before"` model validator converts `expires_in → expires_at = now + timedelta(seconds=expires_in)` when `expires_at` is not provided
- Existing `expires_at` usage is fully backward-compatible — if both are supplied, `expires_at` wins
- Adds unit tests covering conversion, precedence, expiry validation, and backward compat

## Problem

OAuth providers return `expires_in` (seconds, per [RFC 6749 §5.1](https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/)), but `OAuthTokenAuthentication` only accepted `expires_at` (datetime). This forced every SDK/API caller to manually compute the absolute timestamp:

```ts
// workaround callers had to write:
const expiresAt = new Date(Date.now() + authFields.expires_in * 1000)
  .toISOString().replace('Z', '');
```

## Changes

| File | Change |
|---|---|
| `backend/airweave/schemas/source_connection.py` | Add `expires_in` field + `coerce_expires_in_to_expires_at` validator |
| `backend/tests/unit/schemas/test_source_connection_schemas.py` | 6 unit tests covering all behaviours |

## Test plan

- [x] `expires_in` alone → `expires_at` computed correctly (within 2 s of expected)
- [x] `expires_at` + `expires_in` → `expires_at` not overwritten
- [x] Neither field → both remain `None`
- [x] Negative `expires_in` (already expired) → `ValidationError`
- [x] `expires_at` alone → unchanged (backward compat)
- [x] Blank `access_token` with `expires_in` → still rejected

Fixes #1024

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `expires_in` support to `OAuthTokenAuthentication` and auto-convert it to `expires_at` so callers can pass standard OAuth responses directly. Keeps `expires_at` precedence for backward compatibility and removes client-side timestamp math. Fixes #1024.

- **New Features**
  - Accepts `expires_in` (RFC 6749 §5.1) and converts to `expires_at` via a `model_validator(mode="before")` when `expires_at` is missing.
  - If both are provided, `expires_at` wins; negative `expires_in` is rejected.
  - Added unit tests for conversion, precedence, and invalid inputs.

<sup>Written for commit 63a3ba879df391d5bc018c3a50c693375fd5b0a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

