### PR TITLE
fix(syncs): stop counting customer credential errors as workflow failures

### DIFF
--- a/backend/airweave/core/events/sync.py
+++ b/backend/airweave/core/events/sync.py
@@ -19,6 +19,7 @@ from airweave.core.events.enums import (
     QueryEventType,
     SyncEventType,
 )
+from airweave.core.shared_models import SourceConnectionErrorCategory
 
 
 class TypeActionCounts(BaseModel):
@@ -135,6 +136,7 @@ class SyncLifecycleEvent(DomainEvent):
 
     # Error info (for failed events)
     error: Optional[str] = None
+    error_category: Optional[str] = None
 
     @classmethod
     def pending(
@@ -258,8 +260,15 @@ class SyncLifecycleEvent(DomainEvent):
         collection_name: str,
         collection_readable_id: str,
         error: str,
+        error_category: Optional[SourceConnectionErrorCategory] = None,
     ) -> "SyncLifecycleEvent":
-        """Create a FAILED event (error)."""
+        """Create a FAILED event.
+
+        ``error_category`` carries the classified failure reason (e.g.
+        ``oauth_credentials_expired``, ``usage_limit_exceeded``) so
+        webhook subscribers can distinguish user-actionable failures from
+        system outages without parsing the free-text ``error`` field.
+        """
         return cls(
             event_type=SyncEventType.FAILED,
             organization_id=organization_id,
@@ -271,6 +280,7 @@ class SyncLifecycleEvent(DomainEvent):
             collection_name=collection_name,
             collection_readable_id=collection_readable_id,
             error=error,
+            error_category=error_category.value if error_category is not None else None,
         )
 
     @classmethod

--- a/backend/airweave/core/events/tests/test_sync_event.py
+++ b/backend/airweave/core/events/tests/test_sync_event.py
@@ -1,0 +1,103 @@
+"""Tests for SyncLifecycleEvent — focused on the failed-event payload.
+
+We only test SyncLifecycleEvent.failed here, since the other factories
+are mechanical and already exercised by callers. The failed factory has
+extra semantics: it carries optional error_category so webhook
+subscribers can distinguish classified user errors (NEEDS_REAUTH,
+billing) from real outages without parsing the free-text error string.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from airweave.core.events.enums import SyncEventType
+from airweave.core.events.sync import SyncLifecycleEvent
+from airweave.core.shared_models import SourceConnectionErrorCategory
+
+
+def _ids() -> dict:
+    return {
+        "organization_id": uuid4(),
+        "sync_id": uuid4(),
+        "sync_job_id": uuid4(),
+        "collection_id": uuid4(),
+        "source_connection_id": uuid4(),
+    }
+
+
+def test_failed_without_error_category_omits_field():
+    """Backward-compat: callers that don't pass error_category get None."""
+    event = SyncLifecycleEvent.failed(
+        **_ids(),
+        source_type="github",
+        collection_name="my-collection",
+        collection_readable_id="my-collection",
+        error="boom",
+    )
+
+    assert event.event_type == SyncEventType.FAILED
+    assert event.error == "boom"
+    assert event.error_category is None
+
+
+@pytest.mark.parametrize(
+    "category, expected_value",
+    [
+        (
+            SourceConnectionErrorCategory.OAUTH_CREDENTIALS_EXPIRED,
+            "oauth_credentials_expired",
+        ),
+        (
+            SourceConnectionErrorCategory.API_KEY_INVALID,
+            "api_key_invalid",
+        ),
+        (
+            SourceConnectionErrorCategory.AUTH_PROVIDER_ACCOUNT_GONE,
+            "auth_provider_account_gone",
+        ),
+        (
+            SourceConnectionErrorCategory.AUTH_PROVIDER_CREDENTIALS_INVALID,
+            "auth_provider_credentials_invalid",
+        ),
+        (
+            SourceConnectionErrorCategory.USAGE_LIMIT_EXCEEDED,
+            "usage_limit_exceeded",
+        ),
+        (
+            SourceConnectionErrorCategory.RATE_LIMITED,
+            "rate_limited",
+        ),
+    ],
+    ids=lambda v: v if isinstance(v, str) else v.name,
+)
+def test_failed_serializes_each_error_category(category, expected_value):
+    """Each SourceConnectionErrorCategory serializes to its string value.
+
+    External webhook consumers rely on stable string identifiers in the payload.
+    """
+    event = SyncLifecycleEvent.failed(
+        **_ids(),
+        source_type="github",
+        collection_name="my-collection",
+        collection_readable_id="my-collection",
+        error="boom",
+        error_category=category,
+    )
+    assert event.error_category == expected_value
+
+
+def test_failed_event_serializes_to_dict_with_error_category():
+    """Pydantic dump includes error_category — what Svix actually sends."""
+    event = SyncLifecycleEvent.failed(
+        **_ids(),
+        source_type="github",
+        collection_name="my-collection",
+        collection_readable_id="my-collection",
+        error="JWT expired",
+        error_category=SourceConnectionErrorCategory.OAUTH_CREDENTIALS_EXPIRED,
+    )
+    payload = event.model_dump(mode="json")
+    assert payload["error"] == "JWT expired"
+    assert payload["error_category"] == "oauth_credentials_expired"
+    assert payload["event_type"] == SyncEventType.FAILED.value

--- a/backend/airweave/core/shared_models.py
+++ b/backend/airweave/core/shared_models.py
@@ -74,6 +74,8 @@ class SourceConnectionErrorCategory(str, Enum):
     API_KEY_INVALID = "api_key_invalid"
     AUTH_PROVIDER_ACCOUNT_GONE = "auth_provider_account_gone"
     AUTH_PROVIDER_CREDENTIALS_INVALID = "auth_provider_credentials_invalid"
+    USAGE_LIMIT_EXCEEDED = "usage_limit_exceeded"
+    RATE_LIMITED = "rate_limited"
 
 
 class CollectionStatus(str, Enum):

--- a/backend/airweave/domains/sources/exceptions/classifier.py
+++ b/backend/airweave/domains/sources/exceptions/classifier.py
@@ -2,10 +2,13 @@
 
 Maps source exceptions to SourceConnectionErrorCategory values.
 
-Three exception hierarchies can signal credential errors:
-1. AuthProviderError  — raised by auth providers (Composio, Pipedream) directly
-2. TokenProviderError — raised by token providers wrapping auth provider errors
-3. SourceAuthError    — raised by sources on HTTP 401/403 responses
+Five exception hierarchies can signal user-actionable errors:
+1. AuthProviderError       — raised by auth providers (Composio, Pipedream) directly
+2. TokenProviderError      — raised by token providers wrapping auth provider errors
+3. SourceAuthError         — raised by sources on HTTP 401/403 responses
+4. UsageLimitExceededError — raised by the usage limit checker (billing)
+5. SourceRateLimitError /
+   SourceEntityForbiddenError("rate limit") — upstream rate-limit signals
 """
 
 from __future__ import annotations
@@ -17,7 +20,12 @@ from airweave.domains.auth_provider.exceptions import (
     AuthProviderError,
 )
 from airweave.domains.source_connections.types import ErrorClassification
-from airweave.domains.sources.exceptions import SourceAuthError, SourceTokenRefreshError
+from airweave.domains.sources.exceptions import (
+    SourceAuthError,
+    SourceEntityForbiddenError,
+    SourceRateLimitError,
+    SourceTokenRefreshError,
+)
 from airweave.domains.sources.token_providers.exceptions import (
     TokenCredentialsInvalidError,
     TokenExpiredError,
@@ -25,6 +33,7 @@ from airweave.domains.sources.token_providers.exceptions import (
     TokenProviderError,
 )
 from airweave.domains.sources.token_providers.protocol import AuthProviderKind
+from airweave.domains.usage.exceptions import UsageLimitExceededError
 
 # All exception types the classifier can recognise directly or via __cause__
 _CLASSIFIABLE = (
@@ -32,10 +41,13 @@ _CLASSIFIABLE = (
     SourceAuthError,
     SourceTokenRefreshError,
     TokenProviderError,
+    UsageLimitExceededError,
+    SourceRateLimitError,
+    SourceEntityForbiddenError,
 )
 
 
-def classify_error(exc: Exception) -> ErrorClassification:
+def classify_error(exc: Exception) -> ErrorClassification:  # noqa: C901
     """Classify an exception into an error category for UI remediation.
 
     Args:
@@ -101,8 +113,37 @@ def classify_error(exc: Exception) -> ErrorClassification:
     if isinstance(exc, TokenCredentialsInvalidError):
         return _classify_by_provider_kind(exc.provider_kind, exc)
 
-    # Not a credential error — return empty classification
+    # --- UsageLimitExceededError (billing / plan limit) ---
+    if isinstance(exc, UsageLimitExceededError):
+        return ErrorClassification(
+            category=SourceConnectionErrorCategory.USAGE_LIMIT_EXCEEDED,
+            message=str(exc),
+        )
+
+    # --- Rate-limit signals from upstream APIs ---
+    # SourceRateLimitError is the canonical 429 case. SourceEntityForbiddenError
+    # carries 403 messages, some of which are actually disguised rate limits
+    # (notably GitHub, which returns 403 with "API rate limit exceeded").
+    if isinstance(exc, SourceRateLimitError):
+        return ErrorClassification(
+            category=SourceConnectionErrorCategory.RATE_LIMITED,
+            message=str(exc),
+        )
+
+    if isinstance(exc, SourceEntityForbiddenError) and _is_rate_limit_403(str(exc)):
+        return ErrorClassification(
+            category=SourceConnectionErrorCategory.RATE_LIMITED,
+            message=str(exc),
+        )
+
+    # Not a classified error — return empty classification
     return ErrorClassification(category=None, message=None)
