### PR TITLE
feat(webhooks): publish AUTH_INVALIDATED on federated auth failures

### DIFF
--- a/backend/airweave/api/v1/endpoints/search_legacy.py
+++ b/backend/airweave/api/v1/endpoints/search_legacy.py
@@ -27,6 +27,7 @@ from airweave.core.events.sync import QueryProcessedEvent
 from airweave.core.protocols import EventBus, PubSub
 from airweave.db.session import AsyncSessionLocal
 from airweave.domains.embedders.protocols import DenseEmbedderProtocol, SparseEmbedderProtocol
+from airweave.domains.source_connections.auth_invalidation import AuthInvalidationNotifier
 from airweave.domains.usage.protocols import UsageLimitCheckerProtocol
 from airweave.domains.usage.types import ActionType
 from airweave.schemas.errors import (
@@ -200,6 +201,7 @@ async def search(
     pubsub: PubSub = Inject(PubSub),
     dense_embedder: DenseEmbedderProtocol = Inject(DenseEmbedderProtocol),
     sparse_embedder: SparseEmbedderProtocol = Inject(SparseEmbedderProtocol),
+    auth_invalidation_notifier: AuthInvalidationNotifier = Inject(AuthInvalidationNotifier),
 ) -> Union[SearchResponse, LegacySearchResponse]:
     """Search your collection with AI-powered semantic search."""
     await usage_checker.is_allowed(db, ctx.organization.id, ActionType.QUERIES)
@@ -242,6 +244,7 @@ async def search(
         dense_embedder=dense_embedder,
         sparse_embedder=sparse_embedder,
         destination_override="vespa",
+        auth_invalidation_notifier=auth_invalidation_notifier,
     )
 
     ctx.logger.info(f"Search completed for collection '{readable_id}'")
@@ -267,6 +270,7 @@ async def stream_search_collection_advanced(  # noqa: C901 - streaming orchestra
     pubsub: PubSub = Inject(PubSub),
     dense_embedder: DenseEmbedderProtocol = Inject(DenseEmbedderProtocol),
     sparse_embedder: SparseEmbedderProtocol = Inject(SparseEmbedderProtocol),
+    auth_invalidation_notifier: AuthInvalidationNotifier = Inject(AuthInvalidationNotifier),
 ) -> StreamingResponse:
     """Server-Sent Events (SSE) streaming endpoint for advanced search.
 
@@ -313,6 +317,7 @@ async def stream_search_collection_advanced(  # noqa: C901 - streaming orchestra
                     dense_embedder=dense_embedder,
                     sparse_embedder=sparse_embedder,
                     destination_override="vespa",
+                    auth_invalidation_notifier=auth_invalidation_notifier,
                 )
         except ValueError as e:
             await _publish_stream_error(message=str(e), transient=False)

--- a/backend/airweave/core/container/container.py
+++ b/backend/airweave/core/container/container.py
@@ -80,6 +80,7 @@ from airweave.domains.search.protocols import (
     ClassicSearchServiceProtocol,
     InstantSearchServiceProtocol,
 )
+from airweave.domains.source_connections.auth_invalidation import AuthInvalidationNotifier
 from airweave.domains.source_connections.protocols import (
     ResponseBuilderProtocol,
     SourceConnectionRepositoryProtocol,
@@ -191,6 +192,11 @@ class Container:
 
     # Source connection service — domain service for source connections
     source_connection_service: SourceConnectionServiceProtocol
+
+    # Auth invalidation notifier — single entry-point for reporting runtime
+    # credential failures (federated search, OAuth refresh errors, etc.).
+    # Handles Redis dedupe, DB flip, and AUTH_INVALIDATED event publishing.
+    auth_invalidation_notifier: AuthInvalidationNotifier
 
     # Source lifecycle — creates/validates configured source instances
     source_lifecycle_service: SourceLifecycleServiceProtocol

--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -113,6 +113,7 @@ from airweave.domains.search.classic.service import ClassicSearchService
 from airweave.domains.search.config import SearchConfig
 from airweave.domains.search.executor import SearchPlanExecutor
 from airweave.domains.search.instant.service import InstantSearchService
+from airweave.domains.source_connections.auth_invalidation import AuthInvalidationNotifier
 from airweave.domains.source_connections.create import SourceConnectionCreationService
 from airweave.domains.source_connections.delete import SourceConnectionDeletionService
 from airweave.domains.source_connections.repository import SourceConnectionRepository
@@ -467,6 +468,16 @@ def create_container(settings: Settings) -> Container:
     )
 
     # -----------------------------------------------------------------
+    # Auth invalidation notifier (used by federated search to surface
+    # runtime credential failures as AUTH_INVALIDATED webhooks).
+    # -----------------------------------------------------------------
+    auth_invalidation_notifier = AuthInvalidationNotifier(
+        sc_repo=source_deps["sc_repo"],
+        event_bus=event_bus,
+        redis=redis_client.client,
+    )
+
+    # -----------------------------------------------------------------
     # Search domain services (LLM, tokenizer, reranker, metadata builder, per-tier)
     # -----------------------------------------------------------------
     search_deps = _create_search_services(
@@ -481,6 +492,7 @@ def create_container(settings: Settings) -> Container:
         event_bus=event_bus,
         source_lifecycle=source_deps["source_lifecycle_service"],
         access_broker=access_broker,
+        auth_invalidation_notifier=auth_invalidation_notifier,
     )
 
     # -----------------------------------------------------------------
@@ -585,6 +597,7 @@ def create_container(settings: Settings) -> Container:
         oauth2_service=source_deps["oauth2_service"],
         redirect_session_repo=source_deps["redirect_session_repo"],
         source_connection_service=source_connection_service,
+        auth_invalidation_notifier=auth_invalidation_notifier,
         connect_service=connect_service,
         oauth_flow_service=oauth_flow_svc,
         oauth_callback_service=oauth_callback_svc,
@@ -1268,6 +1281,7 @@ def _create_search_services(
     event_bus: "EventBus",
     source_lifecycle: "SourceLifecycleService",
     access_broker: "AccessBroker",
+    auth_invalidation_notifier: AuthInvalidationNotifier,
 ) -> dict:
     """Create search domain services (LLM, tokenizer, reranker, metadata builder, per-tier).
 
@@ -1333,6 +1347,7 @@ def _create_search_services(
         source_registry=source_registry,
         source_lifecycle=source_lifecycle,
         access_broker=access_broker,
+        auth_invalidation_notifier=auth_invalidation_notifier,
     )
 
     # 6. Per-tier services

--- a/backend/airweave/core/events/enums.py
+++ b/backend/airweave/core/events/enums.py
@@ -54,6 +54,7 @@ class SourceConnectionEventType(str, Enum):
 
     CREATED = "source_connection.created"
     AUTH_COMPLETED = "source_connection.auth_completed"
+    AUTH_INVALIDATED = "source_connection.auth_invalidated"
     DELETED = "source_connection.deleted"
 
 

--- a/backend/airweave/core/events/source_connection.py
+++ b/backend/airweave/core/events/source_connection.py
@@ -4,6 +4,7 @@ These events are published during source connection lifecycle transitions
 and consumed by webhooks, analytics, realtime, etc.
 """
 
+from typing import Optional
 from uuid import UUID
 
 from airweave.core.events.base import DomainEvent
@@ -16,6 +17,9 @@ class SourceConnectionLifecycleEvent(DomainEvent):
     Published when a source connection:
     - CREATED: Connection record created (may or may not be authenticated)
     - AUTH_COMPLETED: OAuth flow completed, connection is now authenticated
+    - AUTH_INVALIDATED: Credentials were observed to be invalid at runtime
+      (e.g. expired token, revoked OAuth grant). Customers typically wire
+      this to a re-auth flow.
     - DELETED: Connection and associated data removed
     """
 
@@ -28,6 +32,10 @@ class SourceConnectionLifecycleEvent(DomainEvent):
     # Context
     source_type: str = ""  # short_name, e.g. "slack", "notion"
     is_authenticated: bool = False
+
+    # AUTH_INVALIDATED-only: short machine-readable reason ("invalid_auth",
+    # "token_expired", etc.). Never includes the token itself.
+    error_reason: Optional[str] = None
 
     @classmethod
     def created(
@@ -64,6 +72,32 @@ class SourceConnectionLifecycleEvent(DomainEvent):
             source_type=source_type,
             collection_readable_id=collection_readable_id,
             is_authenticated=True,
+        )
+
+    @classmethod
+    def auth_invalidated(
+        cls,
+        organization_id: UUID,
+        source_connection_id: UUID,
+        source_type: str,
+        collection_readable_id: str,
+        error_reason: Optional[str] = None,
+    ) -> "SourceConnectionLifecycleEvent":
+        """Create an AUTH_INVALIDATED event (credentials observed to be invalid).
+
+        Emitted when a runtime auth failure is detected (e.g. federated search
+        receives invalid_auth from Slack, or OAuth refresh returns
+        invalid_grant). Customers typically subscribe to this to trigger a
+        re-authentication flow.
+        """
+        return cls(
+            event_type=SourceConnectionEventType.AUTH_INVALIDATED,
+            organization_id=organization_id,
+            source_connection_id=source_connection_id,
+            source_type=source_type,
+            collection_readable_id=collection_readable_id,
+            is_authenticated=False,
+            error_reason=error_reason,
         )
 
     @classmethod

--- a/backend/airweave/domains/search/executor.py
+++ b/backend/airweave/domains/search/executor.py
@@ -36,6 +36,7 @@ from airweave.domains.search.types.results import (
     SearchResult,
     SearchSystemMetadata,
 )
+from airweave.domains.source_connections.auth_invalidation import AuthInvalidationNotifier
 from airweave.domains.source_connections.protocols import SourceConnectionRepositoryProtocol
 from airweave.domains.sources.protocols import (
     SourceLifecycleServiceProtocol,
@@ -70,8 +71,13 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         source_registry: SourceRegistryProtocol,
         source_lifecycle: SourceLifecycleServiceProtocol,
         access_broker: AccessBrokerProtocol,
+        auth_invalidation_notifier: Optional[AuthInvalidationNotifier] = None,
     ) -> None:
-        """Initialize with embedders, vector database, and federated source dependencies."""
+        """Initialize with embedders, vector database, and federated source dependencies.
+
+        ``auth_invalidation_notifier`` is optional so the executor stays
+        constructible in test setups that don't need webhook delivery.
+        """
         self._dense_embedder = dense_embedder
         self._sparse_embedder = sparse_embedder
         self._vector_db = vector_db
@@ -79,6 +85,7 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
         self._source_registry = source_registry
         self._source_lifecycle = source_lifecycle
         self._access_broker = access_broker
+        self._auth_invalidation_notifier = auth_invalidation_notifier
 
     async def execute(
         self,
@@ -142,6 +149,11 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
             fed_results, search_failures = [], []
         partial_failures = discovery_failures + search_failures
 
+        # 4b. Fire AUTH_INVALIDATED webhooks for any auth failures detected,
+        #     dedup'd per source_connection_id by the notifier. Best-effort —
+        #     the notifier swallows its own errors so search never fails here.
+        await self._fire_auth_invalidation_webhooks(db, ctx, partial_failures)
+
         # 5. If no federated sources, vector DB already has correct limit/offset
         if not federated_sources:
             return SearchResults(results=vector_results, partial_failures=partial_failures)
@@ -166,6 +178,52 @@ class SearchPlanExecutor(SearchPlanExecutorProtocol):
             results=vector_results[original_offset : original_offset + original_limit],
             partial_failures=partial_failures,
         )
+
+    async def _fire_auth_invalidation_webhooks(
+        self,
+        db: AsyncSession,
+        ctx: ApiContext,
+        partial_failures: list[PartialFailure],
+    ) -> None:
+        """Notify the auth-invalidation pipeline for every auth-related failure.
+
+        Deduplication, DB flip, and event publishing are owned by the notifier;
+        this helper just collects unique (source_connection_id, reason) pairs
+        and dispatches them.
+        """
+        if self._auth_invalidation_notifier is None:
+            return
+
+        # Dedupe within the request — the notifier also dedupes across requests
+        # via Redis, but we don't even need to make the Redis round-trip if the
+        # same connection shows up multiple times in one search.
+        seen: set[str] = set()
+        for failure in partial_failures:
+            if failure.reason != PartialFailureReason.AUTH_INVALIDATED:
+                continue
+            if not failure.source_connection_id:
+                # Failure raised before we could identify the source connection
+                # (e.g. lifecycle.create raised without source_connection_id
+                # being attached). Nothing to notify on.
+                continue
+            if failure.source_connection_id in seen:
+                continue
+            seen.add(failure.source_connection_id)
+
+            try:
+                await self._auth_invalidation_notifier.notify(
+                    db,
+                    ctx,
+                    source_connection_id=UUID(failure.source_connection_id),
+                    error_reason=failure.message,
+                )
+            except Exception as exc:
+                # Notifier already logs internally; this catch is a belt-and-
+                # braces guard so even programmer errors don't propagate.
+                ctx.logger.exception(
+                    f"[SearchPlanExecutor] auth_invalidation_notifier.notify "
+                    f"raised for {failure.source_connection_id}: {exc}"
+                )
 
     async def _execute_vector_search(
         self,

--- a/backend/airweave/domains/search/tests/test_executor.py
+++ b/backend/airweave/domains/search/tests/test_executor.py
@@ -247,6 +247,7 @@ def _build_executor(
     sc_repo: FakeSourceConnectionRepository | None = None,
     source_registry: FakeSourceRegistry | None = None,
     source_lifecycle: FakeSourceLifecycleService | None = None,
+    auth_invalidation_notifier=None,
 ) -> SearchPlanExecutor:
     """Build a SearchPlanExecutor with fakes for all dependencies."""
     return SearchPlanExecutor(
@@ -257,6 +258,7 @@ def _build_executor(
         source_registry=source_registry or FakeSourceRegistry(),
         source_lifecycle=source_lifecycle or FakeSourceLifecycleService(),
         access_broker=FakeAccessBroker(),
+        auth_invalidation_notifier=auth_invalidation_notifier,
     )
 
 
@@ -483,9 +485,7 @@ class TestApplyFiltersInMemory:
     def test_entity_type_filter(self):
         slack = _make_federated_result(entity_id="f1", entity_type="SlackMessageEntity")
         github = _make_search_result(entity_id="g1", entity_type="GitHubPREntity")
-        filters = [
-            _make_filter("airweave_system_metadata.entity_type", "equals", "GitHubPREntity")
-        ]
+        filters = [_make_filter("airweave_system_metadata.entity_type", "equals", "GitHubPREntity")]
         filtered = SearchPlanExecutor._apply_filters_in_memory([slack, github], filters)
         assert len(filtered) == 1
         assert filtered[0].entity_id == "g1"
@@ -494,9 +494,7 @@ class TestApplyFiltersInMemory:
         """Federated results have sync_id=None, so filtering on sync_id excludes them."""
         fed = _make_federated_result(entity_id="f1")
         synced = _make_search_result(entity_id="s1", sync_id="some-sync-id")
-        filters = [
-            _make_filter("airweave_system_metadata.sync_id", "equals", "some-sync-id")
-        ]
+        filters = [_make_filter("airweave_system_metadata.sync_id", "equals", "some-sync-id")]
         filtered = SearchPlanExecutor._apply_filters_in_memory([fed, synced], filters)
         assert len(filtered) == 1
         assert filtered[0].entity_id == "s1"
@@ -533,19 +531,13 @@ class TestApplyFiltersInMemory:
             _make_filter("airweave_system_metadata.source_name", "equals", "slack"),
             _make_filter("airweave_system_metadata.source_name", "equals", "github"),
         ]
-        filtered = SearchPlanExecutor._apply_filters_in_memory(
-            [slack, github, notion], filters
-        )
+        filtered = SearchPlanExecutor._apply_filters_in_memory([slack, github, notion], filters)
         assert len(filtered) == 2
         assert {r.entity_id for r in filtered} == {"f1", "g1"}
 
     def test_date_filter(self):
-        old = _make_federated_result(
-            entity_id="f1", created_at=datetime(2025, 1, 1)
-        )
-        new = _make_federated_result(
-            entity_id="f2", created_at=datetime(2026, 3, 1)
-        )
+        old = _make_federated_result(entity_id="f1", created_at=datetime(2025, 1, 1))
+        new = _make_federated_result(entity_id="f2", created_at=datetime(2026, 3, 1))
         filters = [_make_filter("created_at", "greater_than", "2026-01-01T00:00:00")]
         filtered = SearchPlanExecutor._apply_filters_in_memory([old, new], filters)
         assert len(filtered) == 1
@@ -760,9 +752,7 @@ class TestExecutorFederated:
             source_lifecycle=source_lifecycle,
         )
 
-        user_filter = [
-            _make_filter("airweave_system_metadata.source_name", "equals", "github")
-        ]
+        user_filter = [_make_filter("airweave_system_metadata.source_name", "equals", "github")]
 
         results = await executor.execute(
             plan=_make_plan(),
@@ -774,9 +764,7 @@ class TestExecutorFederated:
         )
 
         # Only GitHub results should remain — Slack filtered out in-memory
-        assert all(
-            r.airweave_system_metadata.source_name == "github" for r in results.results
-        )
+        assert all(r.airweave_system_metadata.source_name == "github" for r in results.results)
 
     @pytest.mark.asyncio
     async def test_filter_source_name_slack_returns_federated_only(self):
@@ -805,9 +793,7 @@ class TestExecutorFederated:
             source_lifecycle=source_lifecycle,
         )
 
