### PR TITLE
feat(search): surface federated source failures as partial_failures

### DIFF
--- a/backend/airweave/api/v1/endpoints/search.py
+++ b/backend/airweave/api/v1/endpoints/search.py
@@ -79,7 +79,7 @@ async def instant_search(
     )
 
     results = await service.search(db, ctx, readable_id, request)
-    return SearchV2Response(results=results.results)
+    return SearchV2Response(results=results.results, partial_failures=results.partial_failures)
 
 
 @router.post(
@@ -139,7 +139,7 @@ async def classic_search(
     )
 
     results = await service.search(db, ctx, readable_id, request)
-    return SearchV2Response(results=results.results)
+    return SearchV2Response(results=results.results, partial_failures=results.partial_failures)
 
 
 @router.post(
@@ -179,7 +179,7 @@ async def agentic_search(
     # Service emits SearchCompletedEvent internally
     results = await service.search(db, ctx, readable_id, request)
     truncated = results.results[: request.limit] if request.limit else results.results
-    return SearchV2Response(results=truncated)
+    return SearchV2Response(results=truncated, partial_failures=results.partial_failures)
 
 
 # ── Streaming agentic search ──────────────────────────────────────────
@@ -407,7 +407,7 @@ async def admin_instant_search_as_user(
     results = await service.search(
         db, ctx, readable_id, request, user_principal_override=user_principal
     )
-    return SearchV2Response(results=results.results)
+    return SearchV2Response(results=results.results, partial_failures=results.partial_failures)
 
 
 @admin_router.post(
@@ -438,7 +438,7 @@ async def admin_classic_search_as_user(
     results = await service.search(
         db, ctx, readable_id, request, user_principal_override=user_principal
     )
-    return SearchV2Response(results=results.results)
+    return SearchV2Response(results=results.results, partial_failures=results.partial_failures)
 
 
 @admin_router.post(
@@ -470,4 +470,4 @@ async def admin_agentic_search_as_user(
         db, ctx, readable_id, request, user_principal_override=user_principal
     )
     truncated = results.results[: request.limit] if request.limit else results.results
-    return SearchV2Response(results=truncated)
+    return SearchV2Response(results=truncated, partial_failures=results.partial_failures)

--- a/backend/airweave/core/events/search.py
+++ b/backend/airweave/core/events/search.py
@@ -259,6 +259,13 @@ class SearchCompletedEvent(DomainEvent):
 
     # User-facing
     results: list[dict[str, Any]] = Field(default_factory=list)  # serialized SearchResults
+    partial_failures: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Sources that failed during this search but were skipped so other sources "
+            "could still return results. Each item is a serialized PartialFailure."
+        ),
+    )
     duration_ms: int
 
     # Diagnostics (agentic only, None for instant/classic)

--- a/backend/airweave/domains/search/classic/service.py
+++ b/backend/airweave/domains/search/classic/service.py
@@ -172,7 +172,10 @@ class ClassicSearchService(ClassicSearchServiceProtocol):
                 documents=documents,
                 top_n=request.limit,
             )
-            results = SearchResults(results=[results.results[r.index] for r in reranked])
+            results = SearchResults(
+                results=[results.results[r.index] for r in reranked],
+                partial_failures=results.partial_failures,
+            )
 
         # 7. Emit event + return
         duration_ms = int((time.monotonic() - start_time) * 1000)
@@ -183,6 +186,7 @@ class ClassicSearchService(ClassicSearchServiceProtocol):
                 tier=SearchTier.CLASSIC,
                 plan=ctx.billing_plan,
                 results=[r.model_dump(mode="json") for r in results.results],
+                partial_failures=[pf.model_dump(mode="json") for pf in results.partial_failures],
                 duration_ms=duration_ms,
                 collection_id=UUID(str(collection.id)),
             )

--- a/backend/airweave/domains/search/executor.py
+++ b/backend/airweave/domains/search/executor.py
@@ -19,10 +19,11 @@ from airweave.domains.access_control.protocols import AccessBrokerProtocol
 from airweave.domains.embedders.protocols import DenseEmbedderProtocol, SparseEmbedderProtocol
 from airweave.domains.search.adapters.vector_db.protocol import VectorDBProtocol
 from airweave.domains.search.builders.search_plan import SearchPlanBuilder
-from airweave.domains.search.exceptions import FederatedSearchError
 from airweave.domains.search.protocols import SearchPlanExecutorProtocol
 from airweave.domains.search.types import (
     FilterGroup,
+    PartialFailure,
+    PartialFailureReason,
     QueryEmbeddings,
     RetrievalStrategy,
     SearchPlan,
@@ -98,8 +99,12 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         # 1. Merge plan filters with user filters
         complete_plan = SearchPlanBuilder.build(plan, user_filter)
 
-        # 2. Discover federated sources for this collection
-        federated_sources = await self._discover_federated_sources(db, ctx, collection_readable_id)
+        # 2. Discover federated sources for this collection. Discovery failures
+        #    (e.g., a Slack connection whose credentials no longer validate)
+        #    are captured rather than raised — search continues without them.
+        federated_sources, discovery_failures = await self._discover_federated_sources(
+            db, ctx, collection_readable_id
+        )
 
         # 3. Adjust limit/offset for RRF pagination (if federated sources exist)
         original_limit = complete_plan.limit
@@ -131,11 +136,15 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
             )
 
         vector_results = await vector_task
-        fed_results = await fed_task if fed_task else []
+        if fed_task:
+            fed_results, search_failures = await fed_task
+        else:
+            fed_results, search_failures = [], []
+        partial_failures = discovery_failures + search_failures
 
         # 5. If no federated sources, vector DB already has correct limit/offset
         if not federated_sources:
-            return SearchResults(results=vector_results)
+            return SearchResults(results=vector_results, partial_failures=partial_failures)
 
         # 6. We over-fetched from vector DB (limit=offset+limit, offset=0) for RRF.
         #    Filter federated results in-memory and merge, or slice vector-only.
@@ -147,11 +156,15 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
 
         if fed_filtered:
             merged = self._merge_with_rrf(vector_results, fed_filtered)
-            return SearchResults(results=merged[original_offset : original_offset + original_limit])
+            return SearchResults(
+                results=merged[original_offset : original_offset + original_limit],
+                partial_failures=partial_failures,
+            )
 
         # All federated results filtered out — slice vector results to original window
         return SearchResults(
-            results=vector_results[original_offset : original_offset + original_limit]
+            results=vector_results[original_offset : original_offset + original_limit],
+            partial_failures=partial_failures,
         )
 
     async def _execute_vector_search(
@@ -261,11 +274,13 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         db: AsyncSession,
         ctx: ApiContext,
         collection_readable_id: str,
-    ) -> list[BaseSource]:
+    ) -> tuple[list[BaseSource], list[PartialFailure]]:
         """Discover and instantiate federated sources for a collection.
 
         Queries source connections, checks the registry for federated_search flag,
-        and instantiates via SourceLifecycleService.
+        and instantiates via SourceLifecycleService. Per-source instantiation
+        failures (e.g., invalid credentials caught by validate()) are captured as
+        PartialFailure entries instead of aborting the whole search.
         """
         source_connections = await self._sc_repo.get_by_collection_ids(
             db,
@@ -274,9 +289,10 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         )
 
         if not source_connections:
-            return []
+            return [], []
 
         federated_sources: list[BaseSource] = []
+        partial_failures: list[PartialFailure] = []
         for sc in source_connections:
             entry = self._source_registry.get(sc.short_name)
             if not entry.federated_search:
@@ -290,9 +306,25 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
                 )
                 federated_sources.append(source_instance)
             except Exception as e:
-                raise FederatedSearchError([(sc.short_name, e)]) from e
+                error_str = str(e)
+                ctx.logger.warning(
+                    f"[FederatedSearch] Failed to instantiate {sc.short_name} "
+                    f"(connection {sc.id}), skipping: {error_str}"
+                )
+                partial_failures.append(
+                    PartialFailure(
+                        source_connection_id=str(sc.id),
+                        source_short_name=str(sc.short_name),
+                        reason=(
+                            PartialFailureReason.AUTH_INVALIDATED
+                            if _is_auth_error(error_str)
+                            else PartialFailureReason.ERROR
+                        ),
+                        message=error_str,
+                    )
+                )
 
-        return federated_sources
+        return federated_sources, partial_failures
 
     # ------------------------------------------------------------------
     # Federated search execution
@@ -304,37 +336,51 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         query: str,
         limit: int,
         ctx: ApiContext,
-    ) -> list[SearchResult]:
+    ) -> tuple[list[SearchResult], list[PartialFailure]]:
         """Search all federated sources concurrently and return deduplicated results.
 
-        Raises FederatedSearchError if any source fails.
+        Per-source failures are captured as PartialFailure entries instead of
+        raising — so one broken connection (e.g., Slack with an expired token)
+        no longer fails the entire search request.
         """
         results_lists = await asyncio.gather(
             *[self._search_single_source(source, query, limit, ctx) for source in sources],
             return_exceptions=True,
         )
 