+
+
+def _is_rate_limit_403(message: str) -> bool:
+    """Detect APIs (notably GitHub) that return 403 for rate-limit responses."""
+    lowered = message.lower()
+    return "rate limit" in lowered or "abuse detection" in lowered
 
 
 def _classify_by_provider_kind(

--- a/backend/airweave/domains/sources/exceptions/tests/test_classifier.py
+++ b/backend/airweave/domains/sources/exceptions/tests/test_classifier.py
@@ -7,8 +7,8 @@ from airweave.domains.auth_provider.exceptions import (
     AuthProviderAccountNotFoundError,
     AuthProviderAuthError,
 )
-from airweave.domains.sources.exceptions.classifier import classify_error
 from airweave.domains.sources.exceptions import SourceAuthError, SourceTokenRefreshError
+from airweave.domains.sources.exceptions.classifier import classify_error
 from airweave.domains.sources.token_providers.exceptions import (
     TokenCredentialsInvalidError,
     TokenExpiredError,
@@ -16,7 +16,6 @@ from airweave.domains.sources.token_providers.exceptions import (
     TokenProviderServerError,
 )
 from airweave.domains.sources.token_providers.protocol import AuthProviderKind
-
 
 # ---------------------------------------------------------------------------
 # Legacy SourceAuthError / SourceTokenRefreshError
@@ -257,3 +256,100 @@ def test_auth_provider_error_unwrapped_from_cause():
 
     result = classify_error(wrapper)
     assert result.category == SourceConnectionErrorCategory.AUTH_PROVIDER_CREDENTIALS_INVALID
+
+
+# ---------------------------------------------------------------------------
+# UsageLimitExceededError → USAGE_LIMIT_EXCEEDED
+# ---------------------------------------------------------------------------
+
+
+def test_usage_limit_exceeded_classified():
+    """UsageLimitExceededError (entity cap hit) classifies as USAGE_LIMIT_EXCEEDED."""
+    from airweave.domains.usage.exceptions import UsageLimitExceededError
+
+    result = classify_error(
+        UsageLimitExceededError(
+            action_type="entities",
+            limit=50000,
+            current_usage=50103,
+        )
+    )
+    assert result.category == SourceConnectionErrorCategory.USAGE_LIMIT_EXCEEDED
+    assert result.message is not None
+    assert "50000" in result.message
+
+
+def test_usage_limit_exceeded_unwrapped_from_cause():
+    """A wrapper exception with UsageLimitExceededError as __cause__ is classified."""
+    from airweave.domains.usage.exceptions import UsageLimitExceededError
+
+    cause = UsageLimitExceededError(action_type="entities", limit=100, current_usage=101)
+    wrapper = RuntimeError("guard rail check failed")
+    wrapper.__cause__ = cause
+
+    result = classify_error(wrapper)
+    assert result.category == SourceConnectionErrorCategory.USAGE_LIMIT_EXCEEDED
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit signals → RATE_LIMITED
+# ---------------------------------------------------------------------------
+
+
+def test_source_rate_limit_error_classified():
+    """The canonical 429 SourceRateLimitError classifies as RATE_LIMITED."""
+    from airweave.domains.sources.exceptions import SourceRateLimitError
+
+    result = classify_error(SourceRateLimitError(retry_after=60.0, source_short_name="hubspot"))
+    assert result.category == SourceConnectionErrorCategory.RATE_LIMITED
+    assert result.message is not None
+
+
+def test_github_403_rate_limit_classified():
+    """GitHub returns 403 for rate limits.
+
+    SourceEntityForbiddenError carrying 'rate limit' in its message is
+    classified as RATE_LIMITED.
+    """
+    from airweave.domains.sources.exceptions import SourceEntityForbiddenError
+
+    result = classify_error(
+        SourceEntityForbiddenError(
+            "Forbidden (403): API rate limit exceeded for user ID 3160046",
+            source_short_name="github",
+        )
+    )
+    assert result.category == SourceConnectionErrorCategory.RATE_LIMITED
+
+
+def test_github_403_abuse_detection_classified():
+    """GitHub's other 403 rate-limit variant — 'secondary rate limit' / abuse.
+
+    detection — is also classified as RATE_LIMITED.
+    """
+    from airweave.domains.sources.exceptions import SourceEntityForbiddenError
+
+    result = classify_error(
+        SourceEntityForbiddenError(
+            "Forbidden (403): You have triggered an abuse detection mechanism",
+            source_short_name="github",
+        )
+    )
+    assert result.category == SourceConnectionErrorCategory.RATE_LIMITED
+
+
+def test_403_without_rate_limit_message_not_classified():
+    """A plain 403 (permission denied, not rate limit) is NOT classified —.
+
+    those represent entity-level permission issues, not connection problems.
+    """
+    from airweave.domains.sources.exceptions import SourceEntityForbiddenError
+
+    result = classify_error(
+        SourceEntityForbiddenError(
+            "Forbidden (403): You don't have access to this resource",
+            source_short_name="github",
+        )
+    )
+    assert result.category is None
+    assert result.message is None

--- a/backend/airweave/domains/sync_pipeline/orchestrator.py
+++ b/backend/airweave/domains/sync_pipeline/orchestrator.py
@@ -11,7 +11,11 @@ from airweave.core.events.sync import (
     AccessControlMembershipBatchProcessedEvent,
 )
 from airweave.core.protocols.event_bus import EventBus
-from airweave.core.shared_models import SyncJobStatus, SyncStatus
+from airweave.core.shared_models import (
+    SourceConnectionErrorCategory,
+    SyncJobStatus,
+    SyncStatus,
+)
 from airweave.db.session import get_db_context
 from airweave.domains.access_control.pipeline import AccessControlPipeline
 from airweave.domains.sources.exceptions.classifier import classify_error
@@ -25,6 +29,7 @@ from airweave.domains.syncs.cursors.service import SyncCursorService
 from airweave.domains.syncs.jobs.protocols import SyncJobStateMachineProtocol
 from airweave.domains.syncs.jobs.types import InvalidTransitionError, LifecycleData
 from airweave.domains.syncs.protocols import SyncStateMachineProtocol
+from airweave.domains.temporal.exceptions import classified_user_application_error
 from airweave.domains.temporal.metrics import worker_metrics
 from airweave.domains.usage.exceptions import (
     PaymentRequiredError,
@@ -143,7 +148,12 @@ class SyncOrchestrator:
             await self._handle_cancellation()
             raise
         except Exception as e:
-            await self._handle_sync_failure(e)
+            category = await self._handle_sync_failure(e)
+            # Classified user errors (expired credentials, usage limits,
+            # rate limits) are wrapped so the workflow can complete normally
+            # rather than incrementing temporal_workflow_failed.
+            if category is not None:
+                raise classified_user_application_error(e, category) from e
             raise
         finally:
             # Note: Removed aggregate metrics recording (histograms/counters)
@@ -655,14 +665,33 @@ class SyncOrchestrator:
                 exc_info=True,
             )
 
-    async def _handle_sync_failure(self, error: Exception) -> None:
-        """Handle sync failure by updating job status with error details."""
-        error_message = get_error_message(error)
-        self.sync_context.logger.error(
-            f"Sync job {self.sync_context.sync_job.id} failed: {error_message}", exc_info=True
-        )
+    async def _handle_sync_failure(
+        self, error: Exception
+    ) -> Optional[SourceConnectionErrorCategory]:
+        """Handle sync failure by updating job status with error details.
 
+        Returns the classified error category, or None for unclassified
+        (true system) failures. Callers use the return value to decide
+        whether to wrap the exception as a classified user error before
+        re-raising.
+        """
+        error_message = get_error_message(error)
         classification = classify_error(error)
+
+        # User-actionable failures (expired credentials, usage limits,
+        # rate limits) are logged at WARNING — they're not Airweave
+        # outages, they're customer integration state that the UI
+        # surfaces via NEEDS_REAUTH / billing.
+        if classification.category is not None:
+            self.sync_context.logger.warning(
+                f"Sync job {self.sync_context.sync_job.id} failed "
+                f"({classification.category.value}): {error_message}"
+            )
+        else:
+            self.sync_context.logger.error(
+                f"Sync job {self.sync_context.sync_job.id} failed: {error_message}",
+                exc_info=True,
+            )
 
         stats = self.runtime.entity_tracker.get_stats()
 
@@ -676,17 +705,22 @@ class SyncOrchestrator:
             error_category=classification.category,
         )
 
-        if classification.category is not None:
+        # Rate-limit hits are transient; the next scheduled run will
+        # likely succeed once the window resets. Don't pause the sync.
+        if (
+            classification.category is not None
+            and classification.category != SourceConnectionErrorCategory.RATE_LIMITED
+        ):
             try:
                 await self._sync_state_machine.transition(
                     sync_id=self.sync_context.sync.id,
                     target=SyncStatus.PAUSED,
                     ctx=self.sync_context,
-                    reason=f"Credential error: {classification.category.value}",
+                    reason=f"Classified error: {classification.category.value}",
                 )
             except Exception as pause_err:
                 self.sync_context.logger.warning(
-                    f"Failed to pause sync after credential error: {pause_err}",
+                    f"Failed to pause sync after classified error: {pause_err}",
                     exc_info=True,
                 )
 
@@ -709,6 +743,8 @@ class SyncOrchestrator:
             error=error_message,
             duration_ms=duration_ms,
         )
