### PR TITLE
fix(arf): accept sync pipeline kwargs in ArfReplaySource.generate_entities

### DIFF
--- a/backend/airweave/domains/arf/replay_source.py
+++ b/backend/airweave/domains/arf/replay_source.py
@@ -82,8 +82,20 @@ class ArfReplaySource(BaseSource):
             original_short_name=original_short_name,
         )
 
-    async def generate_entities(self) -> AsyncGenerator[BaseEntity, None]:
-        """Generate entities from ARF storage."""
+    async def generate_entities(
+        self,
+        *,
+        cursor: object | None = None,
+        files: object | None = None,
+        node_selections: list | None = None,
+    ) -> AsyncGenerator[BaseEntity, None]:
+        """Generate entities from ARF storage.
+
+        Accepts the sync pipeline's standard generate_entities kwargs
+        (cursor, files, node_selections) but ignores them — replay reads
+        from the ARF store, not from a live source.
+        """
+        del cursor, files, node_selections  # unused; only present to match contract
         self.logger.info(f"ARF Replay: Reading entities from sync {self.sync_id}")
         async for entity in self.reader.iter_entities():
             yield entity

--- a/backend/airweave/domains/arf/tests/test_replay_source.py
+++ b/backend/airweave/domains/arf/tests/test_replay_source.py
@@ -11,18 +11,15 @@ Uses FakeArfReader to avoid real I/O.
 
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 from uuid import uuid4
 
 import pytest
 
 from airweave.core.exceptions import NotFoundException
 from airweave.domains.arf.fakes.reader import FakeArfReader
-from airweave.domains.arf.reader import ArfReader
 from airweave.domains.arf.replay_source import ArfReplaySource
-from airweave.domains.storage.exceptions import StorageNotFoundError
 from airweave.domains.storage.fakes import FakeStorageBackend
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -103,6 +100,27 @@ async def test_generate_entities_empty():
     async for entity in source.generate_entities():
         results.append(entity)
     assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_entities_accepts_pipeline_kwargs():
+    # SyncFactory._build_stream always calls generate_entities with
+    # cursor=, files=, node_selections=. Replay ignores them but must
+    # accept them or the dst sync_job fails with TypeError.
+    source = ArfReplaySource(sync_id=SYNC_ID, storage=FakeStorageBackend())
+    fake_reader = FakeArfReader()
+    fake_reader.seed_entities([_make_entity("ent-0")])
+    source._reader = fake_reader
+
+    results = [
+        entity
+        async for entity in source.generate_entities(
+            cursor=object(),
+            files=object(),
+            node_selections=[object()],
+        )
+    ]
+    assert len(results) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- \`SyncFactory._build_stream\` (backend/airweave/domains/sync_pipeline/factory.py:320) always calls \`source.generate_entities(cursor=..., files=..., node_selections=...)\`.
- \`ArfReplaySource.generate_entities\` declared no kwargs, so any replay sync_job (triggered by \`execution_config.behavior.replay_from_arf=true\`) crashed instantly with \`TypeError: ArfReplaySource.generate_entities() got an unexpected keyword argument 'cursor'\`.
- Widen the signature to accept and ignore the three standard kwargs. Replay reads from ARF storage, not a live source, so the cursor / file service / node selections are irrelevant.

Discovered while building a two-stack migration integration test in the \`airweave-migrations\` repo. Without this, the dst-side replay sync_job never produces entities and the migration verification step can't run.

## Test plan

- [x] Added \`test_generate_entities_accepts_pipeline_kwargs\` covering the exact kwarg signature \`SyncFactory\` invokes.
- [x] Full unit suite passes locally (\`poetry run pytest tests/unit -q --no-cov\` — 1207 passed).
- [x] Changed-lines mypy gate passes (\`diff-quality --violations=mypy --fail-under=100\` against \`origin/main\` — 100% on both files).
- [x] Changed-lines ruff gate passes (\`diff-quality --violations=ruff.check --fail-under=100\` — 100%).
- [x] Verified end-to-end against the two-stack integration test: dst replay sync_job reaches \`completed\` and \`/collections/{readable_id}/search/instant\` returns hits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `ArfReplaySource.generate_entities` accept the sync pipeline’s standard kwargs (`cursor`, `files`, `node_selections`) to stop the `TypeError` that crashes replay sync jobs. The values are ignored since replay reads from ARF storage, allowing replay jobs and migration verification to complete.

<sup>Written for commit a8d4d101994d4be4072d70726e4b6919c7631729. Summary will update on new commits. <a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1791?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