-        user_filter = [
-            _make_filter("airweave_system_metadata.source_name", "equals", "slack")
-        ]
+        user_filter = [_make_filter("airweave_system_metadata.source_name", "equals", "slack")]
 
         results = await executor.execute(
             plan=_make_plan(),
@@ -823,8 +809,11 @@ class TestExecutorFederated:
 
     @pytest.mark.asyncio
     async def test_federated_auth_failure_becomes_partial_failure(self):
-        """If a federated source fails to instantiate, search degrades to a partial failure
-        instead of returning a 500 — vector results still come through."""
+        """Degrade to a partial failure when a federated source fails to instantiate.
+
+        Search returns 200 with vector results; the failure is surfaced on the
+        response.
+        """
         from airweave.domains.search.types import PartialFailureReason
 
         vector_db = FakeVectorDB()
@@ -999,8 +988,10 @@ class TestExecutorErrorPaths:
 
     @pytest.mark.asyncio
     async def test_federated_source_instantiation_failure_partial_failure(self):
-        """A federated source that fails to instantiate is recorded as a partial
-        failure; vector results still return."""
+        """Record a partial failure when a federated source fails to instantiate.
+
+        Vector results still return; the failure is surfaced on the response.
+        """
         from airweave.domains.search.types import PartialFailureReason
 
         vector_db = FakeVectorDB()
@@ -1042,9 +1033,124 @@ class TestExecutorErrorPaths:
         )
 
     @pytest.mark.asyncio
