### PR TITLE
feat(redis): support Sentinel for high-availability Redis topologies

### DIFF
--- a/backend/airweave/adapters/pubsub/redis.py
+++ b/backend/airweave/adapters/pubsub/redis.py
@@ -11,18 +11,19 @@ Usage patterns:
 Notes:
 - Publishes accept either strings (already JSON) or dicts which will be JSON-encoded
 - Subscriptions create a dedicated Redis connection suited for long-lived SSE streams
+- Both single-host and Sentinel topologies are supported transparently via
+  ``airweave.core.redis_factory.make_redis_client``.
 """
 
 from __future__ import annotations
 
 import json
-import platform
 from typing import Any
 
 import redis.asyncio as redis
 
-from airweave.core.config import settings
 from airweave.core.redis_client import redis_client
+from airweave.core.redis_factory import get_socket_keepalive_options, make_redis_client
 
 
 class RedisPubSub:
@@ -56,7 +57,8 @@ class RedisPubSub:
         """Create a dedicated pubsub connection and subscribe to a channel.
 
         A separate client is created for pubsub to avoid connection pool
-        interference with regular Redis usage.
+        interference with regular Redis usage. In Sentinel mode the connection
+        is bound to the current master and transparently reconnects on failover.
 
         Args:
             namespace: The channel namespace
