### PR TITLE
feat(gooclaim): auto-provision org from X-Organization-ID — S5 bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,14 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 MISTRAL_API_KEY=
 
+# Gooclaim patch — Azure OpenAI routing (optional).
+# When set, OpenAI client (embedder + LLM provider) uses this base URL.
+# Example for Azure OpenAI:
+#   OPENAI_BASE_URL=https://<resource>.openai.azure.com/openai/v1/
+#   OPENAI_API_KEY=<azure-openai-key>
+# Leave blank for OpenAI direct.
+OPENAI_BASE_URL=
+
 # Development Settings
 LOCAL_DEVELOPMENT=false
 LOCAL_CURSOR_DEVELOPMENT=false

--- a/backend/airweave/api/context_resolver.py
+++ b/backend/airweave/api/context_resolver.py
@@ -9,13 +9,14 @@ Testable by passing fakes for every dependency.
 
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Optional
 
 from fastapi import HTTPException, Request
 from fastapi_auth0 import Auth0User
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from airweave import schemas
+from airweave import crud, schemas
 from airweave.analytics.service import analytics
 from airweave.api.context import ApiContext, RequestHeaders
 from airweave.core.config import settings
@@ -29,6 +30,8 @@ from airweave.domains.organizations.protocols import (
     OrganizationRepositoryProtocol,
 )
 from airweave.domains.users.protocols import UserRepositoryProtocol
+from airweave.models.organization import Organization as OrganizationModel
+from airweave.models.user_organization import UserOrganization
 from airweave.schemas.rate_limit import RateLimitResult
 
 # ---------------------------------------------------------------------------
@@ -213,8 +216,6 @@ class ContextResolver:
     async def _fetch_auth0_user(
         self, db: AsyncSession, auth0_user: Auth0User
     ) -> Optional[schemas.User]:
-        from datetime import datetime
-
         if not auth0_user.email:
             return None
         try:
@@ -260,11 +261,65 @@ class ContextResolver:
                 db, id=uuid.UUID(organization_id), skip_access_validation=True, enrich=True
             )
             if not org:
-                raise HTTPException(
-                    status_code=404, detail=f"Organization {organization_id} not found"
-                )
+                # Gooclaim fork — auto-provision org for trusted external
+                # callers when EXTERNAL_ORG_ID_PROVISIONING is on. The nginx
+                # auth-request sidecar is the trusted boundary that has
+                # already verified the gooclaim JWT before forwarding the
+                # X-Organization-ID header (= gooclaim tenant_id).
+                if not settings.AUTH_ENABLED and settings.EXTERNAL_ORG_ID_PROVISIONING:
+                    org = await self._auto_provision_organization(db, organization_id)
+                else:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Organization {organization_id} not found",
+                    )
             await self._cache.set_organization(org)
         return org
+
+    async def _auto_provision_organization(
+        self, db: AsyncSession, organization_id: str
+    ) -> schemas.Organization:
+        """Auto-create an organization with a caller-supplied UUID.
+
+        Gooclaim fork only — gated behind EXTERNAL_ORG_ID_PROVISIONING. In
+        v1.0 the gooclaim tenant_id is reused as the Airweave org id 1:1,
+        eliminating the need for a separate mapping table. The nginx
+        sidecar already verified the upstream JWT, so the header is trusted.
+        The system superuser is added as the owner of the new org.
+        """
+        system_user_model = await self._users.get_by_email(db, email=settings.FIRST_SUPERUSER)
+        if not system_user_model:
+            raise HTTPException(
+                status_code=500,
+                detail="System superuser missing — cannot auto-provision org",
+            )
+
+        org_uuid = uuid.UUID(organization_id)
+        organization = OrganizationModel(
+            id=org_uuid,
+            name=f"tenant-{organization_id[:8]}",
+            description="Auto-provisioned via gooclaim bridge",
+            org_metadata={"gooclaim_tenant_id": organization_id},
+        )
+        db.add(organization)
+        await db.flush()
+
+        is_primary = system_user_model.primary_organization_id is None
+        user_org = UserOrganization(
+            user_id=system_user_model.id,
+            organization_id=org_uuid,
+            role="owner",
+            is_primary=is_primary,
+        )
+        db.add(user_org)
+        await db.commit()
+        await db.refresh(organization)
+
+        enriched = await crud.organization.get(
+            db, id=org_uuid, skip_access_validation=True, enrich=True
+        )
+        logger.info(f"airweave.gooclaim_bridge: auto-provisioned org {organization_id}")
+        return enriched if enriched else schemas.Organization.model_validate(organization)
 
     # ------------------------------------------------------------------
     # Access validation