+
+        return classification.category
 
     async def _handle_cancellation(self) -> None:
         """Centralized cancellation handler - explicit and immediate."""

--- a/backend/airweave/domains/sync_pipeline/tests/test_orchestrator.py
+++ b/backend/airweave/domains/sync_pipeline/tests/test_orchestrator.py
@@ -67,11 +67,19 @@ class TestUsageLedgerFlushFailure:
 
         with (
             patch.object(
-                orc, "_start_sync",
+                orc,
+                "_start_sync",
                 new_callable=AsyncMock,
                 side_effect=SyncFailureError("source failed"),
             ),
-            patch.object(orc, "_handle_sync_failure", new_callable=AsyncMock),
+            # Returning None signals "unclassified" — original exception
+            # propagates instead of being wrapped as ClassifiedUserError.
+            patch.object(
+                orc,
+                "_handle_sync_failure",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
             patch.object(orc, "entity_pipeline", MagicMock()),
             patch(
                 "airweave.domains.sync_pipeline.orchestrator.worker_metrics",
@@ -156,16 +164,13 @@ class TestHandleSyncFailure:
             token_provider_kind=AuthProviderKind.OAUTH,
         )
 
-        with patch(
-            "airweave.domains.sync_pipeline.orchestrator.business_events"
-        ):
+        with patch("airweave.domains.sync_pipeline.orchestrator.business_events"):
             await orc._handle_sync_failure(exc)
 
         state_machine.transition.assert_awaited_once()
         call_kwargs = state_machine.transition.call_args.kwargs
         assert (
-            call_kwargs["error_category"]
-            == SourceConnectionErrorCategory.OAUTH_CREDENTIALS_EXPIRED
+            call_kwargs["error_category"] == SourceConnectionErrorCategory.OAUTH_CREDENTIALS_EXPIRED
         )
         assert call_kwargs["target"] == SyncJobStatus.FAILED
 
@@ -188,9 +193,7 @@ class TestHandleSyncFailure:
             sync_state_machine=sync_state_machine,
         )
 
-        with patch(
-            "airweave.domains.sync_pipeline.orchestrator.business_events"
-        ):
+        with patch("airweave.domains.sync_pipeline.orchestrator.business_events"):
             await orc._handle_sync_failure(RuntimeError("network timeout"))
 
         call_kwargs = state_machine.transition.call_args.kwargs
@@ -227,10 +230,241 @@ class TestHandleSyncFailure:
             token_provider_kind=AuthProviderKind.OAUTH,
         )
 
-        with patch(
-            "airweave.domains.sync_pipeline.orchestrator.business_events"
-        ):
+        with patch("airweave.domains.sync_pipeline.orchestrator.business_events"):
             await orc._handle_sync_failure(exc)
 
         state_machine.transition.assert_awaited_once()
         ctx.logger.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_category_for_classified_error(self):
+        """_handle_sync_failure returns the classified category, allowing.
+
+        run() to decide whether to wrap the exception.
+        """
+        from airweave.core.shared_models import SourceConnectionErrorCategory
+        from airweave.domains.sources.exceptions import SourceAuthError
+        from airweave.domains.sources.token_providers.protocol import AuthProviderKind
+
+        ctx = _make_sync_context()
+        ctx.sync_job.started_at = None
+
+        orc = _make_orchestrator(
+            sync_context=ctx,
+            state_machine=AsyncMock(),
+            sync_state_machine=AsyncMock(),
+        )
+
+        exc = SourceAuthError(
+            "401",
+            source_short_name="github",
+            status_code=401,
+            token_provider_kind=AuthProviderKind.OAUTH,
+        )
+
+        with patch("airweave.domains.sync_pipeline.orchestrator.business_events"):
+            category = await orc._handle_sync_failure(exc)
+
+        assert category == SourceConnectionErrorCategory.OAUTH_CREDENTIALS_EXPIRED
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_unclassified_error(self):
+        """A true system failure returns None so run() re-raises unwrapped."""
+        ctx = _make_sync_context()
+        ctx.sync_job.started_at = None
+
+        orc = _make_orchestrator(
+            sync_context=ctx,
+            state_machine=AsyncMock(),
+            sync_state_machine=AsyncMock(),
+        )
+
+        with patch("airweave.domains.sync_pipeline.orchestrator.business_events"):
+            category = await orc._handle_sync_failure(RuntimeError("db down"))
+
+        assert category is None
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_does_not_pause(self):
+        """Rate-limit errors return the RATE_LIMITED category but do NOT.
+
+        pause the sync — the next scheduled run will succeed once the
+        window resets.
+        """
+        from airweave.core.shared_models import SourceConnectionErrorCategory
+        from airweave.domains.sources.exceptions import SourceRateLimitError
+
+        state_machine = AsyncMock()
+        sync_state_machine = AsyncMock()
+
+        ctx = _make_sync_context()
+        ctx.sync_job.started_at = None
+
+        orc = _make_orchestrator(
+            sync_context=ctx,
+            state_machine=state_machine,
+            sync_state_machine=sync_state_machine,
+        )
+
+        exc = SourceRateLimitError(retry_after=60.0, source_short_name="hubspot")
+
+        with patch("airweave.domains.sync_pipeline.orchestrator.business_events"):
+            category = await orc._handle_sync_failure(exc)
+
+        assert category == SourceConnectionErrorCategory.RATE_LIMITED
+        # Sync state machine NOT called for rate-limited — sync stays ACTIVE.
+        sync_state_machine.transition.assert_not_awaited()
+        # But the job transition still records the category.
+        state_machine.transition.assert_awaited_once()
+        call_kwargs = state_machine.transition.call_args.kwargs
+        assert call_kwargs["error_category"] == SourceConnectionErrorCategory.RATE_LIMITED
+
+    @pytest.mark.asyncio
+    async def test_usage_limit_error_pauses_and_classifies(self):
+        """Usage limit errors classify as USAGE_LIMIT_EXCEEDED and pause."""
+        from airweave.core.shared_models import SourceConnectionErrorCategory, SyncStatus
+        from airweave.domains.usage.exceptions import UsageLimitExceededError
+
+        state_machine = AsyncMock()
+        sync_state_machine = AsyncMock()
+
+        ctx = _make_sync_context()
+        ctx.sync_job.started_at = None
+
+        orc = _make_orchestrator(
+            sync_context=ctx,
+            state_machine=state_machine,
+            sync_state_machine=sync_state_machine,
+        )
+
+        exc = UsageLimitExceededError(action_type="entities", limit=50000, current_usage=50103)
+
+        with patch("airweave.domains.sync_pipeline.orchestrator.business_events"):
+            category = await orc._handle_sync_failure(exc)
+
+        assert category == SourceConnectionErrorCategory.USAGE_LIMIT_EXCEEDED
+        sync_state_machine.transition.assert_awaited_once()
+        pause_kwargs = sync_state_machine.transition.call_args.kwargs
+        assert pause_kwargs["target"] == SyncStatus.PAUSED
+
+    @pytest.mark.asyncio
+    async def test_classified_error_logs_at_warning(self):
+        """Classified failures log at WARNING — they're customer state, not.
+
+        Airweave outages.
+        """
+        from airweave.domains.sources.exceptions import SourceAuthError
+        from airweave.domains.sources.token_providers.protocol import AuthProviderKind
+
+        ctx = _make_sync_context()
+        ctx.sync_job.started_at = None
+
+        orc = _make_orchestrator(
+            sync_context=ctx,
+            state_machine=AsyncMock(),
+            sync_state_machine=AsyncMock(),
+        )
+
+        exc = SourceAuthError(
+            "401",
+            source_short_name="github",
+            status_code=401,
+            token_provider_kind=AuthProviderKind.OAUTH,
+        )
+
+        with patch("airweave.domains.sync_pipeline.orchestrator.business_events"):
+            await orc._handle_sync_failure(exc)
+
+        ctx.logger.warning.assert_called()
+        ctx.logger.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unclassified_error_logs_at_error(self):
+        """Unclassified failures (true system errors) log at ERROR with traceback."""
+        ctx = _make_sync_context()
+        ctx.sync_job.started_at = None
+
+        orc = _make_orchestrator(
+            sync_context=ctx,
+            state_machine=AsyncMock(),
+            sync_state_machine=AsyncMock(),
+        )
+
+        with patch("airweave.domains.sync_pipeline.orchestrator.business_events"):
+            await orc._handle_sync_failure(RuntimeError("db down"))
+
+        ctx.logger.error.assert_called()
+
+
+# ===========================================================================
+# Orchestrator.run() — classified errors are wrapped, system errors are not
+# ===========================================================================
+
+
+class TestRunWrapsClassifiedErrors:
+    @pytest.mark.asyncio
+    async def test_classified_error_wrapped_as_application_error(self):
+        """When the sync raises a classified error, run() wraps it as an.
+
+        ApplicationError of type CLASSIFIED_USER_ERROR_TYPE so the workflow
+        completes normally instead of incrementing temporal_workflow_failed.
+        """
+        from temporalio.exceptions import ApplicationError
+
+        from airweave.core.shared_models import SourceConnectionErrorCategory
+        from airweave.domains.sources.exceptions import SourceAuthError
+        from airweave.domains.sources.token_providers.protocol import AuthProviderKind
+        from airweave.domains.temporal.exceptions import CLASSIFIED_USER_ERROR_TYPE
+
+        orc = _make_orchestrator()
+        exc = SourceAuthError(
+            "401",
+            source_short_name="github",
+            status_code=401,
+            token_provider_kind=AuthProviderKind.OAUTH,
+        )
+
+        async def _fake_handler(_e: Exception):
+            return SourceConnectionErrorCategory.OAUTH_CREDENTIALS_EXPIRED
+
+        with (
+            patch.object(
+                orc,
+                "_start_sync",
+                new_callable=AsyncMock,
+                side_effect=exc,
+            ),
+            patch.object(orc, "_handle_sync_failure", side_effect=_fake_handler),
+            patch.object(orc, "entity_pipeline", MagicMock()),
+        ):
+            with pytest.raises(ApplicationError) as exc_info:
+                await orc.run()
+
+        assert exc_info.value.type == CLASSIFIED_USER_ERROR_TYPE
+        assert exc_info.value.non_retryable is True
+        assert exc_info.value.__cause__ is exc
+
+    @pytest.mark.asyncio
+    async def test_unclassified_error_not_wrapped(self):
+        """A true system failure propagates unwrapped — the workflow records.
+
+        a real temporal_workflow_failed.
+        """
+        orc = _make_orchestrator()
+        original = RuntimeError("redis down")
+
+        async def _fake_handler(_e: Exception):
+            return None
+
+        with (
+            patch.object(
+                orc,
+                "_start_sync",
+                new_callable=AsyncMock,
+                side_effect=original,
+            ),
+            patch.object(orc, "_handle_sync_failure", side_effect=_fake_handler),
+            patch.object(orc, "entity_pipeline", MagicMock()),
+        ):
+            with pytest.raises(RuntimeError, match="redis down"):
+                await orc.run()