-        # Check for failures — fail if any source errored
-        source_errors: list[tuple[str, BaseException]] = []
-        for idx, result_or_exc in enumerate(results_lists):
-            if isinstance(result_or_exc, BaseException):
-                source_name = sources[idx].__class__.__name__
-                source_errors.append((source_name, result_or_exc))
-
-        if source_errors:
-            raise FederatedSearchError(source_errors)
-
-        # All succeeded — deduplicate and return
+        partial_failures: list[PartialFailure] = []
         seen_ids: set[str] = set()
         all_results: list[SearchResult] = []
 
-        for result_list in results_lists:
-            for result in result_list:  # type: ignore[union-attr]
+        for idx, result_or_exc in enumerate(results_lists):
+            source = sources[idx]
+            source_name = source.__class__.__name__
+
+            if isinstance(result_or_exc, BaseException):
+                error_str = str(result_or_exc)
+                ctx.logger.warning(f"[FederatedSearch] {source_name} failed, skipping: {error_str}")
+                source_conn_id = getattr(source, "_source_connection_id", None)
+                short_name = getattr(source, "short_name", None) or source_name.lower()
+                partial_failures.append(
+                    PartialFailure(
+                        source_connection_id=(str(source_conn_id) if source_conn_id else None),
+                        source_short_name=short_name,
+                        reason=(
+                            PartialFailureReason.AUTH_INVALIDATED
+                            if _is_auth_error(error_str)
+                            else PartialFailureReason.ERROR
+                        ),
+                        message=error_str,
+                    )
+                )
+                continue
+
+            for result in result_or_exc:
                 if result.entity_id not in seen_ids:
                     seen_ids.add(result.entity_id)
                     all_results.append(result)
 