@@ -67,37 +69,11 @@ class RedisPubSub:
         """
         channel = self.make_channel(namespace, str(id_value))
 
-        if settings.REDIS_PASSWORD:
-            from urllib.parse import quote
-
-            encoded_pwd = quote(settings.REDIS_PASSWORD, safe="")
-            redis_url = (
-                f"redis://:{encoded_pwd}@{settings.REDIS_HOST}:"
-                f"{settings.REDIS_PORT}/{settings.REDIS_DB}"
-            )
-        else:
-            redis_url = f"redis://{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.REDIS_DB}"
-
-        if platform.system() == "Darwin":
-            socket_keepalive_options = {}
-        else:
-            import socket
-
-            if hasattr(socket, "TCP_KEEPIDLE"):
-                socket_keepalive_options = {
-                    socket.TCP_KEEPIDLE: 60,
-                    socket.TCP_KEEPINTVL: 10,
-                    socket.TCP_KEEPCNT: 6,
-                }
-            else:
-                socket_keepalive_options = {}
-
-        pubsub_redis = await redis.from_url(
-            redis_url,
-            decode_responses=True,
+        pubsub_redis = make_redis_client(
+            max_connections=1,
             socket_keepalive=True,
+            socket_keepalive_options=get_socket_keepalive_options(),
             socket_connect_timeout=5,
-            socket_keepalive_options=socket_keepalive_options,
         )
 
         pubsub = pubsub_redis.pubsub()

--- a/backend/airweave/core/config/settings.py
+++ b/backend/airweave/core/config/settings.py
@@ -63,10 +63,14 @@ class Settings(BaseSettings):
         RUN_ALEMBIC_MIGRATIONS (bool): Whether to run the alembic migrations.
         RUN_DB_SYNC (bool): Whether to run the system sync to process sources,
             destinations, and entity types.
-        REDIS_HOST (str): The Redis server hostname.
-        REDIS_PORT (int): The Redis server port.
+        REDIS_HOST (str): The Redis server hostname (single-host mode).
+        REDIS_PORT (int): The Redis server port (single-host mode).
         REDIS_PASSWORD (Optional[str]): The Redis password (if authentication is enabled).
         REDIS_DB (int): The Redis database number.
+        REDIS_NODES (Optional[str]): JSON list of Sentinel nodes ``[[host, port], ...]``.
+            When set together with ``REDIS_SERVICE_NAME``, enables Sentinel mode and
+            ``REDIS_HOST``/``REDIS_PORT`` are ignored.
+        REDIS_SERVICE_NAME (Optional[str]): The Sentinel master name to discover.
         TEXT2VEC_INFERENCE_URL (str): The URL for text2vec-transformers inference service.
         OPENAI_API_KEY (Optional[str]): The OpenAI API key.
         MISTRAL_API_KEY (Optional[str]): The Mistral AI API key.
@@ -139,11 +143,19 @@ class Settings(BaseSettings):
     RUN_DB_SYNC: bool = True
     ENABLE_INTERNAL_SOURCES: bool = False  # Enable internal/testing sources (stub, snapshot)
 
-    # Redis configuration
+    # Redis configuration.
+    # Two modes are supported:
+    # 1. Single-host (default): set REDIS_HOST + REDIS_PORT.
+    # 2. Sentinel: set REDIS_NODES (JSON list of [host, port] sentinel nodes) and
+    #    REDIS_SERVICE_NAME (the master name registered with Sentinel, e.g. "mymaster").
+    #    When both are set, REDIS_HOST and REDIS_PORT are ignored and the client
+    #    discovers the current master via Sentinel.
     REDIS_HOST: str = "localhost"
     REDIS_PORT: int = 6379
     REDIS_PASSWORD: Optional[str] = None
     REDIS_DB: int = 0
+    REDIS_NODES: Optional[str] = None  # e.g. '[["host-0", 26379], ["host-1", 26379]]'
+    REDIS_SERVICE_NAME: Optional[str] = None  # e.g. "mymaster"
 
     TEXT2VEC_INFERENCE_URL: str = "http://localhost:9878"
 

--- a/backend/airweave/core/redis_client.py
+++ b/backend/airweave/core/redis_client.py
@@ -1,13 +1,11 @@
 """Redis client configuration."""
 
-import platform
-import socket
 from typing import Optional
 
 import redis.asyncio as redis
 
-from airweave.core.config import settings
 from airweave.core.logging import logger
+from airweave.core.redis_factory import get_socket_keepalive_options, make_redis_client
 
 
 class RedisClient:
@@ -32,49 +30,21 @@ class RedisClient:
             self._pubsub_client = self._create_client(max_connections=100)
         return self._pubsub_client
 
-    def _get_socket_keepalive_options(self) -> dict:
-        """Get socket keepalive options based on the OS.
-
-        Returns empty dict for macOS to avoid socket option errors.
-        Returns proper TCP keepalive settings for Linux.
-        """
-        if platform.system() == "Darwin":  # macOS
-            return {}
-        else:  # Linux and others
-            # Use the correct Linux TCP keepalive constants
-            # TCP_KEEPIDLE = 4
-            # TCP_KEEPINTVL = 5
-            # TCP_KEEPCNT = 6
-
-            if hasattr(socket, "TCP_KEEPIDLE"):
-                return {
-                    socket.TCP_KEEPIDLE: 60,  # Start keepalive after 60s idle
-                    socket.TCP_KEEPINTVL: 10,  # Interval between keepalive probes
-                    socket.TCP_KEEPCNT: 6,  # Number of keepalive probes
-                }
-            else:
-                # Fallback for systems without these constants
-                return {}
-
     def _create_client(self, max_connections: int = 50) -> redis.Redis:
-        """Create a Redis client with specified connection pool size."""
-        # Create connection pool with proper configuration
-        pool = redis.ConnectionPool(
-            host=settings.REDIS_HOST,
-            port=settings.REDIS_PORT,
-            db=settings.REDIS_DB,
-            password=settings.REDIS_PASSWORD if settings.REDIS_PASSWORD else None,
-            decode_responses=True,
+        """Create a Redis client using the shared factory.
+
+        Honours single-host vs. Sentinel mode based on settings — see
+        ``airweave.core.redis_factory.make_redis_client``.
+        """
+        return make_redis_client(
             max_connections=max_connections,
             retry_on_timeout=True,
             socket_keepalive=True,
-            socket_keepalive_options=self._get_socket_keepalive_options(),
-            socket_connect_timeout=5,  # Add connection timeout
-            socket_timeout=5,  # Add socket timeout
-            retry_on_error=[ConnectionError, TimeoutError],  # Retry on these errors
+            socket_keepalive_options=get_socket_keepalive_options(),
+            socket_connect_timeout=5,
+            socket_timeout=5,
+            retry_on_error=[ConnectionError, TimeoutError],
         )
-
-        return redis.Redis(connection_pool=pool)
 
     async def publish(self, channel: str, message: str) -> int:
         """Publish a message to a channel.

--- a/backend/airweave/core/redis_factory.py
+++ b/backend/airweave/core/redis_factory.py
@@ -20,8 +20,8 @@ import platform
 import socket
 from typing import Any
 
-import redis.asyncio as redis
-from redis.asyncio.sentinel import Sentinel
+import redis.asyncio as redis  # type: ignore[import-untyped]
+from redis.asyncio.sentinel import Sentinel  # type: ignore[import-untyped]
 
 from airweave.core.config import settings
 
@@ -53,9 +53,7 @@ def _parse_sentinel_nodes(raw: str) -> list[tuple[str, int]]:
             or not isinstance(entry[0], str)
             or not isinstance(entry[1], (int, str))
         ):
-            raise ValueError(
-                f"REDIS_NODES entries must be [host, port], got: {entry!r}"
-            )
+            raise ValueError(f"REDIS_NODES entries must be [host, port], got: {entry!r}")
         host, port = entry
         nodes.append((host, int(port)))
     return nodes