--- a/backend/airweave/domains/syncs/jobs/state_machine.py
+++ b/backend/airweave/domains/syncs/jobs/state_machine.py
@@ -135,7 +135,9 @@ class SyncJobStateMachine(SyncJobStateMachineProtocol):
         logger.info(f"Sync job {sync_job_id}: {current.value} → {target.value}")
 
         if lifecycle_data is not None:
-            await self._publish_lifecycle_event(target, lifecycle_data, error=error)
+            await self._publish_lifecycle_event(
+                target, lifecycle_data, error=error, error_category=error_category
+            )
 
         return TransitionResult(applied=True, previous=current, current=target)
 
@@ -199,6 +201,7 @@ class SyncJobStateMachine(SyncJobStateMachineProtocol):
         ld: LifecycleData,
         *,
         error: Optional[str] = None,
+        error_category: Optional[SourceConnectionErrorCategory] = None,
     ) -> None:
         """Publish the appropriate SyncLifecycleEvent for the target status."""
         factory = _LIFECYCLE_EVENT_FACTORY.get(target)
@@ -218,6 +221,9 @@ class SyncJobStateMachine(SyncJobStateMachineProtocol):
 
         if target == SyncJobStatus.FAILED and error is not None:
             kwargs["error"] = error
+
+        if target == SyncJobStatus.FAILED and error_category is not None:
+            kwargs["error_category"] = error_category
 
         try:
             await self.event_bus.publish(factory(**kwargs))

--- a/backend/airweave/domains/syncs/jobs/tests/test_state_machine_coverage.py
+++ b/backend/airweave/domains/syncs/jobs/tests/test_state_machine_coverage.py
@@ -6,6 +6,7 @@ from uuid import UUID
 import pytest
 
 from airweave.adapters.event_bus.fake import FakeEventBus
+from airweave.core.events.sync import SyncLifecycleEvent
 from airweave.core.shared_models import SourceConnectionErrorCategory, SyncJobStatus
 from airweave.domains.syncs.jobs.state_machine import SyncJobStateMachine
 from airweave.domains.syncs.jobs.types import LifecycleData
@@ -95,6 +96,7 @@ async def test_publish_lifecycle_event_failed_with_error_category():
 
     assert len(event_bus.events) == 1
     event = event_bus.events[0]
+    assert isinstance(event, SyncLifecycleEvent)
     assert event.error == "JWT expired"
     assert event.error_category == "oauth_credentials_expired"
 
@@ -112,6 +114,7 @@ async def test_publish_lifecycle_event_failed_without_category_omits_field():
 
     assert len(event_bus.events) == 1
     event = event_bus.events[0]
+    assert isinstance(event, SyncLifecycleEvent)
     assert event.error_category is None
 
 
@@ -135,6 +138,7 @@ async def test_publish_lifecycle_event_completed_ignores_category():
 
     assert len(event_bus.events) == 1
     event = event_bus.events[0]
+    assert isinstance(event, SyncLifecycleEvent)
     # error_category exists on the event class but is None for non-failed payloads
     assert event.error_category is None
 
@@ -173,7 +177,9 @@ async def test_transition_failed_publishes_lifecycle_event_with_error_category()
         )
 
     assert len(event_bus.events) == 1
-    assert event_bus.events[0].error_category == "usage_limit_exceeded"
+    event = event_bus.events[0]
+    assert isinstance(event, SyncLifecycleEvent)
+    assert event.error_category == "usage_limit_exceeded"
 
 
 @pytest.mark.asyncio

--- a/backend/airweave/domains/syncs/jobs/tests/test_state_machine_coverage.py
+++ b/backend/airweave/domains/syncs/jobs/tests/test_state_machine_coverage.py
@@ -38,9 +38,7 @@ async def test_publish_lifecycle_event_unknown_target():
         event_bus=FakeEventBus(),
     )
 
-    await sm._publish_lifecycle_event(
-        SyncJobStatus.CREATED, _make_lifecycle()
-    )
+    await sm._publish_lifecycle_event(SyncJobStatus.CREATED, _make_lifecycle())
 
 
 @pytest.mark.unit
@@ -56,9 +54,7 @@ async def test_publish_lifecycle_event_publish_failure():
         event_bus=FailingEventBus(),
     )
 
-    await sm._publish_lifecycle_event(
-        SyncJobStatus.COMPLETED, _make_lifecycle()
-    )
+    await sm._publish_lifecycle_event(SyncJobStatus.COMPLETED, _make_lifecycle())
 
 
 @pytest.mark.unit
@@ -75,6 +71,109 @@ async def test_publish_lifecycle_event_failed_with_error():
     )
 
     assert len(event_bus.events) == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_lifecycle_event_failed_with_error_category():
+    """FAILED events include error_category in the payload — webhook.
+
+    subscribers use this to distinguish classified user errors from
+    real outages without parsing the free-text error field.
+    """
+    event_bus = FakeEventBus()
+    sm = SyncJobStateMachine(
+        sync_job_repo=MagicMock(),
+        event_bus=event_bus,
+    )
+
+    await sm._publish_lifecycle_event(
+        SyncJobStatus.FAILED,
+        _make_lifecycle(),
+        error="JWT expired",
+        error_category=SourceConnectionErrorCategory.OAUTH_CREDENTIALS_EXPIRED,
+    )
+
+    assert len(event_bus.events) == 1
+    event = event_bus.events[0]
+    assert event.error == "JWT expired"
+    assert event.error_category == "oauth_credentials_expired"
+
+
+@pytest.mark.asyncio
+async def test_publish_lifecycle_event_failed_without_category_omits_field():
+    """FAILED events without an error_category still publish with error_category=None."""
+    event_bus = FakeEventBus()
+    sm = SyncJobStateMachine(
+        sync_job_repo=MagicMock(),
+        event_bus=event_bus,
+    )
+
+    await sm._publish_lifecycle_event(SyncJobStatus.FAILED, _make_lifecycle(), error="db down")
+
+    assert len(event_bus.events) == 1
+    event = event_bus.events[0]
+    assert event.error_category is None
+
+
+@pytest.mark.asyncio
+async def test_publish_lifecycle_event_completed_ignores_category():
+    """error_category is only meaningful for FAILED events. Passing it for.
+
+    COMPLETED is a no-op (the field is not on the success payload).
+    """
+    event_bus = FakeEventBus()
+    sm = SyncJobStateMachine(
+        sync_job_repo=MagicMock(),
+        event_bus=event_bus,
+    )
+
+    await sm._publish_lifecycle_event(
+        SyncJobStatus.COMPLETED,
+        _make_lifecycle(),
+        error_category=SourceConnectionErrorCategory.OAUTH_CREDENTIALS_EXPIRED,
+    )
+
+    assert len(event_bus.events) == 1
+    event = event_bus.events[0]
+    # error_category exists on the event class but is None for non-failed payloads
+    assert event.error_category is None
+
+
+@pytest.mark.asyncio
+async def test_transition_failed_publishes_lifecycle_event_with_error_category():
+    """End-to-end: transition(FAILED, error_category=...) results in a.
+
+    lifecycle event carrying the category to webhook subscribers.
+    """
+    repo = MagicMock()
+    db_job = MagicMock()
+    db_job.id = SYNC_JOB_ID
+    db_job.status = SyncJobStatus.RUNNING.value
+    repo.get = AsyncMock(return_value=db_job)
+    repo.update = AsyncMock()
+
+    event_bus = FakeEventBus()
+    sm = SyncJobStateMachine(sync_job_repo=repo, event_bus=event_bus)
+    ctx = MagicMock()
+    ctx.organization = MagicMock()
+    ctx.organization.id = ORG_ID
+
+    with patch("airweave.domains.syncs.jobs.state_machine.get_db_context") as mock_ctx:
+        mock_db = AsyncMock()
+        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await sm.transition(
+            sync_job_id=SYNC_JOB_ID,
+            target=SyncJobStatus.FAILED,
+            ctx=ctx,
+            lifecycle_data=_make_lifecycle(),
+            error="50103/50000",
+            error_category=SourceConnectionErrorCategory.USAGE_LIMIT_EXCEEDED,
+        )
+
+    assert len(event_bus.events) == 1
+    assert event_bus.events[0].error_category == "usage_limit_exceeded"
 
 
 @pytest.mark.asyncio