@@ -283,6 +338,17 @@ class ContextResolver:
                     status_code=401,
                     detail="Authentication succeeded but user account was not found",
                 )
+            # Gooclaim fork — in SYSTEM-auth + external-provisioning mode,
+            # nginx is the trusted boundary; we skip the user_organizations
+            # membership check because (a) the org may have just been
+            # auto-provisioned in this very request, and (b) the system
+            # user is implicitly an owner of every auto-provisioned org.
+            if (
+                auth.method == AuthMethod.SYSTEM
+                and not settings.AUTH_ENABLED
+                and settings.EXTERNAL_ORG_ID_PROVISIONING
+            ):
+                return
             user_org_ids = [str(org.organization.id) for org in auth.user.user_organizations]
             if organization_id not in user_org_ids:
                 raise HTTPException(

--- a/backend/airweave/core/config/settings.py
+++ b/backend/airweave/core/config/settings.py
@@ -104,6 +104,14 @@ class Settings(BaseSettings):
     FIRST_SUPERUSER_NAME: str = "Admin"
 
     AUTH_ENABLED: Optional[bool] = False
+    # Gooclaim fork — when AUTH_ENABLED is False AND this flag is True, the
+    # context resolver will auto-create an organization with the UUID
+    # provided in the X-Organization-ID header if it does not yet exist.
+    # The nginx-auth-request sidecar in front of Airweave is the trusted
+    # boundary that validates the upstream JWT before forwarding the header.
+    # See gooclaim-infra/helm/airweave/templates/ingress.yaml for the nginx
+    # config that gates this header.
+    EXTERNAL_ORG_ID_PROVISIONING: bool = False
     AUTH0_DOMAIN: Optional[str] = None
     AUTH0_AUDIENCE: Optional[str] = None
     AUTH0_RULE_NAMESPACE: Optional[str] = None

--- a/backend/airweave/domains/embedders/dense/openai.py
+++ b/backend/airweave/domains/embedders/dense/openai.py
@@ -3,9 +3,15 @@
 Handles batching, concurrency, token validation, input/response
 validation, and error translation. Callers pass text, get
 DenseEmbedding back, handle errors themselves.
+
+Gooclaim patch: supports Azure OpenAI via OPENAI_BASE_URL env var.
+Set OPENAI_BASE_URL=https://<resource>.openai.azure.com/openai/v1/
+and OPENAI_API_KEY=<azure-key> to route embeddings through Azure
+OpenAI (Indian-region for IRDAI compliance).
 """
 
 import asyncio
+import os
 
 import tiktoken
 from openai import AsyncOpenAI
@@ -57,8 +63,11 @@ class OpenAIDenseEmbedder(DenseEmbedderProtocol):
         """
         self._model = model
         self._dimensions = dimensions
+        # Gooclaim patch: honor OPENAI_BASE_URL for Azure OpenAI routing.
+        base_url = os.getenv("OPENAI_BASE_URL") or None
         self._client = AsyncOpenAI(
             api_key=api_key,
+            base_url=base_url,
             timeout=self._CLIENT_TIMEOUT,
             max_retries=self._CLIENT_MAX_RETRIES,
         )

--- a/backend/airweave/search/providers/openai.py
+++ b/backend/airweave/search/providers/openai.py
@@ -2,8 +2,13 @@
 
 Supports text generation, structured output, embeddings, and reranking.
 Most complete provider with all capabilities.
+
+Gooclaim patch: supports Azure OpenAI via OPENAI_BASE_URL env var.
+Set OPENAI_BASE_URL=https://<resource>.openai.azure.com/openai/v1/
+to route through Azure OpenAI (Indian-region for IRDAI compliance).
 """
 
+import os
 from typing import Any, Dict, List, Optional
 
 from openai import AsyncOpenAI
@@ -32,8 +37,13 @@ class OpenAIProvider(BaseProvider):
         super().__init__(api_key, model_spec, ctx)
 
         try:
+            # Gooclaim patch: honor OPENAI_BASE_URL for Azure OpenAI routing.
+            base_url = os.getenv("OPENAI_BASE_URL") or None
             self.client = AsyncOpenAI(
-                api_key=api_key, timeout=self.TIMEOUT, max_retries=self.MAX_RETRIES
+                api_key=api_key,
+                base_url=base_url,
+                timeout=self.TIMEOUT,
+                max_retries=self.MAX_RETRIES,
             )
         except Exception as e:
             raise RuntimeError(f"Failed to initialize OpenAI client: {e}") from e

--- a/docs/gooclaim-fork-rebase.md
+++ b/docs/gooclaim-fork-rebase.md
@@ -1,0 +1,101 @@
+# Gooclaim fork — upstream rebase runbook
+
+This fork (`gooclaim-claimos/airweave-fork`) carries a minimal patch on top
+of `airweave-ai/airweave` to support **Azure OpenAI** routing via the
+`OPENAI_BASE_URL` env var.
+
+## The patch (small, focused)
+
+Modified files:
+- `backend/airweave/domains/embedders/dense/openai.py`
+  Adds `base_url=os.getenv("OPENAI_BASE_URL")` to `AsyncOpenAI(...)`
+- `backend/airweave/search/providers/openai.py`
+  Same change for the LLM provider client
+- `.env.example`
+  Documents the new `OPENAI_BASE_URL` env var
+
+Total: ~10 lines across 3 files.
+
+## Why this patch
+
+Upstream Airweave instantiates `AsyncOpenAI(api_key=...)` without
+`base_url`, hardcoding OpenAI direct. Gooclaim's stack is locked to
+**Azure OpenAI** (centralindia region) per IRDAI / DPDP requirements
+(memory: `project_irdai_binding_constraint.md`). The patch reads
+`OPENAI_BASE_URL` from env so the same `openai` SDK client can route
+through Azure OpenAI without further code changes.
+
+## Branches
+
+- `main` — tracks upstream `airweave-ai/airweave` releases (we pin tags)
+- `gooclaim-azure-openai` — feature branch with our patch
+- `gooclaim` — our "production" branch, fast-forwarded from a tagged upstream
+  release + cherry-pick of `gooclaim-azure-openai`
+
+## Rebase against new upstream release
+
+```bash
+# 1. Fetch latest upstream
+git fetch upstream
+
+# 2. Check what's new (e.g. tag v0.9.70)
+git log --oneline upstream/main | head -20
+
+# 3. Rebase our patch onto the new release
+git checkout gooclaim-azure-openai
+git rebase upstream/v0.9.70
+
+# 4. Resolve any conflicts in the 3 files above. Almost never conflicts
+#    because the upstream files rarely change in the patched lines.
+
+# 5. Re-tag our image
+docker build -t ghcr.io/gooclaim-claimos/airweave-backend:v0.9.70-gck.1 \
+  -f backend/Dockerfile backend/
+docker push ghcr.io/gooclaim-claimos/airweave-backend:v0.9.70-gck.1
+
+# 6. Bump image tag in gooclaim-infra Helm values
+#    helm/airweave/values-dev.yaml → BACKEND_IMAGE
+```
+
+## Tagging convention
+
+Our images are tagged as `<upstream-version>-gck.<patch-revision>`:
+- `v0.9.69-gck.1` — initial patch on upstream v0.9.69
+- `v0.9.70-gck.1` — same patch rebased onto v0.9.70
+- `v0.9.70-gck.2` — additional patch added (e.g. SSO support)
+
+## When NOT to rebase
+
+If upstream changes the embedder file (`dense/openai.py`) substantially,
+review carefully before rebasing. Our patch is just a `base_url=` param
+addition — usually safe. If they refactor to a different client class,
+re-think the patch.
+
+## Verification after rebase
+
+```bash
+# Build image
+docker build -t airweave-backend-test -f backend/Dockerfile backend/
+
+# Run smoke test with Azure OpenAI
+docker run --rm \
+  -e OPENAI_BASE_URL=https://<resource>.openai.azure.com/openai/v1/ \
+  -e OPENAI_API_KEY=<azure-key> \
+  -e DENSE_EMBEDDER=openai_text_embedding_3_small \
+  -e EMBEDDING_DIMENSIONS=1536 \
+  airweave-backend-test \
+  python -c "
+from airweave.domains.embedders.dense.openai import OpenAIDenseEmbedder
+import asyncio
+e = OpenAIDenseEmbedder(api_key='<azure-key>', model='text-embedding-3-small', dimensions=1536)
+result = asyncio.run(e.embed('hello world'))
+print(f'vector dim: {len(result.values)}')  # Should print: vector dim: 1536
+"
+```
+
+## v1.1 plan
+
+When Gooclaim's own `gooclaim-knowledge` pipeline goes live in v1.1
+(memory: `project_s5_airweave_strategy.md`), this fork may be deprecated
+entirely if we move away from Airweave. Until then, this is the
+production path.


### PR DESCRIPTION
## Summary

Gooclaim v1.0 simplification. Reuses the gooclaim \`tenant_id\` (UUID) as the Airweave \`organization_id\` 1:1, eliminating the need for a separate \`tenant_airweave_org_mapping\` table on our side.

Strategy memory: \`project_s5_airweave_strategy.md\`.

## How it works

Adds one setting:

\`\`\`
EXTERNAL_ORG_ID_PROVISIONING: bool = False   # off by default upstream
\`\`\`

When \`AUTH_ENABLED=False\` AND \`EXTERNAL_ORG_ID_PROVISIONING=True\`:

1. Every \`/v1/*\` request carries \`X-Organization-ID = <gooclaim tenant_id>\` (set by our nginx-auth-request sidecar after validating the gooclaim JWT)
2. If that org does not yet exist in Airweave, \`ContextResolver._auto_provision_organization()\` creates it with the supplied UUID and attaches \`FIRST_SUPERUSER\` as the owner
3. \`_validate_organization_access\` skips the \`user_organizations\` membership check in this mode — the trust boundary is nginx, not the Airweave backend

## Why this is safe

- \`AUTH_ENABLED\` is False in our deployment — the upstream Auth0 path is fully bypassed
- The only way an \`X-Organization-ID\` header reaches the backend is via the nginx ingress (\`gooclaim-infra/helm/airweave/templates/ingress.yaml\`) which validates the gooclaim bridge JWT via \`/v1/auth/introspect\` first
- Header injection through any other path requires bypassing the cluster ingress

## Changes

| File | What |
|------|------|
| \`backend/airweave/core/config/settings.py\` | New \`EXTERNAL_ORG_ID_PROVISIONING\` flag (default False) |
| \`backend/airweave/api/context_resolver.py\` | Auto-provision branch in \`_get_or_fetch_organization\`; trust-skip in \`_validate_organization_access\`; new \`_auto_provision_organization\` helper |
| \`backend/airweave/api/context_resolver.py\` | Drive-by: hoisted a pre-existing \`from datetime import datetime\` lazy import to top-level (passes ruff PLC0415) |

## Test plan

- [x] \`ruff check backend/airweave/api/context_resolver.py backend/airweave/core/config/settings.py\` — clean
- [x] \`ruff format --check\` — clean
- [ ] CI green (incl. import-linter + mypy)
- [ ] E2E on dev cluster (Day 16) — first visit auto-creates org; second visit reuses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-provisions Airweave organizations from trusted `X-Organization-ID` headers for the S5 bridge, reusing the gooclaim `tenant_id` as `organization_id`. Also adds optional Azure OpenAI routing via `OPENAI_BASE_URL`.

- **New Features**
  - External org provisioning: new `EXTERNAL_ORG_ID_PROVISIONING` flag (off by default). When `AUTH_ENABLED=false` and the flag is true, the backend auto-creates orgs from `X-Organization-ID`, assigns `FIRST_SUPERUSER`, and skips membership checks in this mode.
  - Azure OpenAI support: `OPENAI_BASE_URL` is now honored by the `openai` embedder and LLM provider (`AsyncOpenAI`), with `.env.example` and a rebase runbook updated.

- **Migration**
  - Enable by setting `EXTERNAL_ORG_ID_PROVISIONING=true` with `AUTH_ENABLED=false`, and ensure ingress validates the gooclaim JWT and forwards `X-Organization-ID`.
  - Optionally set `OPENAI_BASE_URL` to route through Azure OpenAI.

<sup>Written for commit 4d9c6b3ea362361103fefd1faaa12ac6605cc77f. Summary will update on new commits. <a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1788?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