-        return all_results
+        return all_results, partial_failures
 
     _FEDERATED_MAX_RETRIES = 2
     _FEDERATED_INITIAL_DELAY = 1.0
@@ -506,6 +552,35 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
             result_map[eid].model_copy(update={"relevance_score": scores[eid]})
             for eid in sorted_ids
         ]
+
+
+# ── Auth-error classifier ────────────────────────────────────────────
+
+# Substrings that indicate a credential/auth failure across federated source APIs.
+# Kept in sync with airweave.search.operations.federated_search._is_auth_error.
+_AUTH_ERROR_INDICATORS = (
+    "token_expired",
+    "token_revoked",
+    "invalid_token",
+    "not_authed",
+    "invalid_auth",
+    "account_inactive",
+    "missing_scope",
+    "unauthorized",
+    "401",
+    "403",
+    "authentication",
+    "access_denied",
+    "invalid_credentials",
+    "expired",
+    "revoked",
+)
+
+
+def _is_auth_error(error_str: str) -> bool:
+    """Return True if the error message looks like an auth/credential failure."""
+    lowered = error_str.lower()
+    return any(indicator in lowered for indicator in _AUTH_ERROR_INDICATORS)
 
 
 # ── In-memory filter helpers (module-level for testability) ──────────

--- a/backend/airweave/domains/search/instant/service.py
+++ b/backend/airweave/domains/search/instant/service.py
@@ -122,6 +122,7 @@ class InstantSearchService(InstantSearchServiceProtocol):
                 tier=SearchTier.INSTANT,
                 plan=ctx.billing_plan,
                 results=[r.model_dump(mode="json") for r in results.results],
+                partial_failures=[pf.model_dump(mode="json") for pf in results.partial_failures],
                 duration_ms=duration_ms,
             )
         )

--- a/backend/airweave/domains/search/tests/test_executor.py
+++ b/backend/airweave/domains/search/tests/test_executor.py
@@ -822,9 +822,10 @@ class TestExecutorFederated:
         assert results.results[0].airweave_system_metadata.source_name == "slack"
 
     @pytest.mark.asyncio
-    async def test_federated_auth_failure_raises_error(self):
-        """If federated source fails to instantiate, FederatedSearchError is raised."""
-        from airweave.domains.search.exceptions import FederatedSearchError
+    async def test_federated_auth_failure_becomes_partial_failure(self):
+        """If a federated source fails to instantiate, search degrades to a partial failure
+        instead of returning a 500 — vector results still come through."""
+        from airweave.domains.search.types import PartialFailureReason
 
         vector_db = FakeVectorDB()
         vector_db.seed_results(SearchResults(results=[_make_search_result()]))
@@ -846,18 +847,24 @@ class TestExecutorFederated:
             source_lifecycle=source_lifecycle,
         )
 
-        with pytest.raises(FederatedSearchError) as exc_info:
-            await executor.execute(
-                plan=_make_plan(),
-                user_filter=[],
-                collection_id="col-1",
-                db=AsyncMock(),
-                ctx=_make_ctx(),
-                collection_readable_id="my-collection",
-            )
+        results = await executor.execute(
+            plan=_make_plan(),
+            user_filter=[],
+            collection_id="col-1",
+            db=AsyncMock(),
+            ctx=_make_ctx(),
+            collection_readable_id="my-collection",
+        )
 
-        assert len(exc_info.value.source_errors) == 1
-        assert exc_info.value.source_errors[0][0] == "slack"
+        assert len(results.results) == 1
+        assert len(results.partial_failures) == 1
+        failure = results.partial_failures[0]
+        assert failure.source_short_name == "slack"
+        # FakeSourceLifecycleService raises a non-auth error, so reason is ERROR
+        assert failure.reason in (
+            PartialFailureReason.ERROR,
+            PartialFailureReason.AUTH_INVALIDATED,
+        )
 
 
 class TestExecutorPagination:
@@ -991,9 +998,10 @@ class TestExecutorErrorPaths:
             )
 
     @pytest.mark.asyncio
-    async def test_federated_source_instantiation_failure_raises(self):
-        """Federated source that can't be instantiated → FederatedSearchError."""
-        from airweave.domains.search.exceptions import FederatedSearchError
+    async def test_federated_source_instantiation_failure_partial_failure(self):
+        """A federated source that fails to instantiate is recorded as a partial
+        failure; vector results still return."""
+        from airweave.domains.search.types import PartialFailureReason
 
         vector_db = FakeVectorDB()
         vector_db.seed_results(SearchResults(results=[_make_search_result()]))
@@ -1015,29 +1023,36 @@ class TestExecutorErrorPaths:
             source_lifecycle=source_lifecycle,
         )
 
-        with pytest.raises(FederatedSearchError) as exc_info:
-            await executor.execute(
-                plan=_make_plan(),
-                user_filter=[],
-                collection_id="col-1",
-                db=AsyncMock(),
-                ctx=_make_ctx(),
-                collection_readable_id="my-collection",
-            )
+        results = await executor.execute(
+            plan=_make_plan(),
+            user_filter=[],
+            collection_id="col-1",
+            db=AsyncMock(),
+            ctx=_make_ctx(),
+            collection_readable_id="my-collection",
+        )
 
-        assert len(exc_info.value.source_errors) == 1
-        assert exc_info.value.source_errors[0][0] == "slack"
+        assert len(results.results) == 1
+        assert len(results.partial_failures) == 1
+        failure = results.partial_failures[0]
+        assert failure.source_short_name == "slack"
+        assert failure.reason in (
+            PartialFailureReason.ERROR,
+            PartialFailureReason.AUTH_INVALIDATED,
+        )
 
     @pytest.mark.asyncio
-    async def test_federated_source_search_failure_raises(self):
-        """Federated source that errors during search() → FederatedSearchError."""
-        from airweave.domains.search.exceptions import FederatedSearchError
+    async def test_federated_source_search_auth_failure_partial_failure(self):
+        """A federated source that fails with an auth error during search() is
+        recorded as an AUTH_INVALIDATED partial failure; search degrades, doesn't raise."""
+        from airweave.domains.search.types import PartialFailureReason
 
         class _FailingFederatedSource:
             short_name = "slack"
+            _source_connection_id = None
 
             async def search(self, query: str, limit: int) -> list:
-                raise RuntimeError("search endpoint unavailable")
+                raise RuntimeError("invalid_auth")
 
         vector_db = FakeVectorDB()
         vector_db.seed_results(SearchResults(results=[]))
@@ -1059,17 +1074,20 @@ class TestExecutorErrorPaths:
             source_lifecycle=source_lifecycle,
         )
 
-        with pytest.raises(FederatedSearchError) as exc_info:
-            await executor.execute(
-                plan=_make_plan(),
-                user_filter=[],
-                collection_id="col-1",
-                db=AsyncMock(),
-                ctx=_make_ctx(),
-                collection_readable_id="my-collection",
-            )
+        results = await executor.execute(
+            plan=_make_plan(),
+            user_filter=[],
+            collection_id="col-1",
+            db=AsyncMock(),
+            ctx=_make_ctx(),
+            collection_readable_id="my-collection",
+        )
 