--- a/backend/airweave/domains/syncs/service.py
+++ b/backend/airweave/domains/syncs/service.py
@@ -22,7 +22,11 @@ from airweave import schemas
 from airweave.api.context import ApiContext
 from airweave.core.constants.reserved_ids import NATIVE_VESPA_UUID
 from airweave.core.context import BaseContext
-from airweave.core.shared_models import SyncJobStatus, SyncStatus
+from airweave.core.shared_models import (
+    SourceConnectionErrorCategory,
+    SyncJobStatus,
+    SyncStatus,
+)
 from airweave.db.session import get_db_context
 from airweave.db.unit_of_work import UnitOfWork
 from airweave.domains.sources.exceptions.classifier import classify_error
@@ -45,6 +49,7 @@ from airweave.domains.syncs.types import (
     SyncProvisionResult,
     SyncTransitionResult,
 )
+from airweave.domains.temporal.exceptions import classified_user_application_error
 from airweave.domains.temporal.protocols import (
     TemporalScheduleServiceProtocol,
     TemporalWorkflowServiceProtocol,
@@ -407,9 +412,18 @@ class SyncService(SyncServiceProtocol):
                     access_token=access_token,
                 )
         except Exception as e:
-            ctx.logger.error(f"Error during sync orchestrator creation: {e}")
-
             classification = classify_error(e)
+
+            # User-actionable errors (expired credentials, usage limits,
+            # rate limits) are logged at WARNING — they're not Airweave
+            # failures, they're customer integration state that the UI
+            # already surfaces via NEEDS_REAUTH.
+            if classification.category is not None:
+                ctx.logger.warning(
+                    f"Sync orchestrator creation failed ({classification.category.value}): {e}"
+                )
+            else:
+                ctx.logger.error(f"Error during sync orchestrator creation: {e}")
 
             await self._job_state_machine.transition(
                 sync_job_id=sync_job.id,
@@ -419,16 +433,25 @@ class SyncService(SyncServiceProtocol):
                 error_category=classification.category,
             )
 
-            if classification.category is not None and sync:
+            if (
+                classification.category is not None
+                and classification.category != SourceConnectionErrorCategory.RATE_LIMITED
+                and sync
+            ):
                 try:
                     await self._state_machine.transition(
                         sync_id=sync.id,
                         target=SyncStatus.PAUSED,
                         ctx=ctx,
-                        reason=f"Credential error: {classification.category.value}",
+                        reason=f"Classified error: {classification.category.value}",
                     )
                 except Exception:
-                    ctx.logger.warning("Failed to pause sync after credential error", exc_info=True)
+                    ctx.logger.warning("Failed to pause sync after classified error", exc_info=True)
+
+            # Classified errors are wrapped so the workflow can complete
+            # normally instead of incrementing temporal_workflow_failed.
+            if classification.category is not None:
+                raise classified_user_application_error(e, classification.category) from e
 
             raise e
 

--- a/backend/airweave/domains/syncs/tests/test_service.py
+++ b/backend/airweave/domains/syncs/tests/test_service.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+from temporalio.exceptions import ApplicationError
 
 from airweave.core.shared_models import SyncJobStatus
 from airweave.domains.syncs.service import SyncService
@@ -207,11 +208,19 @@ async def test_run_forwards_optional_kwargs():
 
 @pytest.mark.asyncio
 async def test_credential_error_propagates_error_category():
-    """Factory raising a credential error -> error_category set on state machine transition."""
+    """Factory raising a credential error -> error_category set on state machine transition.
+
+    Classified errors are wrapped in an ApplicationError of type
+    CLASSIFIED_USER_ERROR_TYPE so the Temporal workflow can complete
+    normally instead of counting toward temporal_workflow_failed.
+    """
+    from temporalio.exceptions import ApplicationError
+
     from airweave.core.shared_models import SourceConnectionErrorCategory
     from airweave.domains.sources.exceptions import SourceValidationError
     from airweave.domains.sources.token_providers.exceptions import TokenExpiredError
     from airweave.domains.sources.token_providers.protocol import AuthProviderKind