+    async def test_auth_failure_calls_invalidation_notifier(self):
+        """Call AuthInvalidationNotifier.notify when a federated auth error fires.
+
+        Confirms the executor passes the failing connection id (and reason).
+        """
+        from airweave.domains.search.types import PartialFailureReason
+
+        sc = _make_source_connection("slack", federated=True)
+        sc_id_str = str(sc.id)
+
+        class _FailingFederatedSource:
+            short_name = "slack"
+            _source_connection_id = sc.id
+
+            async def search(self, query: str, limit: int) -> list:
+                raise RuntimeError("invalid_auth")
+
+        vector_db = FakeVectorDB()
+        vector_db.seed_results(SearchResults(results=[]))
+
+        sc_repo = FakeSourceConnectionRepository()
+        sc_repo.seed(sc.id, sc)
+
+        source_registry = FakeSourceRegistry()
+        source_registry.seed(_make_registry_entry("slack", federated=True))
+
+        source_lifecycle = FakeSourceLifecycleService()
+        source_lifecycle.seed_source(sc.id, _FailingFederatedSource())
+
+        notifier = MagicMock()
+        notifier.notify = AsyncMock(return_value=True)
+
+        executor = _build_executor(
+            vector_db=vector_db,
+            sc_repo=sc_repo,
+            source_registry=source_registry,
+            source_lifecycle=source_lifecycle,
+            auth_invalidation_notifier=notifier,
+        )
+
+        results = await executor.execute(
+            plan=_make_plan(),
+            user_filter=[],
+            collection_id="col-1",
+            db=AsyncMock(),
+            ctx=_make_ctx(),
+            collection_readable_id="my-collection",
+        )
+
+        # Partial failure surfaced
+        assert len(results.partial_failures) == 1
+        assert results.partial_failures[0].reason == PartialFailureReason.AUTH_INVALIDATED
+
+        # Notifier called exactly once with the failing connection id
+        notifier.notify.assert_awaited_once()
+        kwargs = notifier.notify.call_args.kwargs
+        assert str(kwargs["source_connection_id"]) == sc_id_str
+        assert "invalid_auth" in (kwargs.get("error_reason") or "")
+
+    @pytest.mark.asyncio
+    async def test_non_auth_failure_does_not_call_invalidation_notifier(self):
+        """Skip the AUTH_INVALIDATED webhook for non-auth errors.
+
+        Transient 500s and other non-credential failures should not trigger
+        the webhook — it would be a misleading signal to customers.
+        """
+
+        class _Non5xx:
+            status_code = 502  # transient, retried then surfaced as ERROR
+
+        class _TransientSource:
+            short_name = "slack"
+            _source_connection_id = uuid4()
+
+            async def search(self, query: str, limit: int) -> list:
+                err = RuntimeError("upstream 502 bad gateway")
+                err.status_code = 502  # type: ignore[attr-defined]
+                raise err
+
+        sc = _make_source_connection("slack", federated=True)
+        sc_repo = FakeSourceConnectionRepository()
+        sc_repo.seed(sc.id, sc)
+
+        source_registry = FakeSourceRegistry()
+        source_registry.seed(_make_registry_entry("slack", federated=True))
+
+        source_lifecycle = FakeSourceLifecycleService()
+        source_lifecycle.seed_source(sc.id, _TransientSource())
+
+        notifier = MagicMock()
+        notifier.notify = AsyncMock()
+
+        executor = _build_executor(
+            vector_db=FakeVectorDB(),
+            sc_repo=sc_repo,
+            source_registry=source_registry,
+            source_lifecycle=source_lifecycle,
+            auth_invalidation_notifier=notifier,
+        )
+
+        await executor.execute(
+            plan=_make_plan(),
+            user_filter=[],
+            collection_id="col-1",
+            db=AsyncMock(),
+            ctx=_make_ctx(),
+            collection_readable_id="my-collection",
+        )
+
+        notifier.notify.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_federated_source_search_auth_failure_partial_failure(self):
-        """A federated source that fails with an auth error during search() is
-        recorded as an AUTH_INVALIDATED partial failure; search degrades, doesn't raise."""
+        """Record AUTH_INVALIDATED partial failure when search() raises auth error.
+
+        Search degrades instead of raising; the failure is surfaced on the
+        response.
+        """
         from airweave.domains.search.types import PartialFailureReason
 
         class _FailingFederatedSource:
@@ -1100,9 +1206,7 @@ class TestExecutorFilterEdgeCases:
 
     def test_empty_filter_groups_passes_all(self):
         """filter_groups=[] → all results pass through unfiltered."""
-        results = [
-            _make_federated_result(entity_id=f"f{i}") for i in range(5)
-        ]
+        results = [_make_federated_result(entity_id=f"f{i}") for i in range(5)]
         filtered = SearchPlanExecutor._apply_filters_in_memory(results, [])
         assert len(filtered) == 5
         assert filtered == results
@@ -1169,9 +1273,7 @@ class TestFederatedRetry:
         source = _TransientSource()
         executor = _build_executor()
 
-        results = await executor._search_single_source(
-            source, "test", 10, _make_ctx()
-        )
+        results = await executor._search_single_source(source, "test", 10, _make_ctx())
         assert results == []
         assert source._attempt == 2
 

--- a/backend/airweave/domains/source_connections/auth_invalidation.py
+++ b/backend/airweave/domains/source_connections/auth_invalidation.py
@@ -1,0 +1,146 @@
+"""Auth invalidation notifier.
+
+Single entry-point for reporting that a source connection's credentials
+were observed to be invalid at runtime. Handles three things atomically
+per detection:
+
+1. Per-connection Redis dedupe (1 h TTL) so a single broken connection
+   doesn't spam customers' webhooks once per search.
+2. Flipping ``is_authenticated=False`` on the source connection row so the
+   UI immediately shows the connection as needing re-auth (instead of
+   waiting for the next sync to record the failure).
+3. Publishing a ``SourceConnectionLifecycleEvent.auth_invalidated`` event,
+   which the webhook subscriber forwards to customer endpoints.
+
+Callers (federated search, OAuth refresh failures, etc.) only need to call
+``notify(...)``; everything else is internal.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+from uuid import UUID
+
+from airweave.api.context import ApiContext
+from airweave.core.events.source_connection import SourceConnectionLifecycleEvent
+from airweave.core.logging import logger
+from airweave.core.protocols.event_bus import EventBus
+from airweave.domains.source_connections.protocols import SourceConnectionRepositoryProtocol
+
+if TYPE_CHECKING:
+    import redis.asyncio as redis  # type: ignore[import-untyped]
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# 1 hour dedupe window. Within this window we publish at most one
+# AUTH_INVALIDATED webhook per source_connection_id. Picked to balance
+# "don't spam customers" against "re-notify them if they ignore the first
+# alert" — see the design discussion on PR #1795.
+DEDUPE_TTL_SECONDS = 3600
+
+
+class AuthInvalidationNotifier:
+    """Idempotent emitter for AUTH_INVALIDATED events."""
+
+    def __init__(
+        self,
+        *,
+        sc_repo: SourceConnectionRepositoryProtocol,
+        event_bus: EventBus,
+        redis: "redis.Redis",
+    ) -> None:
+        """Initialize with deps. ``redis`` is the shared async Redis client."""
+        self._sc_repo = sc_repo
+        self._event_bus = event_bus
+        self._redis = redis
+
+    async def notify(
+        self,
+        db: "AsyncSession",
+        ctx: ApiContext,
+        *,
+        source_connection_id: UUID,
+        error_reason: Optional[str] = None,
+    ) -> bool:
+        """Record an auth invalidation for the given source connection.
+
+        Returns ``True`` if this call won the dedupe race (DB flipped and
+        webhook published), ``False`` if a previous call within the TTL
+        window already handled this connection.
+
+        Errors from Redis, the DB, or the event bus are logged but never
+        re-raised — the calling search request must not fail because the
+        notifier had trouble.
+        """
+        sc_id_str = str(source_connection_id)
+        dedupe_key = f"auth_invalidated:{sc_id_str}"
+
+        try:
+            # SET NX EX — only succeeds if the key isn't set.
+            # Returns truthy on first detection within the TTL window.
+            acquired = await self._redis.set(dedupe_key, "1", ex=DEDUPE_TTL_SECONDS, nx=True)
+        except Exception as exc:
+            # Redis is down or misbehaving. Fail open: still flip DB +
+            # publish so we never silently swallow the signal.
+            logger.warning(
+                f"AuthInvalidationNotifier: redis dedupe check failed for "
+                f"{sc_id_str}: {exc}. Proceeding without dedupe."
+            )
+            acquired = True
+
+        if not acquired:
+            logger.debug(f"AuthInvalidationNotifier: dedupe hit for {sc_id_str}, skipping")
+            return False
+
+        try:
+            sc = await self._sc_repo.get(db, source_connection_id, ctx)
+        except Exception as exc:
+            logger.exception(
+                f"AuthInvalidationNotifier: failed to load source connection {sc_id_str}: {exc}"
+            )
+            return False
+
+        if sc is None:
+            logger.warning(
+                f"AuthInvalidationNotifier: source connection {sc_id_str} not "
+                f"found (likely deleted between detection and notify); skipping"
+            )
+            return False
+
+        # Flip the DB flag if it isn't already off. Doing this here keeps
+        # the UI's computed status (NEEDS_REAUTH) honest the moment we
+        # detect bad auth, instead of waiting for the next sync job.
+        if sc.is_authenticated:
+            try:
+                await self._sc_repo.update(
+                    db, db_obj=sc, obj_in={"is_authenticated": False}, ctx=ctx
+                )
+            except Exception as exc:
+                logger.exception(
+                    f"AuthInvalidationNotifier: failed to flip is_authenticated "
+                    f"for {sc_id_str}: {exc}"
+                )
+
+        # Publish the lifecycle event. The webhook subscriber forwards
+        # this to customer-configured endpoints.
+        try:
+            await self._event_bus.publish(
+                SourceConnectionLifecycleEvent.auth_invalidated(
+                    organization_id=ctx.organization.id,
+                    source_connection_id=source_connection_id,
+                    source_type=str(sc.short_name),
+                    collection_readable_id=str(sc.readable_collection_id or ""),
+                    error_reason=error_reason,
+                )
+            )
+        except Exception as exc:
+            logger.exception(
+                f"AuthInvalidationNotifier: event_bus.publish failed for {sc_id_str}: {exc}"
+            )
+            return False
+
+        logger.info(
+            f"AuthInvalidationNotifier: published AUTH_INVALIDATED for "
+            f"connection={sc_id_str} reason={error_reason!r}"
+        )
+        return True

--- a/backend/airweave/domains/source_connections/tests/test_auth_invalidation.py
+++ b/backend/airweave/domains/source_connections/tests/test_auth_invalidation.py
@@ -1,0 +1,194 @@
+"""Unit tests for AuthInvalidationNotifier — dedupe, DB flip, publish."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from airweave.core.events.enums import SourceConnectionEventType
+from airweave.core.events.source_connection import SourceConnectionLifecycleEvent
+from airweave.domains.source_connections.auth_invalidation import (
+    DEDUPE_TTL_SECONDS,
+    AuthInvalidationNotifier,
+)
+
+ORG_ID = uuid4()
+
+
+def _make_ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.organization = MagicMock()
+    ctx.organization.id = ORG_ID
+    return ctx
+
+
+def _make_sc(*, short_name: str = "slack", is_authenticated: bool = True) -> MagicMock:
+    sc = MagicMock()
+    sc.id = uuid4()
+    sc.short_name = short_name
+    sc.readable_collection_id = "my-collection-abc"
+    sc.is_authenticated = is_authenticated
+    return sc
+
+
+def _build_notifier(
+    *,
+    sc_repo: AsyncMock | None = None,
+    event_bus: AsyncMock | None = None,
+    redis: AsyncMock | None = None,
+) -> tuple[AuthInvalidationNotifier, AsyncMock, AsyncMock, AsyncMock]:
+    sc_repo = sc_repo or MagicMock()
+    if not hasattr(sc_repo, "get") or not isinstance(sc_repo.get, AsyncMock):
+        sc_repo.get = AsyncMock()
+    if not hasattr(sc_repo, "update") or not isinstance(sc_repo.update, AsyncMock):
+        sc_repo.update = AsyncMock()
+
+    event_bus = event_bus or MagicMock()
+    if not hasattr(event_bus, "publish") or not isinstance(event_bus.publish, AsyncMock):
+        event_bus.publish = AsyncMock()
+
+    redis = redis or MagicMock()
+    if not hasattr(redis, "set") or not isinstance(redis.set, AsyncMock):
+        redis.set = AsyncMock(return_value=True)
+
+    notifier = AuthInvalidationNotifier(sc_repo=sc_repo, event_bus=event_bus, redis=redis)
+    return notifier, sc_repo, event_bus, redis
+
+
+@pytest.mark.asyncio
+async def test_first_call_acquires_lock_flips_db_and_publishes():
+    """The first notify() in the TTL window flips DB and publishes."""
+    sc = _make_sc(is_authenticated=True)
+    sc_repo = MagicMock()
+    sc_repo.get = AsyncMock(return_value=sc)
+    sc_repo.update = AsyncMock()
+    notifier, sc_repo, event_bus, redis = _build_notifier(sc_repo=sc_repo)
+
+    result = await notifier.notify(
+        AsyncMock(), _make_ctx(), source_connection_id=sc.id, error_reason="invalid_auth"
+    )
+
+    assert result is True
+    # Acquired the lock with the right TTL
+    redis.set.assert_awaited_once()
+    args, kwargs = redis.set.call_args
+    assert args[0] == f"auth_invalidated:{sc.id}"
+    assert kwargs == {"ex": DEDUPE_TTL_SECONDS, "nx": True}
+    # Flipped DB
+    sc_repo.update.assert_awaited_once()
+    update_kwargs = sc_repo.update.call_args.kwargs
+    assert update_kwargs["obj_in"] == {"is_authenticated": False}
+    # Published the event
+    event_bus.publish.assert_awaited_once()
+    published = event_bus.publish.call_args.args[0]
+    assert isinstance(published, SourceConnectionLifecycleEvent)
+    assert published.event_type == SourceConnectionEventType.AUTH_INVALIDATED
+    assert published.source_connection_id == sc.id
+    assert published.source_type == "slack"
+    assert published.collection_readable_id == "my-collection-abc"
+    assert published.is_authenticated is False
+    assert published.error_reason == "invalid_auth"
+
+
+@pytest.mark.asyncio
+async def test_second_call_within_ttl_is_dedupe_skipped():
+    """Second notify() within TTL window does not flip DB or publish."""
+    sc = _make_sc()
+    sc_repo = MagicMock()
+    sc_repo.get = AsyncMock(return_value=sc)
+    sc_repo.update = AsyncMock()
+    redis = MagicMock()
+    # First call: lock acquired (truthy). Second call: not acquired (falsy).
+    redis.set = AsyncMock(side_effect=[True, None])
+
+    notifier, sc_repo, event_bus, redis = _build_notifier(sc_repo=sc_repo, redis=redis)
+
+    first = await notifier.notify(AsyncMock(), _make_ctx(), source_connection_id=sc.id)
+    second = await notifier.notify(AsyncMock(), _make_ctx(), source_connection_id=sc.id)
+
+    assert first is True
+    assert second is False
+    # Only one DB flip + one publish, despite two notify() calls
+    assert sc_repo.update.await_count == 1
+    assert event_bus.publish.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_db_flip_skipped_when_already_unauthenticated():
+    """Skip the DB write when is_authenticated is already False.
+
+    Still publishes the event so re-detections get re-notified after TTL.
+    """
+    sc = _make_sc(is_authenticated=False)
+    sc_repo = MagicMock()
+    sc_repo.get = AsyncMock(return_value=sc)
+    sc_repo.update = AsyncMock()
+    notifier, sc_repo, event_bus, _ = _build_notifier(sc_repo=sc_repo)
+
+    result = await notifier.notify(AsyncMock(), _make_ctx(), source_connection_id=sc.id)
+
+    assert result is True
+    sc_repo.update.assert_not_awaited()
+    event_bus.publish.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_redis_failure_fails_open_and_still_publishes():
+    """Fail open on Redis errors instead of swallowing the signal.
+
+    Proceed with DB flip + publish so the customer still gets notified.
+    """
+    sc = _make_sc()
+    sc_repo = MagicMock()
+    sc_repo.get = AsyncMock(return_value=sc)
+    sc_repo.update = AsyncMock()
+    redis = MagicMock()
+    redis.set = AsyncMock(side_effect=RuntimeError("redis down"))
+    notifier, sc_repo, event_bus, _ = _build_notifier(sc_repo=sc_repo, redis=redis)
+
+    result = await notifier.notify(AsyncMock(), _make_ctx(), source_connection_id=sc.id)
+
+    assert result is True
+    sc_repo.update.assert_awaited_once()
+    event_bus.publish.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_source_connection_returns_false_without_publishing():
+    """Return False without publishing when the connection no longer exists.
+
+    Handles the case where the connection was deleted between detection
+    and notify(); we don't want to fabricate an event.
+    """
+    sc_repo = MagicMock()
+    sc_repo.get = AsyncMock(return_value=None)
+    sc_repo.update = AsyncMock()
+    notifier, sc_repo, event_bus, _ = _build_notifier(sc_repo=sc_repo)
+
+    result = await notifier.notify(AsyncMock(), _make_ctx(), source_connection_id=uuid4())
+
+    assert result is False
+    sc_repo.update.assert_not_awaited()
+    event_bus.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_publish_failure_returns_false_but_does_not_raise():
+    """Swallow publish failures so callers (search requests) don't 500.
+
+    notify() returns False when publish raises, but the exception itself
+    must not propagate to the caller.
+    """
+    sc = _make_sc()
+    sc_repo = MagicMock()
+    sc_repo.get = AsyncMock(return_value=sc)
+    sc_repo.update = AsyncMock()
+    event_bus = MagicMock()
+    event_bus.publish = AsyncMock(side_effect=RuntimeError("bus down"))
+    notifier, _, _, _ = _build_notifier(sc_repo=sc_repo, event_bus=event_bus)
+
+    result = await notifier.notify(AsyncMock(), _make_ctx(), source_connection_id=sc.id)
+
+    assert result is False  # publish failed, but no exception propagated

