### PR TITLE
chore(pre-commit): match CI by gating mypy on changed lines only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,17 @@ repos:
 
   - repo: local
     hooks:
+      # Mypy on changed lines only — matches the CI gate, which runs
+      # mypy across the whole package and then uses diff-quality to fail
+      # only on violations introduced by the diff vs. origin/main.
+      # See .github/workflows/code-quality.yml for the CI counterpart.
       - id: mypy
-        name: mypy
-        entry: bash -c 'cd backend && poetry run mypy --config-file pyproject.toml "${@#backend/}"' --
+        name: mypy (changed lines)
+        entry: bash backend/scripts/mypy_diff.sh
         language: system
         files: ^backend/airweave/.*\.py$
         types: [python]
+        pass_filenames: false
 
   - repo: local
     hooks:

--- a/backend/scripts/mypy_diff.sh
+++ b/backend/scripts/mypy_diff.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Run mypy across the airweave package and fail only on violations that
+# land on lines changed vs. the merge base with origin/main. Mirrors the
+# `mypy (changed lines)` job in .github/workflows/code-quality.yml so the
+# pre-commit gate matches the CI gate.
+#
+# Why this shape: mypy needs the whole import graph to type-check anything,
+# so we always run it on the full package. diff-quality then filters the
+# report down to lines the current diff touches — the same standard CI uses.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT/backend"
+
+COMPARE_BRANCH="${MYPY_DIFF_BASE:-origin/main}"
+
+# If origin/main isn't fetched (fresh shallow clone, offline), fall back
+# to local main, and as a last resort skip the diff gate. We never want
+# the hook to crash the commit because of git plumbing issues.
+if ! git rev-parse --verify --quiet "$COMPARE_BRANCH" >/dev/null; then
+  if git rev-parse --verify --quiet main >/dev/null; then
+    COMPARE_BRANCH="main"
+  else
+    echo "mypy_diff: no origin/main or main ref available; skipping diff-quality gate." >&2
+    exit 0
+  fi
+fi
+
+REPORT="$(mktemp -t mypy_report.XXXXXX.txt)"
+trap 'rm -f "$REPORT"' EXIT
+
+# Full-package mypy — never fails this step; we always want to feed the
+# report into diff-quality below.
+poetry run mypy --config-file pyproject.toml airweave/ > "$REPORT" || true
+
+poetry run diff-quality \
+  --violations=mypy \
+  --compare-branch="$COMPARE_BRANCH" \
+  --fail-under=100 \
+  "$REPORT"


### PR DESCRIPTION
## Summary

The pre-commit mypy hook ran mypy against changed files but surfaced every error mypy found in the transitive import graph. With ~2,400 pre-existing mypy errors on `main`, the hook fails on commits that don't introduce any new violations, which is why contributors regularly bypass it.

CI's `mypy (changed lines)` job already solves this by piping the full mypy report into `diff-quality --fail-under=100 --compare-branch=origin/main`, so only violations introduced by the diff fail the build. This PR mirrors that locally.

- \`backend/scripts/mypy_diff.sh\` runs full-package mypy, then feeds the report into \`diff-quality\` against \`origin/main\` (falls back to local \`main\`, then no-ops if neither ref is available, so the hook never crashes on git plumbing).
- \`.pre-commit-config.yaml\` invokes the script with \`pass_filenames: false\` so mypy always sees the whole import graph.

## Verification

Tested locally:
- Clean working tree vs \`origin/main\`: \`0 lines, 0 violations\` → passes.
- Working tree with a deliberately untyped \`def bad_typing(self, x): return x + 1\` in \`search/state.py\`: diff-quality reports \`Violations: 1 line; % Quality: 66%\` → fails as expected.
- Working tree with a real feature branch (PR 1 — partial_failures) overlaid: 15 changed files, 351 changed lines, \`Violations: 0 lines; % Quality: 100%\` → passes (pre-existing errors elsewhere in the codebase are correctly ignored).

## Test plan
- [ ] CI mypy job still passes
- [ ] Commit on a clean checkout succeeds without bypassing the hook
- [ ] A commit that introduces a new mypy error on changed lines fails the hook

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-commit `mypy` now mirrors CI by failing only on type errors in changed lines using `diff-quality`. This prevents failures from pre-existing errors and keeps the hook useful.

- **Refactors**
  - Added `backend/scripts/mypy_diff.sh` to run full `mypy` and gate via `diff-quality` against `origin/main` (falls back to `main` or skips if refs missing).
  - Updated `.pre-commit-config.yaml` to call the script with `pass_filenames: false` and renamed the hook to “mypy (changed lines)”.

<sup>Written for commit 2e79d4698aecbc9bdc590d8045a954e33cb3402f. Summary will update on new commits. <a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1793?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

