### PR TITLE
feat(google-drive): add drive_id config to scope sync to a specific shared drive (#1735)

### DIFF
--- a/backend/airweave/platform/configs/config.py
+++ b/backend/airweave/platform/configs/config.py
@@ -332,6 +332,17 @@ class GoogleDocsConfig(SourceConfig):
 class GoogleDriveConfig(SourceConfig):
     """Google Drive configuration schema."""
 
+    drive_id: Optional[str] = Field(
+        default=None,
+        title="Shared Drive ID",
+        description=(
+            "Restrict sync to a single shared drive. "
+            "Leave empty to sync all shared drives and My Drive. "
+            "Find the ID in the drive URL after /folders/: "
+            "drive.google.com/drive/folders/{drive_id}"
+        ),
+    )
+
     include_patterns: list[str] = Field(
         default=[],
         title="Include Patterns",

--- a/backend/airweave/platform/sources/google_drive.py
+++ b/backend/airweave/platform/sources/google_drive.py
@@ -89,6 +89,7 @@ class GoogleDriveSource(BaseSource):
         """Create a new Google Drive source instance."""
         instance = cls(auth=auth, logger=logger, http_client=http_client)
         instance.include_patterns = config.include_patterns if config else []
+        instance.drive_id = config.drive_id if config else None
         instance.batch_size = 30
         instance.batch_generation = True
         instance.max_queue_size = 200
@@ -1033,6 +1034,15 @@ class GoogleDriveSource(BaseSource):
             drive_breadcrumbs = self._drive_breadcrumbs
             drive_ids = [drive["id"] for drive in drive_objs]
 
+            # Scope to a specific shared drive when drive_id is configured
+            _config_drive_id: Optional[str] = getattr(self, "drive_id", None)
+            if _config_drive_id:
+                drive_ids = [did for did in drive_ids if did == _config_drive_id]
+                self.logger.info(
+                    f"Scoping sync to shared drive {_config_drive_id} "
+                    f"({len(drive_ids)} match(es) found)"
+                )
+
             # INCREMENTAL MODE: Use Changes API exclusively
             if start_page_token:
                 self.logger.info(
@@ -1070,19 +1080,20 @@ class GoogleDriveSource(BaseSource):
                             )
                             continue
 
-                    try:
-                        async for mydrive_file_entity in self._generate_file_entities(
-                            corpora="user",
-                            include_all_drives=False,
-                            context="MY DRIVE",
-                            parent_breadcrumb=self._my_drive_breadcrumb,
-                            files=files,
-                        ):
-                            yield mydrive_file_entity
-                    except SourceAuthError:
-                        raise
-                    except Exception as e:
-                        self.logger.warning(f"Error processing My Drive files: {str(e)}")
+                    if not _config_drive_id:
+                        try:
+                            async for mydrive_file_entity in self._generate_file_entities(
+                                corpora="user",
+                                include_all_drives=False,
+                                context="MY DRIVE",
+                                parent_breadcrumb=self._my_drive_breadcrumb,
+                                files=files,
+                            ):
+                                yield mydrive_file_entity
+                        except SourceAuthError:
+                            raise
+                        except Exception as e:
+                            self.logger.warning(f"Error processing My Drive files: {str(e)}")
 
                 # INCLUDE MODE: Resolve patterns and traverse only matched subtrees
                 # Shared drives first
@@ -1216,9 +1227,9 @@ class GoogleDriveSource(BaseSource):
                     except Exception as e:
                         self.logger.warning(f"Include mode error for drive {drive_id}: {str(e)}")
 
-                # My Drive include patterns
+                # My Drive include patterns (skipped when scoped to a specific shared drive)
                 try:
-                    for p in patterns:
+                    for p in ([] if _config_drive_id else patterns):
                         roots, fname_glob = await self._resolve_pattern_to_roots(
                             corpora="user",
                             include_all_drives=False,
@@ -1284,7 +1295,7 @@ class GoogleDriveSource(BaseSource):
                     filename_only_patterns = [p for p in patterns if "/" not in p]
                     import fnmatch as _fn
 
-                    for pat in filename_only_patterns:
+                    for pat in ([] if _config_drive_id else filename_only_patterns):
                         if getattr(self, "batch_generation", False):
 
                             async def _worker_match_user(


### PR DESCRIPTION
## Summary

- Adds optional `drive_id` field to `GoogleDriveConfig` — when set, the sync is restricted to that single shared drive
- My Drive and all other shared drives are skipped when `drive_id` is provided
- No change to behaviour when `drive_id` is omitted (syncs all drives + My Drive as before)

## Problem

Users with access to multiple shared drives had no way to scope a sync to just one. The only option was `include_patterns`, but shared drive names are not matchable as folder paths — they're drive objects at the root. This forced listing every top-level folder explicitly, and new folders were silently excluded until patterns were updated.

## How it works

The file-listing plumbing already accepted `drive_id` all the way down (`_generate_file_entities`, `_list_files`, `_list_folders`, `_resolve_pattern_to_roots`). The fix filters `drive_ids` to the configured value before iteration begins, so both the no-patterns and include-patterns code paths respect the restriction automatically.

## Changes

| File | Change |
|---|---|
| `backend/airweave/platform/configs/config.py` | Add `drive_id: Optional[str]` to `GoogleDriveConfig` |
| `backend/airweave/platform/sources/google_drive.py` | Store on instance in `create()`; filter `drive_ids` and skip My Drive in `generate_entities()` |

## Test plan

- [x] `drive_id=None` (default): all shared drives + My Drive synced as before
- [x] `drive_id="<id>"`: only that shared drive is synced, My Drive skipped (both no-patterns and include-patterns paths)
- [x] `drive_id` set to a non-existent ID: `drive_ids` becomes empty, sync produces no entities (graceful)
- [x] Syntax validated on both changed files

Fixes #1735

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `drive_id` to `GoogleDriveConfig` to restrict Google Drive syncs to a single shared drive. When set, only that drive is synced and My Drive/other shared drives are skipped; behavior is unchanged when omitted.

- **New Features**
  - Add `drive_id` to `GoogleDriveConfig` to scope sync to one shared drive (ID is in the URL after `/folders/`).
  - Filter `drive_ids` early in `generate_entities()` so both list-all and include-pattern paths honor the scope.
  - Handle invalid `drive_id` gracefully by syncing nothing and logging.

<sup>Written for commit dd84efa0f13bd766716fbef32ee69408418c2250. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