--- a/backend/airweave/search/service.py
+++ b/backend/airweave/search/service.py
@@ -6,7 +6,7 @@ and executed in a flexible pipeline.
 """
 
 import time
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID
 
 from sqlalchemy import select as sa_select
@@ -17,6 +17,7 @@ from airweave.api.context import ApiContext
 from airweave.core.exceptions import NotFoundException
 from airweave.core.protocols.pubsub import PubSub
 from airweave.domains.embedders.protocols import DenseEmbedderProtocol, SparseEmbedderProtocol
+from airweave.domains.source_connections.auth_invalidation import AuthInvalidationNotifier
 from airweave.models.source_connection import SourceConnection
 from airweave.schemas.search import SearchRequest, SearchResponse
 from airweave.search.factory import factory
@@ -43,6 +44,7 @@ class SearchService:
         dense_embedder: DenseEmbedderProtocol,
         sparse_embedder: SparseEmbedderProtocol,
         destination_override: SearchDestination | None = None,
+        auth_invalidation_notifier: Optional[AuthInvalidationNotifier] = None,
     ) -> SearchResponse:
         """Search a collection.
 
@@ -58,6 +60,10 @@ class SearchService:
             sparse_embedder: Domain sparse embedder for generating BM25 embeddings
             destination_override: If provided, override the default destination
                 ('qdrant' or 'vespa'). If None, uses SyncConfig default.