+    from airweave.domains.temporal.exceptions import CLASSIFIED_USER_ERROR_TYPE
 
     cause = TokenExpiredError(
         "JWT expired", source_short_name="github", provider_kind=AuthProviderKind.OAUTH
@@ -238,7 +247,7 @@ async def test_credential_error_propagates_error_category():
         mock_db_ctx.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
         mock_db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        with pytest.raises(SourceValidationError):
+        with pytest.raises(ApplicationError) as exc_info:
             await svc.run(
                 sync=_mock_sync(),
                 sync_job=_mock_sync_job(),
@@ -246,6 +255,10 @@ async def test_credential_error_propagates_error_category():
                 source_connection=MagicMock(),
                 ctx=_mock_ctx(),
             )
+
+    assert exc_info.value.type == CLASSIFIED_USER_ERROR_TYPE
+    assert exc_info.value.non_retryable is True
+    assert exc_info.value.__cause__ is wrapper
 
     fake_sm.transition.assert_awaited_once()
     call_kwargs = fake_sm.transition.call_args.kwargs
@@ -286,6 +299,315 @@ async def test_non_credential_error_has_no_error_category():
 
     call_kwargs = fake_sm.transition.call_args.kwargs
     assert call_kwargs["error_category"] is None
+
+
+# ---------------------------------------------------------------------------
+# Classified-error semantics: wrapped as ApplicationError, log at WARNING,
+# selectively pause the sync. Mirrors the alert-quieting behavior at the
+# activity → workflow boundary.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_classified_error_logs_at_warning_not_error():
+    """Classified user errors (e.g. expired tokens) log at WARNING — they're.
+
+    not Airweave outages and shouldn't show up as ERROR-level log noise.
+    """
+    from airweave.domains.sources.token_providers.exceptions import TokenExpiredError
+    from airweave.domains.sources.token_providers.protocol import AuthProviderKind
+
+    cause = TokenExpiredError(
+        "JWT expired", source_short_name="github", provider_kind=AuthProviderKind.OAUTH
+    )
+
+    fake_factory = MagicMock()
+    fake_factory.create_orchestrator = AsyncMock(side_effect=cause)
+
+    svc = SyncService(
+        sync_repo=MagicMock(),
+        sync_job_repo=MagicMock(),
+        sync_cursor_repo=MagicMock(),
+        state_machine=AsyncMock(),
+        job_state_machine=AsyncMock(),
+        temporal_workflow_service=MagicMock(),
+        temporal_schedule_service=MagicMock(),
+        sync_factory=fake_factory,
+    )
+
+    ctx = _mock_ctx()
+
+    with patch("airweave.domains.syncs.service.get_db_context") as mock_db_ctx:
+        mock_db_ctx.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(ApplicationError):
+            await svc.run(
+                sync=_mock_sync(),
+                sync_job=_mock_sync_job(),
+                collection=MagicMock(),
+                source_connection=MagicMock(),
+                ctx=ctx,
+            )
+
+    ctx.logger.warning.assert_called_once()
+    ctx.logger.error.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unclassified_error_still_logs_at_error():
+    """Unclassified errors (true system failures) stay at ERROR level."""
+    fake_factory = MagicMock()
+    fake_factory.create_orchestrator = AsyncMock(side_effect=RuntimeError("db down"))
+
+    svc = SyncService(
+        sync_repo=MagicMock(),
+        sync_job_repo=MagicMock(),
+        sync_cursor_repo=MagicMock(),
+        state_machine=AsyncMock(),
+        job_state_machine=AsyncMock(),
+        temporal_workflow_service=MagicMock(),
+        temporal_schedule_service=MagicMock(),
+        sync_factory=fake_factory,
+    )
+
+    ctx = _mock_ctx()
+
+    with patch("airweave.domains.syncs.service.get_db_context") as mock_db_ctx:
+        mock_db_ctx.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(RuntimeError):
+            await svc.run(
+                sync=_mock_sync(),
+                sync_job=_mock_sync_job(),
+                collection=MagicMock(),
+                source_connection=MagicMock(),
+                ctx=ctx,
+            )
+
+    ctx.logger.error.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_classified_error_pauses_sync_for_credentials():
+    """OAuth credential errors pause the sync so the schedule stops retrying."""
+    from airweave.core.shared_models import SyncStatus
+    from airweave.domains.sources.token_providers.exceptions import TokenExpiredError
+    from airweave.domains.sources.token_providers.protocol import AuthProviderKind
+
+    cause = TokenExpiredError(
+        "JWT expired", source_short_name="github", provider_kind=AuthProviderKind.OAUTH
+    )
+
+    fake_factory = MagicMock()
+    fake_factory.create_orchestrator = AsyncMock(side_effect=cause)
+    fake_state_machine = AsyncMock()
+
+    svc = SyncService(
+        sync_repo=MagicMock(),
+        sync_job_repo=MagicMock(),
+        sync_cursor_repo=MagicMock(),
+        state_machine=fake_state_machine,
+        job_state_machine=AsyncMock(),
+        temporal_workflow_service=MagicMock(),
+        temporal_schedule_service=MagicMock(),
+        sync_factory=fake_factory,
+    )
+
+    with patch("airweave.domains.syncs.service.get_db_context") as mock_db_ctx:
+        mock_db_ctx.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(ApplicationError):
+            await svc.run(
+                sync=_mock_sync(),
+                sync_job=_mock_sync_job(),
+                collection=MagicMock(),
+                source_connection=MagicMock(),
+                ctx=_mock_ctx(),
+            )
+
+    fake_state_machine.transition.assert_awaited_once()
+    call_kwargs = fake_state_machine.transition.call_args.kwargs
+    assert call_kwargs["target"] == SyncStatus.PAUSED
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_error_does_not_pause_sync():
+    """Rate-limit hits are transient; the next scheduled run will likely.
+
+    succeed once the window resets. The sync stays ACTIVE.
+    """
+    from airweave.domains.sources.exceptions import SourceRateLimitError
+
+    cause = SourceRateLimitError(retry_after=60.0, source_short_name="hubspot")
+
+    fake_factory = MagicMock()
+    fake_factory.create_orchestrator = AsyncMock(side_effect=cause)
+    fake_state_machine = AsyncMock()
+
+    svc = SyncService(
+        sync_repo=MagicMock(),
+        sync_job_repo=MagicMock(),
+        sync_cursor_repo=MagicMock(),
+        state_machine=fake_state_machine,
+        job_state_machine=AsyncMock(),
+        temporal_workflow_service=MagicMock(),
+        temporal_schedule_service=MagicMock(),
+        sync_factory=fake_factory,
+    )
+
+    with patch("airweave.domains.syncs.service.get_db_context") as mock_db_ctx:
+        mock_db_ctx.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(ApplicationError):
+            await svc.run(
+                sync=_mock_sync(),
+                sync_job=_mock_sync_job(),
+                collection=MagicMock(),
+                source_connection=MagicMock(),
+                ctx=_mock_ctx(),
+            )
+
+    # sync_state_machine.transition should NOT have been called for RATE_LIMITED
+    fake_state_machine.transition.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_classified_error_wrapped_as_application_error():
+    """The original exception is wrapped as ApplicationError with.
+
+    type=CLASSIFIED_USER_ERROR_TYPE so the workflow can detect it and
+    complete normally instead of incrementing temporal_workflow_failed.
+    """
+    from temporalio.exceptions import ApplicationError, ApplicationErrorCategory
+
+    from airweave.core.shared_models import SourceConnectionErrorCategory
+    from airweave.domains.sources.exceptions import SourceRateLimitError
+    from airweave.domains.temporal.exceptions import CLASSIFIED_USER_ERROR_TYPE
+
+    cause = SourceRateLimitError(retry_after=60.0, source_short_name="hubspot")
+
+    fake_factory = MagicMock()
+    fake_factory.create_orchestrator = AsyncMock(side_effect=cause)
+
+    svc = SyncService(
+        sync_repo=MagicMock(),
+        sync_job_repo=MagicMock(),
+        sync_cursor_repo=MagicMock(),
+        state_machine=AsyncMock(),
+        job_state_machine=AsyncMock(),
+        temporal_workflow_service=MagicMock(),
+        temporal_schedule_service=MagicMock(),
+        sync_factory=fake_factory,
+    )
+
+    with patch("airweave.domains.syncs.service.get_db_context") as mock_db_ctx:
+        mock_db_ctx.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(ApplicationError) as exc_info:
+            await svc.run(
+                sync=_mock_sync(),
+                sync_job=_mock_sync_job(),
+                collection=MagicMock(),
+                source_connection=MagicMock(),
+                ctx=_mock_ctx(),
+            )
+
+    assert exc_info.value.type == CLASSIFIED_USER_ERROR_TYPE
+    assert exc_info.value.non_retryable is True
+    assert exc_info.value.category == ApplicationErrorCategory.BENIGN
+    assert exc_info.value.__cause__ is cause
+    # Category is encoded in the details for diagnostics
+    assert SourceConnectionErrorCategory.RATE_LIMITED.value in exc_info.value.details
+
+
+@pytest.mark.asyncio
+async def test_unclassified_error_not_wrapped():
+    """A true system failure (e.g. db connection lost) is NOT wrapped — the.
+
+    original exception bubbles up so the workflow records a real failure.
+    """
+    fake_factory = MagicMock()
+    original = RuntimeError("redis down")
+    fake_factory.create_orchestrator = AsyncMock(side_effect=original)
+
+    svc = SyncService(
+        sync_repo=MagicMock(),
+        sync_job_repo=MagicMock(),
+        sync_cursor_repo=MagicMock(),
+        state_machine=AsyncMock(),
+        job_state_machine=AsyncMock(),
+        temporal_workflow_service=MagicMock(),
+        temporal_schedule_service=MagicMock(),
+        sync_factory=fake_factory,
+    )
+
+    with patch("airweave.domains.syncs.service.get_db_context") as mock_db_ctx:
+        mock_db_ctx.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(RuntimeError, match="redis down"):
+            await svc.run(
+                sync=_mock_sync(),
+                sync_job=_mock_sync_job(),
+                collection=MagicMock(),
+                source_connection=MagicMock(),
+                ctx=_mock_ctx(),
+            )
+
+
+@pytest.mark.asyncio
+async def test_classified_error_pause_failure_does_not_mask_classification():
+    """If the pause-state-machine call itself raises, we still re-raise the.
+
+    classified ApplicationError — the pause failure is logged but swallowed.
+    """
+    from temporalio.exceptions import ApplicationError
+
+    from airweave.domains.sources.token_providers.exceptions import TokenExpiredError
+    from airweave.domains.sources.token_providers.protocol import AuthProviderKind
+    from airweave.domains.temporal.exceptions import CLASSIFIED_USER_ERROR_TYPE
+
+    cause = TokenExpiredError(
+        "JWT expired", source_short_name="github", provider_kind=AuthProviderKind.OAUTH
+    )
+
+    fake_factory = MagicMock()
+    fake_factory.create_orchestrator = AsyncMock(side_effect=cause)
+    fake_state_machine = AsyncMock()
+    fake_state_machine.transition = AsyncMock(side_effect=RuntimeError("pause failed"))
+
+    svc = SyncService(
+        sync_repo=MagicMock(),
+        sync_job_repo=MagicMock(),
+        sync_cursor_repo=MagicMock(),
+        state_machine=fake_state_machine,
+        job_state_machine=AsyncMock(),
+        temporal_workflow_service=MagicMock(),
+        temporal_schedule_service=MagicMock(),
+        sync_factory=fake_factory,
+    )
+
+    ctx = _mock_ctx()
+
+    with patch("airweave.domains.syncs.service.get_db_context") as mock_db_ctx:
+        mock_db_ctx.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(ApplicationError) as exc_info:
+            await svc.run(
+                sync=_mock_sync(),
+                sync_job=_mock_sync_job(),
+                collection=MagicMock(),
+                source_connection=MagicMock(),
+                ctx=ctx,
+            )
+
+    assert exc_info.value.type == CLASSIFIED_USER_ERROR_TYPE
 
 
 def test_stores_injected_deps():

--- a/backend/airweave/domains/temporal/exceptions.py
+++ b/backend/airweave/domains/temporal/exceptions.py
@@ -1,10 +1,50 @@
 """Domain exceptions for the Temporal module."""
 
+from temporalio.exceptions import ApplicationError, ApplicationErrorCategory
+
 from airweave.core.exceptions import AirweaveException, InvalidInputError
+from airweave.core.shared_models import SourceConnectionErrorCategory
 
 ORPHANED_SYNC_ERROR_TYPE = "OrphanedSyncError"
 """ApplicationError.type value used for orphaned sync detection across the
 activity → workflow serialization boundary."""
+
+CLASSIFIED_USER_ERROR_TYPE = "ClassifiedUserError"
+"""ApplicationError.type value used for user-actionable sync failures
+(expired credentials, usage limits, rate limits) across the activity →
+workflow serialization boundary. The activity has already transitioned
+the sync job to FAILED with the appropriate error_category, so the
+workflow should complete normally rather than re-raise — this prevents
+the Temporal workflow failure metric from spiking on customer errors."""
+
+
+def classified_user_application_error(
+    error: Exception,
+    category: SourceConnectionErrorCategory,
+) -> ApplicationError:
+    """Wrap a user-actionable sync error for the activity → workflow boundary.
+
+    Returns an ``ApplicationError`` carrying:
+      - ``type=CLASSIFIED_USER_ERROR_TYPE`` so the workflow can detect it
+        via the type field without importing this module
+      - ``category=BENIGN`` so Temporal does not log it as a system failure
+      - ``non_retryable=True`` because user-actionable errors won't resolve
+        by retrying the same workflow attempt
+      - ``details=[category_value, message]`` for diagnostics
+
+    The activity has already performed the FAILED state transition,
+    pause (if applicable), webhook emission, and analytics tracking
+    before raising this. The workflow handles it by completing normally
+    without an additional transition.
+    """
+    return ApplicationError(
+        str(error),
+        category.value,
+        str(error),
+        type=CLASSIFIED_USER_ERROR_TYPE,
+        non_retryable=True,
+        category=ApplicationErrorCategory.BENIGN,
+    )
 
 
 class OrphanedSyncError(AirweaveException):

--- a/backend/airweave/domains/temporal/tests/test_exceptions.py
+++ b/backend/airweave/domains/temporal/tests/test_exceptions.py
@@ -1,10 +1,13 @@
 """Tests for Temporal domain exceptions."""
 
 import pytest
+from temporalio.exceptions import ApplicationError, ApplicationErrorCategory
 
+from airweave.core.shared_models import SourceConnectionErrorCategory
 from airweave.domains.temporal.exceptions import (
-    InvalidCronExpressionError,
+    CLASSIFIED_USER_ERROR_TYPE,
     OrphanedSyncError,
+    classified_user_application_error,
 )
 
 
@@ -22,3 +25,70 @@ def test_orphaned_sync_error_custom_reason():
     assert err.sync_id == "sync-456"
     assert err.reason == "Deleted during execution"
     assert "Deleted during execution" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# classified_user_application_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_classified_wrapper_sets_type_and_non_retryable():
+    """The wrapper marks the error as CLASSIFIED_USER_ERROR_TYPE and.
+
+    non_retryable so the workflow takes the no-op branch instead of
+    retrying or counting the error toward temporal_workflow_failed.
+    """
+    original = RuntimeError("JWT expired")
+    wrapped = classified_user_application_error(
+        original, SourceConnectionErrorCategory.OAUTH_CREDENTIALS_EXPIRED
+    )
+    assert isinstance(wrapped, ApplicationError)
+    assert wrapped.type == CLASSIFIED_USER_ERROR_TYPE
+    assert wrapped.non_retryable is True
+    assert wrapped.category == ApplicationErrorCategory.BENIGN
+
+
+@pytest.mark.unit
+def test_classified_wrapper_encodes_category_in_details():
+    """The category value goes into details so consumers can inspect it.
+
+    without parsing the message.
+    """
+    original = RuntimeError("over quota")
+    wrapped = classified_user_application_error(
+        original, SourceConnectionErrorCategory.USAGE_LIMIT_EXCEEDED
+    )
+    assert SourceConnectionErrorCategory.USAGE_LIMIT_EXCEEDED.value in wrapped.details
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "category",
+    [
+        SourceConnectionErrorCategory.OAUTH_CREDENTIALS_EXPIRED,
+        SourceConnectionErrorCategory.API_KEY_INVALID,
+        SourceConnectionErrorCategory.AUTH_PROVIDER_ACCOUNT_GONE,
+        SourceConnectionErrorCategory.AUTH_PROVIDER_CREDENTIALS_INVALID,
+        SourceConnectionErrorCategory.USAGE_LIMIT_EXCEEDED,
+        SourceConnectionErrorCategory.RATE_LIMITED,
+    ],
+)
+def test_classified_wrapper_supports_every_category(category):
+    """Every defined category produces a valid wrapped error — guards.
+
+    against silently dropping a category if a new one is added.
+    """
+    wrapped = classified_user_application_error(RuntimeError("x"), category)
+    assert wrapped.type == CLASSIFIED_USER_ERROR_TYPE
+    assert category.value in wrapped.details
+
+
+@pytest.mark.unit
+def test_classified_wrapper_preserves_message():
+    """The wrapped error stringifies to the original error's message."""
+    original = ValueError("specific cause text")
+    wrapped = classified_user_application_error(
+        original, SourceConnectionErrorCategory.API_KEY_INVALID
+    )
+    assert "specific cause text" in str(wrapped)

