### PR TITLE
fix(embedders): use /.well-known/ready instead of /health for local embeddings probe (#1772)

### DIFF
--- a/backend/airweave/domains/embedders/config.py
+++ b/backend/airweave/domains/embedders/config.py
@@ -158,7 +158,7 @@ def _validate_local_reachability(dense_spec: DenseEmbedderEntry) -> None:
         return
 
     inference_url = settings.TEXT2VEC_INFERENCE_URL
-    health_url = f"{inference_url}/health"
+    health_url = f"{inference_url}/.well-known/ready"
 
     try:
         with httpx.Client(timeout=httpx.Timeout(5.0)) as client:

--- a/backend/airweave/domains/embedders/tests/test_local_reachability.py
+++ b/backend/airweave/domains/embedders/tests/test_local_reachability.py
@@ -71,7 +71,7 @@ class TestValidateLocalReachability:
         entry = _make_entry(LocalDenseEmbedder)
         _validate_local_reachability(entry)
 
-        client.get.assert_called_once_with("http://localhost:9878/health")
+        client.get.assert_called_once_with("http://localhost:9878/.well-known/ready")
 
     @patch("airweave.domains.embedders.config.settings")
     @patch("airweave.domains.embedders.config.httpx")

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -40,7 +40,7 @@ services:
       ENABLE_CUDA: 0
       WORKERS_PER_NODE: 1
     healthcheck:
-      test: [ "CMD", "wget", "--spider", "-q", "http://localhost:8080/health" ]
+      test: [ "CMD", "wget", "--spider", "-q", "http://localhost:8080/.well-known/ready" ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -157,7 +157,7 @@ services:
       ENABLE_CUDA: 0
       WORKERS_PER_NODE: 1
     healthcheck:
-      test: [ "CMD", "wget", "--spider", "-q", "http://localhost:8080/health" ]
+      test: [ "CMD", "wget", "--spider", "-q", "http://localhost:8080/.well-known/ready" ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

- Replaces `/health` with `/.well-known/ready` in the backend startup reachability probe and the docker-compose healthcheck for the `text2vec-transformers` container
- Updates the corresponding unit test assertion to match

## Problem

The `semitechnologies/transformers-inference` image does not expose a `/health` endpoint — it serves `/.well-known/ready` (HTTP 204 when ready, 503 when not). Both the backend startup check and the docker-compose healthcheck were calling `/health`, always receiving 404, which caused `raise_for_status()` to throw an `HTTPStatusError`. This prevented the `local_minilm` embedder from ever starting, even when the container was healthy.

## Changes

| File | Change |
|---|---|
| `backend/airweave/domains/embedders/config.py` | `_validate_local_reachability`: `/health` → `/.well-known/ready` |
| `docker/docker-compose.yml` | `text2vec-transformers` healthcheck: `/health` → `/.well-known/ready` |
| `backend/airweave/domains/embedders/tests/test_local_reachability.py` | Update expected URL in `test_passes_when_service_reachable` |

## Test plan

- [x] Syntax validated on all three changed files
- [x] Unit test `test_passes_when_service_reachable` assertion updated to match the new endpoint
- [x] `/.well-known/ready` returns HTTP 204 (no content) when the container is healthy — `raise_for_status()` does not raise on 2xx

Fixes #1772


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the local embeddings health probe from /health to /.well-known/ready so the `text2vec-transformers` container reports healthy and `local_minilm` can start. This avoids 404s from the `semitechnologies/transformers-inference` image.

- **Bug Fixes**
  - Backend reachability check now calls /.well-known/ready.
  - Healthchecks for `text2vec-transformers` updated to /.well-known/ready in both `docker-compose` files.
  - Unit test assertion updated to expect the new endpoint.

<sup>Written for commit 720de02cc8d0bd6a7acc301110d0a26f3d60f747. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