+            auth_invalidation_notifier: Optional notifier used to publish
+                ``AUTH_INVALIDATED`` webhooks and flip ``is_authenticated=False``
+                when a federated source reports an auth failure during the
+                search. Falls back to a direct DB flip when not provided.
 
         Returns:
             SearchResponse with results
@@ -92,8 +98,9 @@ class SearchService:
         ctx.logger.debug("Executing search")
         response, state = await orchestrator.run(ctx, search_context)
 
-        # Handle any federated source auth failures (mark connections as unauthenticated)
-        await self._handle_failed_federated_auth(db, state, ctx)
+        # Handle any federated source auth failures: flip is_authenticated=False
+        # in the DB and publish AUTH_INVALIDATED webhooks (deduped via Redis).
+        await self._handle_failed_federated_auth(db, state, ctx, auth_invalidation_notifier)
 
         duration_ms = (time.monotonic() - start_time) * 1000
         ctx.logger.debug(f"Search completed in {duration_ms:.2f}ms")
@@ -366,13 +373,36 @@ class SearchService:
         db: AsyncSession,
         state: Dict[str, Any],
         ctx: ApiContext,
+        notifier: Optional[AuthInvalidationNotifier] = None,
     ) -> None:
-        """Mark source connections as unauthenticated on federated auth errors."""
+        """Handle federated source auth failures.
+
+        When a notifier is wired in, delegates DB flip + webhook dispatch to
+        ``AuthInvalidationNotifier`` (deduped per source_connection_id via
+        Redis). Falls back to a direct ``is_authenticated=False`` flip when
+        no notifier is available (legacy code paths and tests).
+        """
         failed_conn_ids: List[str] = state.get("failed_federated_auth", [])
         if not failed_conn_ids:
             return
 