@@ -106,6 +104,8 @@ def make_redis_client(
     password = settings.REDIS_PASSWORD or None
 
     if is_sentinel_mode():
+        assert settings.REDIS_NODES is not None
+        assert settings.REDIS_SERVICE_NAME is not None
         nodes = _parse_sentinel_nodes(settings.REDIS_NODES)
         # Pull connection-tuning kwargs out of ``extra`` so we can forward them
         # to both the Sentinel itself (for sentinel-discovery RPCs) and to the

--- a/backend/airweave/core/redis_factory.py
+++ b/backend/airweave/core/redis_factory.py
@@ -1,0 +1,140 @@
+"""Redis client factory with Sentinel support.
+
+Centralises Redis client construction so that both the main connection pool
+(``core/redis_client.py``) and long-lived pubsub connections
+(``adapters/pubsub/redis.py``) pick the same backend based on configuration.
+
+Two modes are supported:
+
+- **Single-host** (default): ``REDIS_HOST`` / ``REDIS_PORT`` are used directly.
+- **Sentinel**: when ``REDIS_NODES`` and ``REDIS_SERVICE_NAME`` are both set,
+  a ``redis.asyncio.sentinel.Sentinel`` instance is built from the node list
+  and the current master is discovered via ``master_for(...)``. ``REDIS_HOST``
+  and ``REDIS_PORT`` are ignored.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import socket
+from typing import Any
+
+import redis.asyncio as redis
+from redis.asyncio.sentinel import Sentinel
+
+from airweave.core.config import settings
+
+
+def is_sentinel_mode() -> bool:
+    """Return True when both ``REDIS_NODES`` and ``REDIS_SERVICE_NAME`` are set."""
+    return bool(settings.REDIS_NODES) and bool(settings.REDIS_SERVICE_NAME)
+
+
+def _parse_sentinel_nodes(raw: str) -> list[tuple[str, int]]:
+    """Parse the ``REDIS_NODES`` JSON string into a list of ``(host, port)`` tuples."""
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"REDIS_NODES must be a JSON list of [host, port] pairs, got: {raw!r}"
+        ) from exc
+
+    if not isinstance(parsed, list) or not parsed:
+        raise ValueError(
+            f"REDIS_NODES must be a non-empty JSON list of [host, port] pairs, got: {raw!r}"
+        )
+
+    nodes: list[tuple[str, int]] = []
+    for entry in parsed:
+        if (
+            not isinstance(entry, (list, tuple))
+            or len(entry) != 2
+            or not isinstance(entry[0], str)
+            or not isinstance(entry[1], (int, str))
+        ):
+            raise ValueError(
+                f"REDIS_NODES entries must be [host, port], got: {entry!r}"
+            )
+        host, port = entry
+        nodes.append((host, int(port)))
+    return nodes
+
+
+def get_socket_keepalive_options() -> dict[int, int]:
+    """Return TCP keepalive options that work on the current OS.
+
+    macOS does not support the Linux keepalive constants and will raise if they
+    are passed to ``setsockopt``. We return an empty dict there and on any
+    Linux system that does not expose ``TCP_KEEPIDLE``.
+    """
+    if platform.system() == "Darwin":
+        return {}
+    if not hasattr(socket, "TCP_KEEPIDLE"):
+        return {}
+    return {
+        socket.TCP_KEEPIDLE: 60,
+        socket.TCP_KEEPINTVL: 10,
+        socket.TCP_KEEPCNT: 6,
+    }
+
+
+def make_redis_client(
+    *,
+    db: int | None = None,
+    max_connections: int = 50,
+    decode_responses: bool = True,
+    **extra: Any,
+) -> redis.Redis:
+    """Build an async Redis client honouring the configured connection mode.
+
+    Args:
+        db: Database index. Defaults to ``settings.REDIS_DB``.
+        max_connections: Connection pool size for both modes.
+        decode_responses: Whether to decode responses to ``str``.
+        **extra: Forwarded to the underlying ``Redis`` / ``ConnectionPool``
+            constructor (e.g. ``socket_keepalive``, ``socket_timeout``,
+            ``retry_on_error``).
+
+    Returns:
+        A connected (or lazily-connecting) ``redis.asyncio.Redis`` instance.
+        In Sentinel mode the returned client transparently re-discovers the
+        master after a failover.
+    """
+    if db is None:
+        db = settings.REDIS_DB
+    password = settings.REDIS_PASSWORD or None
+
+    if is_sentinel_mode():
+        nodes = _parse_sentinel_nodes(settings.REDIS_NODES)
+        # Pull connection-tuning kwargs out of ``extra`` so we can forward them
+        # to both the Sentinel itself (for sentinel-discovery RPCs) and to the
+        # master pool that ``master_for`` builds.
+        sentinel_kwargs = {
+            "socket_connect_timeout": extra.get("socket_connect_timeout", 5),
+            "socket_timeout": extra.get("socket_timeout", 5),
+        }
+        sentinel = Sentinel(
+            nodes,
+            password=password,
+            **sentinel_kwargs,
+        )
+        return sentinel.master_for(
+            settings.REDIS_SERVICE_NAME,
+            db=db,
+            password=password,
+            decode_responses=decode_responses,
+            max_connections=max_connections,
+            **extra,
+        )
+
+    pool = redis.ConnectionPool(
+        host=settings.REDIS_HOST,
+        port=settings.REDIS_PORT,
+        db=db,
+        password=password,
+        decode_responses=decode_responses,
+        max_connections=max_connections,
+        **extra,
+    )
+    return redis.Redis(connection_pool=pool)

--- a/backend/tests/unit/core/test_redis_factory.py
+++ b/backend/tests/unit/core/test_redis_factory.py
@@ -1,0 +1,149 @@
+"""Tests for ``airweave.core.redis_factory``."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from airweave.core import redis_factory
+
+
+class TestIsSentinelMode:
+    def test_returns_false_when_neither_is_set(self):
+        with patch.object(redis_factory.settings, "REDIS_NODES", None), \
+             patch.object(redis_factory.settings, "REDIS_SERVICE_NAME", None):
+            assert redis_factory.is_sentinel_mode() is False
+
+    def test_returns_false_when_only_nodes_set(self):
+        with patch.object(redis_factory.settings, "REDIS_NODES", '[["h", 26379]]'), \
+             patch.object(redis_factory.settings, "REDIS_SERVICE_NAME", None):
+            assert redis_factory.is_sentinel_mode() is False
+
+    def test_returns_false_when_only_service_name_set(self):
+        with patch.object(redis_factory.settings, "REDIS_NODES", None), \
+             patch.object(redis_factory.settings, "REDIS_SERVICE_NAME", "mymaster"):
+            assert redis_factory.is_sentinel_mode() is False
+
+    def test_returns_true_when_both_set(self):
+        with patch.object(redis_factory.settings, "REDIS_NODES", '[["h", 26379]]'), \
+             patch.object(redis_factory.settings, "REDIS_SERVICE_NAME", "mymaster"):
+            assert redis_factory.is_sentinel_mode() is True
+
+
+class TestParseSentinelNodes:
+    def test_parses_valid_list(self):
+        raw = '[["host-0", 26379], ["host-1", 26379]]'
+        assert redis_factory._parse_sentinel_nodes(raw) == [
+            ("host-0", 26379),
+            ("host-1", 26379),
+        ]
+
+    def test_coerces_string_port_to_int(self):
+        raw = '[["host-0", "26379"]]'
+        assert redis_factory._parse_sentinel_nodes(raw) == [("host-0", 26379)]
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "not json",
+            "[]",
+            '[["host-0"]]',
+            '[["host-0", 26379, "extra"]]',
+            "[[123, 26379]]",
+            '"a string"',
+        ],
+    )
+    def test_rejects_invalid_payloads(self, raw):
+        with pytest.raises(ValueError):
+            redis_factory._parse_sentinel_nodes(raw)
+
+
+class TestMakeRedisClient:
+    def test_single_host_mode_builds_connection_pool(self):
+        fake_pool = MagicMock(name="ConnectionPool")
+        fake_redis_cls = MagicMock(name="Redis")
+        with patch.object(redis_factory.settings, "REDIS_NODES", None), \
+             patch.object(redis_factory.settings, "REDIS_SERVICE_NAME", None), \
+             patch.object(redis_factory.settings, "REDIS_HOST", "localhost"), \
+             patch.object(redis_factory.settings, "REDIS_PORT", 6379), \
+             patch.object(redis_factory.settings, "REDIS_PASSWORD", "secret"), \
+             patch.object(redis_factory.settings, "REDIS_DB", 3), \
+             patch.object(redis_factory.redis, "ConnectionPool", return_value=fake_pool), \
+             patch.object(redis_factory.redis, "Redis", fake_redis_cls), \
+             patch.object(redis_factory, "Sentinel") as fake_sentinel_cls:
+            redis_factory.make_redis_client(max_connections=42)
+
+            fake_sentinel_cls.assert_not_called()
+            redis_factory.redis.ConnectionPool.assert_called_once_with(
+                host="localhost",
+                port=6379,
+                db=3,
+                password="secret",
+                decode_responses=True,
+                max_connections=42,
+            )
+            fake_redis_cls.assert_called_once_with(connection_pool=fake_pool)
+
+    def test_single_host_mode_forwards_extra_kwargs(self):
+        with patch.object(redis_factory.settings, "REDIS_NODES", None), \
+             patch.object(redis_factory.settings, "REDIS_SERVICE_NAME", None), \
+             patch.object(redis_factory.settings, "REDIS_HOST", "localhost"), \
+             patch.object(redis_factory.settings, "REDIS_PORT", 6379), \
+             patch.object(redis_factory.settings, "REDIS_PASSWORD", None), \
+             patch.object(redis_factory.settings, "REDIS_DB", 0), \
+             patch.object(redis_factory.redis, "ConnectionPool") as pool_cls, \
+             patch.object(redis_factory.redis, "Redis"):
+            redis_factory.make_redis_client(
+                socket_timeout=7,
+                retry_on_timeout=True,
+            )
+            kwargs = pool_cls.call_args.kwargs
+            assert kwargs["socket_timeout"] == 7
+            assert kwargs["retry_on_timeout"] is True
+            assert kwargs["password"] is None
+
+    def test_sentinel_mode_uses_sentinel_master_for(self):
+        fake_master = MagicMock(name="MasterClient")
+        sentinel_instance = MagicMock(name="SentinelInstance")
+        sentinel_instance.master_for.return_value = fake_master
+        with patch.object(
+            redis_factory.settings, "REDIS_NODES",
+            '[["sentinel-0", 26379], ["sentinel-1", 26379]]',
+        ), patch.object(redis_factory.settings, "REDIS_SERVICE_NAME", "mymaster"), \
+             patch.object(redis_factory.settings, "REDIS_PASSWORD", "secret"), \
+             patch.object(redis_factory.settings, "REDIS_DB", 5), \
+             patch.object(redis_factory, "Sentinel", return_value=sentinel_instance) as sentinel_cls, \
+             patch.object(redis_factory.redis, "ConnectionPool") as pool_cls:
+            result = redis_factory.make_redis_client(
+                max_connections=10, socket_timeout=8
+            )
+
+            pool_cls.assert_not_called()
+            sentinel_cls.assert_called_once_with(
+                [("sentinel-0", 26379), ("sentinel-1", 26379)],
+                password="secret",
+                socket_connect_timeout=5,
+                socket_timeout=8,
+            )
+            sentinel_instance.master_for.assert_called_once_with(
+                "mymaster",
+                db=5,
+                password="secret",
+                decode_responses=True,
+                max_connections=10,
+                socket_timeout=8,
+            )
+            assert result is fake_master
+
+    def test_db_override_takes_precedence_over_settings(self):
+        with patch.object(redis_factory.settings, "REDIS_NODES", None), \
+             patch.object(redis_factory.settings, "REDIS_SERVICE_NAME", None), \
+             patch.object(redis_factory.settings, "REDIS_HOST", "localhost"), \
+             patch.object(redis_factory.settings, "REDIS_PORT", 6379), \
+             patch.object(redis_factory.settings, "REDIS_PASSWORD", None), \
+             patch.object(redis_factory.settings, "REDIS_DB", 0), \
+             patch.object(redis_factory.redis, "ConnectionPool") as pool_cls, \
+             patch.object(redis_factory.redis, "Redis"):
+            redis_factory.make_redis_client(db=11)
+            assert pool_cls.call_args.kwargs["db"] == 11


### PR DESCRIPTION
The Redis client and pubsub adapter previously only accepted a single host/port pair. In HA deployments using Redis Sentinel (e.g. Bitnami's chart with `architecture=replication`), there is no stable master service to point `REDIS_HOST` at — the master can move between nodes on failover and clients must discover it via Sentinel.

This change adds an opt-in Sentinel mode via two new settings:

  REDIS_NODES         JSON list of [host, port] sentinel nodes,
                      e.g. '[["redis-node-0", 26379], ["redis-node-1", 26379]]'
  REDIS_SERVICE_NAME  the master name registered with Sentinel (e.g. "mymaster")

When both are set, the new `redis_factory.make_redis_client(...)` uses `redis.asyncio.sentinel.Sentinel(...).master_for(...)` to discover the current master and transparently reconnects after a failover. Otherwise, behaviour is identical to before (single `REDIS_HOST`/`REDIS_PORT` pool).

The pubsub adapter is also routed through the same factory, replacing the hand-rolled `redis.from_url(...)` path that could not express a Sentinel connection.

Assisted-by: Mistral-Vibe:Foundry-Opus-4.7