-        assert len(exc_info.value.source_errors) >= 1
+        assert len(results.partial_failures) >= 1
+        failure = results.partial_failures[0]
+        assert failure.source_short_name == "slack"
+        assert failure.reason == PartialFailureReason.AUTH_INVALIDATED
+        assert "invalid_auth" in (failure.message or "")
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/backend/airweave/domains/search/types/__init__.py
+++ b/backend/airweave/domains/search/types/__init__.py
@@ -24,6 +24,8 @@ from airweave.domains.search.types.plan import (
 )
 from airweave.domains.search.types.results import (
     CompiledQuery,
+    PartialFailure,
+    PartialFailureReason,
     SearchAccessControl,
     SearchBreadcrumb,
     SearchResult,
@@ -38,6 +40,8 @@ __all__ = [
     "SearchAccessControl",
     "SearchResult",
     "SearchResults",
+    "PartialFailure",
+    "PartialFailureReason",
     "CompiledQuery",
     # filters
     "FilterableField",

--- a/backend/airweave/domains/search/types/results.py
+++ b/backend/airweave/domains/search/types/results.py
@@ -1,15 +1,49 @@
 """Result types for the search module.
 
-SearchResult, SearchResults, CompiledQuery.
+SearchResult, SearchResults, CompiledQuery, PartialFailure.
 """
 
 from __future__ import annotations
 
 import json
 from datetime import datetime
+from enum import Enum
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field, PrivateAttr
+
+
+class PartialFailureReason(str, Enum):
+    """Why a single source was excluded from search results."""
+
+    AUTH_INVALIDATED = "auth_invalidated"
+    RATE_LIMITED = "rate_limited"
+    UNAVAILABLE = "unavailable"
+    ERROR = "error"
+
+
+class PartialFailure(BaseModel):
+    """A source that failed during search but did not cause the whole search to fail.
+
+    Surfaced on the response so clients can show degraded results and prompt
+    the user to re-authenticate or retry the affected source.
+    """
+
+    source_connection_id: Optional[str] = Field(
+        default=None,
+        description="ID of the source connection that failed, when known.",
+    )
+    source_short_name: str = Field(
+        ...,
+        description="Short name of the source (e.g., 'slack').",
+    )
+    reason: PartialFailureReason = Field(
+        ..., description="Machine-readable reason for the failure."
+    )
+    message: Optional[str] = Field(
+        default=None,
+        description="Human-readable failure detail, safe to surface to end users.",
+    )
 
 
 class SearchBreadcrumb(BaseModel):
@@ -237,6 +271,13 @@ class SearchResults(BaseModel):
     results: list[SearchResult] = Field(
         default_factory=list,
         description="Search results ordered by relevance (highest first).",
+    )
+    partial_failures: list[PartialFailure] = Field(
+        default_factory=list,
+        description=(
+            "Sources that failed during this search but were skipped so other "
+            "sources could still return results. Empty when the full search succeeded."
+        ),
     )
 
     def __len__(self) -> int:

--- a/backend/airweave/domains/sources/lifecycle.py
+++ b/backend/airweave/domains/sources/lifecycle.py
@@ -173,6 +173,11 @@ class SourceLifecycleService(SourceLifecycleServiceProtocol):
             config=config,
         )
 
+        # Attach source connection id so downstream code (federated search,
+        # partial-failure reporting) can identify the connection from the
+        # instance without re-plumbing it through every call site.
+        source._source_connection_id = source_connection_data.source_connection_id
+
         # 7. Validate credentials early so failures surface as NEEDS_REAUTH.
         #    Only catch auth-related exceptions — transient errors (server 5xx,
         #    rate limits, network timeouts) must propagate so they don't

--- a/backend/airweave/schemas/search.py
+++ b/backend/airweave/schemas/search.py
@@ -256,6 +256,15 @@ class SearchResponse(BaseModel):
             "Only included when generate_answer is true in the request."
         ),
     )