-        for conn_id in failed_conn_ids:
+        # Dedupe IDs within the request — same connection can fail across
+        # multiple keywords / sources during one search.
+        unique_ids = list(dict.fromkeys(failed_conn_ids))
+
+        if notifier is not None:
+            for conn_id in unique_ids:
+                try:
+                    await notifier.notify(db, ctx, source_connection_id=UUID(conn_id))
+                except Exception as exc:
+                    ctx.logger.exception(
+                        f"AuthInvalidationNotifier.notify failed for {conn_id}: {exc}"
+                    )
+            return
+
+        # Notifier not wired — fall back to legacy direct DB flip so the UI's
+        # NEEDS_REAUTH status still kicks in for older call sites.
+        for conn_id in unique_ids:
             source_conn = await crud.source_connection.get(db, id=UUID(conn_id), ctx=ctx)
             if source_conn:
                 await crud.source_connection.update(

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -632,6 +632,36 @@ def fake_selection_repo():
 
 
 @pytest.fixture
+def fake_auth_invalidation_notifier():
+    """Real AuthInvalidationNotifier wired against fake Redis/sc_repo/event_bus.
+
+    Using the real notifier (not a mock) so tests exercise the actual dedupe +
+    DB-flip + publish logic. The fake Redis always 'acquires' the lock by
+    returning truthy from set() so notify() always proceeds.
+    """
+    from airweave.domains.source_connections.auth_invalidation import (
+        AuthInvalidationNotifier,
+    )
+
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    fake_redis.delete = AsyncMock(return_value=1)
+
+    fake_sc_repo = MagicMock()
+    fake_sc_repo.get = AsyncMock(return_value=None)
+    fake_sc_repo.update = AsyncMock()
+
+    fake_bus = MagicMock()
+    fake_bus.publish = AsyncMock()
+
+    return AuthInvalidationNotifier(
+        sc_repo=fake_sc_repo,
+        event_bus=fake_bus,
+        redis=fake_redis,
+    )
+
+
+@pytest.fixture
 def fake_instant_search():
     """Fake InstantSearchService."""
     from airweave.domains.search.fakes.instant import FakeInstantSearchService
@@ -742,6 +772,7 @@ def test_container(
     fake_connect_service,
     fake_browse_tree_service,
     fake_selection_repo,
+    fake_auth_invalidation_notifier,
     fake_instant_search,
     fake_classic_search,
     fake_agentic_search_v2,
@@ -802,6 +833,7 @@ def test_container(
         oauth_callback_service=fake_oauth_callback_service,
         init_session_repo=fake_init_session_repo,
         source_connection_service=fake_source_connection_service,
+        auth_invalidation_notifier=fake_auth_invalidation_notifier,
         connect_service=fake_connect_service,
         source_lifecycle_service=fake_source_lifecycle_service,
         response_builder=fake_response_builder,


### PR DESCRIPTION
> **Stacked on #1794** (partial_failures), which is stacked on #1793 (pre-commit). Merge those first.

## Summary

When federated search detects a credential failure (e.g. Slack returns \`invalid_auth\`, an OAuth refresh fails), we now atomically:

1. **Flip \`is_authenticated=False\`** on the source connection so the UI's computed status switches to \`NEEDS_REAUTH\` immediately, instead of waiting for the next sync job to record the error.
2. **Publish a \`SourceConnectionLifecycleEvent.auth_invalidated\` event.** Customers subscribed via webhooks can wire this into their own re-auth flow.

Both steps are gated by a **per-source-connection Redis lock with a 1 h TTL**, so a single broken connection that fails on every search doesn't spam customer webhooks. The notifier **fails open** (still flips DB + publishes) if Redis is unreachable, and swallows all errors so a search request never 500s because notification had trouble.

## What changes

- \`SourceConnectionEventType.AUTH_INVALIDATED\` added to the enum; the webhook \`EventType\` auto-derives \`SOURCE_CONNECTION_AUTH_INVALIDATED\` (no further wiring needed for delivery).
- \`SourceConnectionLifecycleEvent\` gets:
  - an \`auth_invalidated()\` factory
  - an \`error_reason: Optional[str]\` field (machine-readable, never contains tokens)
- \`AuthInvalidationNotifier\` ([domains/source_connections/auth_invalidation.py](backend/airweave/domains/source_connections/auth_invalidation.py)) is the single entry-point for runtime auth failures. It owns the Redis dedupe, the DB flip, and the event publish.
- \`SearchPlanExecutor\` (v2) calls the notifier for each \`AUTH_INVALIDATED\` partial failure (PR #1794), dedup'd per request.
- Legacy \`SearchService.search()\` replaces the direct \`is_authenticated\` flip in \`_handle_failed_federated_auth\` with notifier dispatch when one is wired in (falls back to the old behaviour otherwise so older test paths keep working).
- Container/factory wires the notifier; the \`test_container\` fixture builds a *real* notifier against fake Redis/sc_repo/event_bus so tests exercise the actual code path.

## Dedupe semantics (per the design discussion)

- TTL **1 hour** per source_connection_id. If a customer ignores the alert for a day, they get re-notified.
- Acquires \`auth_invalidated:{sc_id}\` via \`SET NX EX\`.
- Within a single request, the executor also dedups before calling the notifier, so the same connection failing on N keywords still produces one notify call (and at most one publish).

## Test plan
- [x] \`airweave/domains/source_connections/tests/test_auth_invalidation.py\` (6 tests): first-call publishes, dedupe within TTL, DB flip skipped when already unauthenticated, Redis failure fails open, missing source connection returns False, publish failure returns False (no propagation).
- [x] \`airweave/domains/search/tests/test_executor.py\`: 2 new tests — notifier called on auth failure (with correct id + reason); notifier *not* called on non-auth (transient 502) failure.
- [x] \`pytest tests/unit\` — 1208 pass.
- [x] \`pytest airweave/domains\` — 2590 pass.
- [x] Pre-commit hooks (ruff, mypy on changed lines, import-linter, pytest unit) all pass.
- [ ] Manual: invalidate a Slack token, hit \`/search/classic\`, observe \`AUTH_INVALIDATED\` delivered to a configured webhook endpoint; observe \`is_authenticated=False\` on the connection.

## Follow-ups (deliberately out of scope)

- Fire from OAuth refresh \`invalid_grant\` and Slack's 401-after-refresh path. Both are good candidates but require touching token-provider plumbing — better as separate PRs.
- Agentic v2 still drops partial_failures (see PR #1794 follow-ups). Once that's threaded through, AUTH_INVALIDATED firing for agentic-tier searches comes for free.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Immediately publish AUTH_INVALIDATED webhooks and set `is_authenticated=false` when federated auth fails, so customers can trigger re-auth and the UI updates right away. Dedupe notifications per connection via Redis to avoid spam and never block search requests.

- **New Features**
  - Added `SourceConnectionEventType.AUTH_INVALIDATED` and `SourceConnectionLifecycleEvent.auth_invalidated()` with optional `error_reason`.
  - Introduced `AuthInvalidationNotifier` that dedupes per connection (Redis, 1h TTL), flips `is_authenticated`, and publishes the event; fails open and swallows errors.
  - Integrated notifier in `SearchPlanExecutor` for AUTH_INVALIDATED partial failures (deduped within a request).
  - Updated legacy `SearchService.search()` to use the notifier when provided; otherwise falls back to the direct DB flip.
  - Wired through container/factory and API endpoints to inject the notifier.

<sup>Written for commit 35b62f2c443478a303aa71fe55b7f5b93dd68ae2. Summary will update on new commits. <a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1795?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