--- a/backend/airweave/domains/temporal/workflows/run_source_connection.py
+++ b/backend/airweave/domains/temporal/workflows/run_source_connection.py
@@ -27,7 +27,10 @@ with workflow.unsafe.imports_passed_through():
         transition_sync_job_activity,
     )
     from airweave.domains.temporal.activity_results import CreateSyncJobResult
-    from airweave.domains.temporal.exceptions import ORPHANED_SYNC_ERROR_TYPE
+    from airweave.domains.temporal.exceptions import (
+        CLASSIFIED_USER_ERROR_TYPE,
+        ORPHANED_SYNC_ERROR_TYPE,
+    )
 
 # ---------------------------------------------------------------------------
 # Execution policies
@@ -102,6 +105,18 @@ class RunSourceConnectionWorkflow:
             if self._is_orphaned_sync_error(e):
                 reason = self._extract_orphaned_reason(e)
                 await self._self_destruct(sync_dict, ctx_dict, reason)
+                return
+            # Classified user errors (expired credentials, usage limits,
+            # rate limits) are not Airweave failures — the activity has
+            # already transitioned the sync_job to FAILED with the
+            # appropriate error_category. Returning here lets the
+            # workflow complete normally so temporal_workflow_failed
+            # only counts real system failures.
+            if self._is_classified_user_error(e):
+                workflow.logger.info(
+                    f"Sync job {sync_job_dict.get('id')} ended with "
+                    f"classified user error; workflow completing normally."
+                )
                 return
             await self._transition("failed", sync_job_dict, ctx_dict, lifecycle, error=str(e))
             raise