+    partial_failures: list[dict] = Field(
+        default_factory=list,
+        description=(
+            "Sources that failed during this search but were skipped so other "
+            "sources could still return results. Each entry includes "
+            "source_short_name, source_connection_id, reason, and message. "
+            "Empty when the full search succeeded."
+        ),
+    )
 
     model_config = {
         "json_schema_extra": {

--- a/backend/airweave/schemas/search_v2.py
+++ b/backend/airweave/schemas/search_v2.py
@@ -7,7 +7,12 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-from airweave.domains.search.types import FilterGroup, RetrievalStrategy, SearchResult
+from airweave.domains.search.types import (
+    FilterGroup,
+    PartialFailure,
+    RetrievalStrategy,
+    SearchResult,
+)
 
 
 class SearchTier(str, Enum):
@@ -285,4 +290,11 @@ class SearchV2Response(BaseModel):
 
     results: list[SearchResult] = Field(
         default_factory=list, description="Search results ordered by relevance."
+    )
+    partial_failures: list[PartialFailure] = Field(
+        default_factory=list,
+        description=(
+            "Sources that failed during this search but were skipped so other "
+            "sources could still return results. Empty when the full search succeeded."
+        ),
     )

--- a/backend/airweave/search/operations/federated_search.py
+++ b/backend/airweave/search/operations/federated_search.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 from pydantic import BaseModel, Field
 
 from airweave.api.context import ApiContext
+from airweave.domains.search.types import PartialFailure, PartialFailureReason
 from airweave.platform.sources._base import BaseSource
 from airweave.search.context import SearchContext
 from airweave.search.providers._base import BaseProvider
@@ -183,10 +184,27 @@ class FederatedSearch(SearchOperation):
             except Exception as e:
                 error_str = str(e)
                 source_conn_id = getattr(source, "_source_connection_id", None)
+                source_short_name = getattr(source, "short_name", None) or source_name.lower()
+                is_auth = self._is_auth_error(error_str)
 
                 # Track auth failures for post-search DB update
-                if self._is_auth_error(error_str) and source_conn_id:
-                    state.failed_federated_auth.append(source_conn_id)
+                if is_auth and source_conn_id:
+                    state.failed_federated_auth.append(str(source_conn_id))
+
+                # Record a structured partial failure so the response can surface
+                # the skip to the client instead of returning a 500.
+                state.partial_failures.append(
+                    PartialFailure(
+                        source_connection_id=(str(source_conn_id) if source_conn_id else None),
+                        source_short_name=source_short_name,
+                        reason=(
+                            PartialFailureReason.AUTH_INVALIDATED
+                            if is_auth
+                            else PartialFailureReason.ERROR
+                        ),
+                        message=error_str,
+                    )
+                )
 
                 ctx.logger.warning(f"[FederatedSearch] {source_name} failed: {error_str}")
                 await context.emitter.emit(

--- a/backend/airweave/search/orchestrator.py
+++ b/backend/airweave/search/orchestrator.py
@@ -94,8 +94,13 @@ class SearchOrchestrator:
         # Emit done event
         await emitter.emit("done", {"request_id": context.request_id})
 
-        # Build response and convert state to dict for analytics
-        response = SearchResponse(results=state.results, completion=state.completion)
+        # Build response and convert state to dict for analytics. partial_failures
+        # are serialized to dicts so legacy SearchResponse stays plain-JSON.
+        response = SearchResponse(
+            results=state.results,
+            completion=state.completion,
+            partial_failures=[pf.model_dump(mode="json") for pf in state.partial_failures],
+        )
         state_dict = state.model_dump()
         return response, state_dict
 

--- a/backend/airweave/search/state.py
+++ b/backend/airweave/search/state.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from airweave.domains.search.types import PartialFailure
+
 
 class SearchState(BaseModel):
     """Typed state passed between search operations.
@@ -89,6 +91,13 @@ class SearchState(BaseModel):
     )
     failed_federated_auth: List[str] = Field(
         default_factory=list, description="Source connection IDs that failed federated auth"
+    )
+    partial_failures: List[PartialFailure] = Field(
+        default_factory=list,
+        description=(
+            "Per-source failures that were tolerated during search (skipped sources "
+            "rather than failing the whole request). Surfaced on the response."
+        ),
     )
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/backend/tests/unit/search/test_state.py
+++ b/backend/tests/unit/search/test_state.py
@@ -12,7 +12,7 @@ class TestSearchState:
     def test_default_initialization(self):
         """Test SearchState initializes with correct defaults."""
         state = SearchState()
-        
+
         # Optional fields should be None
         assert state.expanded_queries is None
         assert state.dense_embeddings is None
@@ -20,21 +20,22 @@ class TestSearchState:
         assert state.interpreted_filter is None
         assert state.filter is None
         assert state.completion is None
-        
+
         # List fields should be empty
         assert state.results == []
-        
+
         # Dict fields should be empty
         assert state.operation_metrics == {}
         assert state.provider_usage == {}
         assert state.failed_federated_auth == []
+        assert state.partial_failures == []
 
     def test_expanded_queries_assignment(self):
         """Test setting expanded_queries field."""
         state = SearchState()
         queries = ["query1", "query2", "query3"]
         state.expanded_queries = queries
-        
+
         assert state.expanded_queries == queries
         assert len(state.expanded_queries) == 3
 
@@ -43,7 +44,7 @@ class TestSearchState:
         state = SearchState()
         embeddings = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
         state.dense_embeddings = embeddings
-        
+
         assert state.dense_embeddings == embeddings
         assert len(state.dense_embeddings) == 2
         assert len(state.dense_embeddings[0]) == 3
@@ -51,14 +52,14 @@ class TestSearchState:
     def test_sparse_embeddings_assignment(self):
         """Test setting sparse_embeddings field."""
         state = SearchState()
-        
+
         class MockSparseEmbedding:
             indices = [0, 1, 2]
             values = [0.8, 0.6, 0.4]
-        
+
         sparse = [MockSparseEmbedding()]
         state.sparse_embeddings = sparse
-        
+
         assert state.sparse_embeddings == sparse
         assert len(state.sparse_embeddings) == 1
 
@@ -71,7 +72,7 @@ class TestSearchState:
             ]
         }
         state.interpreted_filter = filter_dict
-        
+
         assert state.interpreted_filter == filter_dict
         assert "must" in state.interpreted_filter
 
@@ -84,7 +85,7 @@ class TestSearchState:
             ]
         }
         state.filter = filter_dict
-        
+
         assert state.filter == filter_dict
 
     def test_results_assignment(self):
@@ -95,7 +96,7 @@ class TestSearchState:
             {"entity_id": "2", "score": 0.8}
         ]
         state.results = results
-        
+
         assert state.results == results
         assert len(state.results) == 2
 
@@ -104,7 +105,7 @@ class TestSearchState:
         state = SearchState()
         completion = "This is a generated answer."
         state.completion = completion
-        
+
         assert state.completion == completion
 
     def test_operation_metrics_assignment(self):
@@ -115,7 +116,7 @@ class TestSearchState:
             "Retrieval": {"duration_ms": 500, "results_count": 10}
         }
         state.operation_metrics = metrics
-        
+
         assert state.operation_metrics == metrics
         assert "QueryExpansion" in state.operation_metrics
         assert state.operation_metrics["Retrieval"]["duration_ms"] == 500
@@ -128,7 +129,7 @@ class TestSearchState:
             "reranking": "CohereProvider"
         }
         state.provider_usage = usage
-        
+
         assert state.provider_usage == usage
         assert state.provider_usage["query_expansion"] == "CerebrasProvider"
 
@@ -137,9 +138,27 @@ class TestSearchState:
         state = SearchState()
         failed = ["connection-1", "connection-2"]
         state.failed_federated_auth = failed
-        
+
         assert state.failed_federated_auth == failed
         assert len(state.failed_federated_auth) == 2
+
+    def test_partial_failures_assignment(self):
+        """Test appending PartialFailure entries to partial_failures."""
+        from airweave.domains.search.types import PartialFailure, PartialFailureReason
+
+        state = SearchState()
+        state.partial_failures.append(
+            PartialFailure(
+                source_connection_id="conn-1",
+                source_short_name="slack",
+                reason=PartialFailureReason.AUTH_INVALIDATED,
+                message="invalid_auth",
+            )
+        )
+
+        assert len(state.partial_failures) == 1
+        assert state.partial_failures[0].source_short_name == "slack"
+        assert state.partial_failures[0].reason == PartialFailureReason.AUTH_INVALIDATED
 
     def test_model_dump(self):
         """Test SearchState serialization to dict."""
@@ -148,9 +167,9 @@ class TestSearchState:
         state.dense_embeddings = [[0.1, 0.2]]
         state.results = [{"entity_id": "1", "score": 0.9}]
         state.completion = "Answer"
-        
+
         dumped = state.model_dump()
-        
+
         assert isinstance(dumped, dict)
         assert dumped["expanded_queries"] == ["query1", "query2"]
         assert dumped["dense_embeddings"] == [[0.1, 0.2]]
@@ -161,9 +180,9 @@ class TestSearchState:
         """Test model_dump can exclude None values."""
         state = SearchState()
         state.results = [{"entity_id": "1"}]
-        
+
         dumped = state.model_dump(exclude_none=True)
-        
+
         # Should not include None fields
         assert "expanded_queries" not in dumped or dumped["expanded_queries"] is None
         assert "results" in dumped
@@ -171,68 +190,68 @@ class TestSearchState:
     def test_arbitrary_types_allowed(self):
         """Test Config allows arbitrary types."""
         state = SearchState()
-        
+
         # Should allow any type in sparse_embeddings
         class CustomObject:
             value = 42
-        
+
         state.sparse_embeddings = [CustomObject()]
         assert state.sparse_embeddings[0].value == 42
 
     def test_immutable_after_creation(self):
         """Test state can be modified after creation."""
         state = SearchState()
-        
+
         # Should be able to modify
         state.results = [{"id": "1"}]
         state.results.append({"id": "2"})
-        
+
         assert len(state.results) == 2
 
     def test_full_pipeline_state_flow(self):
         """Test state through full search pipeline flow."""
         state = SearchState()
-        
+
         # QueryExpansion
         state.expanded_queries = ["query1", "query2"]
-        
+
         # QueryInterpretation
         state.interpreted_filter = {"must": [{"key": "source", "match": {"value": "GitHub"}}]}
-        
+
         # EmbedQuery
         state.dense_embeddings = [[0.1] * 3072, [0.2] * 3072]
         state.sparse_embeddings = [{"indices": [0, 1], "values": [0.8, 0.6]}]
-        
+
         # UserFilter
         state.filter = {"must": [{"key": "entity_type", "match": {"value": "issue"}}]}
-        
+
         # Retrieval
         state.results = [
             {"entity_id": "1", "score": 0.95},
             {"entity_id": "2", "score": 0.85}
         ]
-        
+
         # Reranking (modifies results)
         state.results = [
             {"entity_id": "2", "score": 0.90},  # Reranked
             {"entity_id": "1", "score": 0.88}
         ]
-        
+
         # GenerateAnswer
         state.completion = "Based on the search results..."
-        
+
         # Metrics
         state.operation_metrics = {
             "QueryExpansion": {"duration_ms": 150},
             "Retrieval": {"duration_ms": 500},
             "Reranking": {"duration_ms": 300}
         }
-        
+
         state.provider_usage = {
             "query_expansion": "CerebrasProvider",
             "reranking": "CohereProvider"
         }
-        
+
         # Verify all fields set correctly
         assert len(state.expanded_queries) == 2
         assert len(state.dense_embeddings) == 2
@@ -246,7 +265,7 @@ class TestSearchState:
         """Test empty state serializes correctly."""
         state = SearchState()
         dumped = state.model_dump()
-        
+
         assert isinstance(dumped, dict)
         assert dumped["results"] == []
         assert dumped["operation_metrics"] == {}
@@ -256,10 +275,10 @@ class TestSearchState:
         """Test results field uses default_factory for empty list."""
         state1 = SearchState()
         state2 = SearchState()
-        
+
         # Should be separate instances
         state1.results.append({"id": "1"})
-        
+
         assert len(state1.results) == 1
         assert len(state2.results) == 0
 
@@ -267,10 +286,10 @@ class TestSearchState:
         """Test operation_metrics uses default_factory for empty dict."""
         state1 = SearchState()
         state2 = SearchState()
-        
+
         # Should be separate instances
         state1.operation_metrics["test"] = {"value": 1}
-        
+
         assert len(state1.operation_metrics) == 1
         assert len(state2.operation_metrics) == 0
 
@@ -278,13 +297,12 @@ class TestSearchState:
         """Test fields have proper descriptions."""
         # Access field info through model
         fields = SearchState.model_fields
-        
+
         assert "expanded_queries" in fields
         assert fields["expanded_queries"].description == "Alternative query phrasings from query expansion"
-        
+
         assert "dense_embeddings" in fields
         assert fields["dense_embeddings"].description == "Dense embeddings for neural search"
-        
+
         assert "results" in fields
         assert fields["results"].description == "Search results as dicts"
-


### PR DESCRIPTION
> **Stacked on #1793** (pre-commit diff-quality). Merge that first.

## Summary

A broken federated connection — e.g. a Slack source with an invalidated OAuth token — used to bubble \`FederatedSearchError\` all the way to the endpoint and fail the whole search with a 500. Now searches degrade: the offending source is skipped, vector results and other federated sources still return, and the skipped source shows up on the response under \`partial_failures\` so clients can prompt the user to re-authenticate.

## What changes

- New \`PartialFailure\` / \`PartialFailureReason\` types on the search domain
- \`partial_failures\` field added to \`SearchV2Response\`, \`SearchResults\` (domain), and the legacy \`SearchResponse\` so both API surfaces carry it
- \`SearchPlanExecutor\`: discover-time and search-time failures are collected as \`PartialFailure\` entries instead of raising \`FederatedSearchError\`; auth errors are classified as \`reason=auth_invalidated\`
- Legacy orchestrator: serialises \`SearchState.partial_failures\` onto the response
- \`SourceLifecycleService\` attaches \`source_connection_id\` to source instances so the federated search path can identify which connection failed
- \`SearchCompletedEvent\` carries \`partial_failures\` so the SSE stream's \`done\` event includes them too

## Follow-ups (deliberately out of scope)

- Agentic v2 (\`AgenticSearchService.search\`) builds a fresh \`SearchResults\` from accumulated tool-call output and currently drops the per-call \`partial_failures\`. Worth threading through, but the executor pattern is the harder part — done here.
- Mid-stream SSE event for partial failures (so the UI can show \"Slack: re-auth needed\" before final results land). The orchestrator already emits \`federated_source_error\` events, so the basic signal exists.

## Test plan
- [x] Unit tests: \`airweave/domains/search/tests/test_executor.py\` (59 passing, 2 new tests: instantiation-failure and search-time auth-failure both become partial failures)
- [x] State tests: \`tests/unit/search/test_state.py\` (new test for \`partial_failures\` field)
- [x] \`pytest tests/unit\` — 1208 pass
- [x] \`pytest airweave/domains/search airweave/api/v1/endpoints/tests\` — 274 pass
- [x] Pre-commit hooks (ruff, mypy on changed lines, import-linter, pytest unit) all pass
- [ ] Manual: invalidate a Slack token, hit \`/search/classic\` — expect 200 with results from other sources and a \`partial_failures\` entry for Slack

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Searches no longer fail with 500 when a federated source breaks. We skip the failing source, return other results, and include a `partial_failures` array so clients can prompt re-auth.

- **New Features**
  - Added `PartialFailure` and `PartialFailureReason`.
  - Added `partial_failures` to `SearchV2Response`, domain `SearchResults`, and legacy `SearchResponse`.
  - `SearchPlanExecutor` collects discover/search-time failures and classifies auth errors as `auth_invalidated`.
  - `SearchCompletedEvent` now includes `partial_failures`; API endpoints pass it through.
  - `SourceLifecycleService` attaches `source_connection_id` to source instances for accurate reporting.

- **Migration**
  - No breaking changes. Clients can optionally read `partial_failures` to notify users or request re-auth.

<sup>Written for commit 831bf68de7cb6bea93177d0b836a4c576a5d0762. Summary will update on new commits. <a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1794?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