@@ -306,6 +321,19 @@ class RunSourceConnectionWorkflow:
         """
         if isinstance(error, ActivityError) and isinstance(error.cause, ApplicationError):
             return error.cause.type == ORPHANED_SYNC_ERROR_TYPE
+        return False
+
+    @staticmethod
+    def _is_classified_user_error(error: BaseException) -> bool:
+        """Check whether a Temporal ActivityError wraps a classified user error.
+
+        The activity converts classified user errors (expired credentials,
+        usage limits, rate limits) to an ApplicationError with
+        type=CLASSIFIED_USER_ERROR_TYPE so the workflow can complete
+        normally instead of counting toward temporal_workflow_failed.
+        """
+        if isinstance(error, ActivityError) and isinstance(error.cause, ApplicationError):
+            return error.cause.type == CLASSIFIED_USER_ERROR_TYPE
         return False
 
     @staticmethod

--- a/backend/airweave/domains/temporal/workflows/tests/test_run_source_connection.py
+++ b/backend/airweave/domains/temporal/workflows/tests/test_run_source_connection.py
@@ -251,3 +251,166 @@ async def test_non_orphan_sync_error_propagates():
     assert "Something broke" in root_message
     assert not recorder.called("self_destruct")
     assert recorder.called("transition_failed")
+
+
+# ------------------------------------------------------------------
+# Phase 2: classified user errors complete normally
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_classified_user_error_completes_workflow_normally():
+    """When run_sync raises a CLASSIFIED_USER_ERROR_TYPE ApplicationError,.
+
+    the workflow returns successfully — no FAILED transition (the activity
+    already did that) and no exception escapes. This keeps the Temporal
+    workflow failure metric from spiking on customer credential errors.
+    """
+    from temporalio.exceptions import ApplicationError, ApplicationErrorCategory
+
+    from airweave.domains.temporal.exceptions import CLASSIFIED_USER_ERROR_TYPE
+
+    recorder = ActivityRecorder()
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        # Workflow should NOT raise — classified errors are absorbed.
+        await _run_workflow(
+            env,
+            activities=[
+                mock_run_sync(
+                    recorder,
+                    raise_error=ApplicationError(
+                        "JWT expired",
+                        "oauth_credentials_expired",
+                        "JWT expired",
+                        type=CLASSIFIED_USER_ERROR_TYPE,
+                        non_retryable=True,
+                        category=ApplicationErrorCategory.BENIGN,
+                    ),
+                ),
+                mock_self_destruct(recorder),
+                mock_transition_sync_job(recorder),
+            ],
+            sync_job_dict=make_sync_job_dict(),
+        )
+
+    # The activity already transitioned the job to FAILED before raising;
+    # the workflow must NOT issue a redundant transition.
+    assert not recorder.called("transition_failed")
+    assert not recorder.called("transition_completed")
+    assert not recorder.called("self_destruct")
+
+
+@pytest.mark.unit
+async def test_classified_user_error_does_not_trigger_orphan_path():
+    """Classified errors and orphan errors share the ApplicationError shape.
+
+    but are routed differently. The classified branch must NOT trigger
+    self-destruct cleanup.
+    """
+    from temporalio.exceptions import ApplicationError, ApplicationErrorCategory
+
+    from airweave.domains.temporal.exceptions import CLASSIFIED_USER_ERROR_TYPE
+
+    recorder = ActivityRecorder()
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        await _run_workflow(
+            env,
+            activities=[
+                mock_run_sync(
+                    recorder,
+                    raise_error=ApplicationError(
+                        "rate limited",
+                        "rate_limited",
+                        "rate limited",
+                        type=CLASSIFIED_USER_ERROR_TYPE,
+                        non_retryable=True,
+                        category=ApplicationErrorCategory.BENIGN,
+                    ),
+                ),
+                mock_self_destruct(recorder),
+                mock_transition_sync_job(recorder),
+            ],
+            sync_job_dict=make_sync_job_dict(),
+        )
+
+    assert not recorder.called("self_destruct")
+
+
+def test_is_classified_user_error_detects_type():
+    """The classifier guard recognises ApplicationError instances by their.
+
+    type field — the workflow's discriminator across the activity boundary.
+    """
+    from temporalio.exceptions import ActivityError, ApplicationError
+
+    from airweave.domains.temporal.exceptions import CLASSIFIED_USER_ERROR_TYPE
+    from airweave.domains.temporal.workflows.run_source_connection import (
+        RunSourceConnectionWorkflow,
+    )
+
+    app_err = ApplicationError(
+        "credentials expired", type=CLASSIFIED_USER_ERROR_TYPE, non_retryable=True
+    )
+    # Build an ActivityError with that cause — the shape the workflow sees.
+    act_err = ActivityError(
+        message="activity failed",
+        scheduled_event_id=1,
+        started_event_id=2,
+        identity="test",
+        activity_type="run_sync_activity",
+        activity_id="1",
+        retry_state=None,
+    )
+    act_err.__cause__ = app_err
+
+    assert RunSourceConnectionWorkflow._is_classified_user_error(act_err) is True
+
+
+def test_is_classified_user_error_rejects_other_types():
+    """Non-classified ApplicationErrors (e.g. orphan, or none-type) are.
+
+    not treated as classified.
+    """
+    from temporalio.exceptions import ActivityError, ApplicationError
+
+    from airweave.domains.temporal.exceptions import ORPHANED_SYNC_ERROR_TYPE
+    from airweave.domains.temporal.workflows.run_source_connection import (
+        RunSourceConnectionWorkflow,
+    )
+
+    # Orphaned sync error
+    orphan_err = ApplicationError("orphaned", type=ORPHANED_SYNC_ERROR_TYPE, non_retryable=True)
+    act_err_orphan = ActivityError(
+        message="activity failed",
+        scheduled_event_id=1,
+        started_event_id=2,
+        identity="test",
+        activity_type="run_sync_activity",
+        activity_id="1",
+        retry_state=None,
+    )
+    act_err_orphan.__cause__ = orphan_err
+    assert RunSourceConnectionWorkflow._is_classified_user_error(act_err_orphan) is False
+
+    # Plain ApplicationError without type
+    plain_err = ApplicationError("something")
+    act_err_plain = ActivityError(
+        message="activity failed",
+        scheduled_event_id=1,
+        started_event_id=2,
+        identity="test",
+        activity_type="run_sync_activity",
+        activity_id="1",
+        retry_state=None,
+    )
+    act_err_plain.__cause__ = plain_err
+    assert RunSourceConnectionWorkflow._is_classified_user_error(act_err_plain) is False
+
+
+def test_is_classified_user_error_rejects_non_activity_error():
+    """A bare exception that didn't come through an activity is not classified."""
+    from airweave.domains.temporal.workflows.run_source_connection import (
+        RunSourceConnectionWorkflow,
+    )
+
+    assert RunSourceConnectionWorkflow._is_classified_user_error(RuntimeError("boom")) is False


### PR DESCRIPTION
## Summary

Sync jobs that fail due to **user-actionable** issues (expired OAuth tokens, revoked API keys, plan limit reached, upstream rate limits) were re-raised from the orchestrator and bubbled up to the Temporal activity as unhandled exceptions. This caused:

- **`TemporalWorkflowHighFailureRate` alert firing** — `airweave:temporal_workflow_failure_rate:ratio5m` was ~35% in prod even though Airweave was healthy. Every revoked GitHub token, every customer hitting their entity cap, every rate-limited connector counted as a workflow failure.
- **ERROR-level log spam** — 200+ ERROR-level log lines per 3h on a single sync-worker, all from classified user errors. Made the real signal harder to find.
- **Lossy webhook payloads** — `SyncLifecycleEvent.failed` only carried free-text `error: str`; consumers couldn't programmatically distinguish "user needs to re-auth" from "Vespa is down" without parsing English.

### The fix

- **Classifier** ([classifier.py](backend/airweave/domains/sources/exceptions/classifier.py)): recognize `UsageLimitExceededError`, `SourceRateLimitError`, and GitHub's 403-disguised rate-limits (GitHub returns 403 with "API rate limit exceeded" in the body, unlike most APIs that use 429).
- **New error categories** ([shared_models.py](backend/airweave/core/shared_models.py)): `USAGE_LIMIT_EXCEEDED` and `RATE_LIMITED`.
- **Activity → workflow boundary** ([exceptions.py](backend/airweave/domains/temporal/exceptions.py)): new `CLASSIFIED_USER_ERROR_TYPE` and `classified_user_application_error()` helper. Mirrors the existing `ORPHANED_SYNC_ERROR_TYPE` pattern.
- **Orchestrator + SyncService**: classified failures re-raise as `ApplicationError(type=CLASSIFIED_USER_ERROR_TYPE, non_retryable=True, category=BENIGN)` instead of the raw exception. Log demoted from ERROR to WARNING.
- **Workflow** ([run_source_connection.py](backend/airweave/domains/temporal/workflows/run_source_connection.py)): new `_is_classified_user_error()` branch — when set, workflow `return`s normally instead of `raise`ing. The activity has already transitioned `sync_job` to FAILED and fired the FAILED webhook, so no redundant transition.
- **RATE_LIMITED skips the PAUSED transition** — those resolve on their own when the upstream window resets; pausing the schedule would prevent recovery. OAuth/usage errors still pause as before.
- **Webhook payload** ([sync.py](backend/airweave/core/events/sync.py)): `SyncLifecycleEvent.failed` now carries `error_category` so external consumers route on classified state programmatically.

### Result

- `temporal_workflow_failed` ticks only on real system failures (Vespa down, DB outage, code bugs), so `TemporalWorkflowHighFailureRate` becomes meaningful again.
- ERROR-level log volume drops dramatically; customer state changes log at WARNING with the category in the message.
- Webhook subscribers can switch on `error_category` instead of regexing free-text.
- Sync job → `FAILED` + `error_category` persisted to DB → UI shows `NEEDS_REAUTH` as before; nothing regressed.

## Test plan

- [x] **3104 unit tests pass** locally; 38 new tests added:
  - Classifier (6) — `UsageLimitExceededError`, `SourceRateLimitError`, GitHub 403 substring matching, 403-without-rate-limit-NOT-classified
  - Temporal exceptions (4) — wrapper helper for every category
  - Workflow (5) — classified branch returns cleanly, no orphan path collision, type-discriminator guard
  - Service (7) — log levels, RATE_LIMITED no-pause, wrapping shape, pause-failure resilience
  - Orchestrator (8) — `_handle_sync_failure` return contract, `run()` wrapping
  - State machine (5) — `error_category` threaded end-to-end into published event
  - Lifecycle event (8) — Pydantic serialization for every category
- [ ] Deploy to staging and confirm `TemporalWorkflowHighFailureRate` alert no longer fires on expected customer-credential events
- [ ] Verify sync job UI still flips to `NEEDS_REAUTH` on expired-credentials path
- [ ] Verify webhook subscribers receive `error_category` in `failed` event payload

## Out of scope (separate work)

- Sync-worker memory leak (sync-worker pods at 30 GiB each — separate `WorkerMemoryGrowthSustained` alert)
- End-user email notifications on credential failures
- Joblib `/tmp` memmap leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop counting user‑actionable sync errors (expired tokens, invalid API keys, plan limits, rate limits) as workflow failures. Workflow failure metrics now reflect real system issues, logs are quieter, and `failed` webhooks include `error_category`.

- **Bug Fixes**
  - Classify `UsageLimitExceededError`, `SourceRateLimitError`, and GitHub 403 messages with “rate limit”/“abuse detection”.
  - Added `USAGE_LIMIT_EXCEEDED` and `RATE_LIMITED` to `SourceConnectionErrorCategory`.
  - Wrap classified errors as `ApplicationError` with type `CLASSIFIED_USER_ERROR_TYPE` (non-retryable, BENIGN) via `classified_user_application_error(...)`; workflow completes normally.
  - Orchestrator/`SyncService`: log classified errors at WARNING, set job to `FAILED`, pause sync except `RATE_LIMITED` (no pause).
  - `SyncLifecycleEvent.failed` now includes `error_category` so subscribers can route without parsing `error`.
  - Tests: narrow event type to `SyncLifecycleEvent` in assertions to satisfy mypy on changed lines.

<sup>Written for commit 8ea8fd1fd5e79f4cc97d996c09c5ea20a6b6ca5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

