### PR TITLE
Fix expired OAuth token loading for refresh

### DIFF
--- a/backend/airweave/domains/source_connections/create.py
+++ b/backend/airweave/domains/source_connections/create.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import secrets
+from datetime import datetime, timezone
 from typing import Any, Optional
 from uuid import UUID
 
@@ -28,7 +29,9 @@ from airweave.domains.source_connections.protocols import (
     SourceConnectionRepositoryProtocol,
 )
 from airweave.domains.sources.exceptions import SourceError, SourceNotFoundError
-from airweave.domains.sources.http_translation import http_exception_for_credential_validation
+from airweave.domains.sources.http_translation import (
+    http_exception_for_credential_validation,
+)
 from airweave.domains.sources.protocols import (
     SourceLifecycleServiceProtocol,
     SourceRegistryProtocol,
@@ -58,6 +61,15 @@ from airweave.schemas.source_connection import (
 def _default_redirect_url(readable_collection_id: str) -> str:
     """Return the default post-OAuth redirect URL for a collection."""
     return f"{settings.app_url}/collections/{readable_collection_id}"
+
+
+def _is_expired(expires_at: Optional[datetime]) -> bool:
+    """Return True when an OAuth token expiry is in the past."""
+    if expires_at is None:
+        return False
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return expires_at < datetime.now(timezone.utc)
 
 
 class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
@@ -109,7 +121,10 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
         auth_method = self._determine_auth_method(obj_in)
         self._validate_auth_compatibility(source_class, entry.short_name, auth_method)
 
-        if source_class.requires_byoc and auth_method == AuthenticationMethod.OAUTH_BROWSER:
+        if (
+            source_class.requires_byoc
+            and auth_method == AuthenticationMethod.OAUTH_BROWSER
+        ):
             raise HTTPException(
                 status_code=400,
                 detail=(
@@ -124,7 +139,10 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
                 AuthenticationMethod.OAUTH_BYOC,
             )
 
-        if auth_method in (AuthenticationMethod.OAUTH_BROWSER, AuthenticationMethod.OAUTH_BYOC):
+        if auth_method in (
+            AuthenticationMethod.OAUTH_BROWSER,
+            AuthenticationMethod.OAUTH_BYOC,
+        ):
             if obj_in.sync_immediately:
                 raise HTTPException(
                     status_code=400,
@@ -178,7 +196,9 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
         source_conn = await self._sc_repo.get(db, id=id, ctx=ctx)
         if not source_conn:
             raise NotFoundException("Source connection not found")
-        if source_conn.is_authenticated and not await self._has_credential_error(db, source_conn):
+        if source_conn.is_authenticated and not await self._has_credential_error(
+            db, source_conn
+        ):
             raise HTTPException(
                 status_code=400,
                 detail="Connection is already authenticated",
@@ -303,13 +323,22 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
         """Check if the last sync job for this connection has a credential error."""
         if not source_conn.sync_id:
             return False
-        job = await self._sync_job_repo.get_latest_by_sync_id(db, sync_id=source_conn.sync_id)
+        job = await self._sync_job_repo.get_latest_by_sync_id(
+            db, sync_id=source_conn.sync_id
+        )
         return job is not None and job.error_category is not None
 
     async def _create_with_direct_auth(
-        self, db: AsyncSession, *, obj_in: SourceConnectionCreate, entry, ctx: ApiContext
+        self,
+        db: AsyncSession,
+        *,
+        obj_in: SourceConnectionCreate,
+        entry,
+        ctx: ApiContext,
     ) -> SourceConnectionSchema:
-        if not obj_in.authentication or not isinstance(obj_in.authentication, DirectAuthentication):
+        if not obj_in.authentication or not isinstance(
+            obj_in.authentication, DirectAuthentication
+        ):
             raise HTTPException(
                 status_code=400, detail="Direct authentication requires credentials"
             )
@@ -348,12 +377,27 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
         )
 
     async def _create_with_oauth_token(
-        self, db: AsyncSession, *, obj_in: SourceConnectionCreate, entry, ctx: ApiContext
+        self,
+        db: AsyncSession,
+        *,
+        obj_in: SourceConnectionCreate,
+        entry,
+        ctx: ApiContext,
     ) -> SourceConnectionSchema:
         if not obj_in.authentication or not isinstance(
             obj_in.authentication, OAuthTokenAuthentication
         ):
-            raise HTTPException(status_code=400, detail="OAuth token authentication requires token")
+            raise HTTPException(
+                status_code=400, detail="OAuth token authentication requires token"
+            )
+        if _is_expired(obj_in.authentication.expires_at):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "OAuth access token has already expired; "
+                    "refresh it before creating the connection"
+                ),
+            )
 
         validated_config = self._source_validation.validate_config(
             obj_in.short_name, obj_in.config, ctx
@@ -388,7 +432,12 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
         )
 
     async def _create_with_auth_provider(
-        self, db: AsyncSession, *, obj_in: SourceConnectionCreate, entry, ctx: ApiContext
+        self,
+        db: AsyncSession,
+        *,
+        obj_in: SourceConnectionCreate,
+        entry,
+        ctx: ApiContext,
     ) -> SourceConnectionSchema:
         if not obj_in.authentication or not isinstance(
             obj_in.authentication, AuthProviderAuthentication
@@ -419,9 +468,11 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
 
         validated_auth_provider_config = None
         if obj_in.authentication.provider_config is not None:
-            validated_auth_provider_config = self._auth_provider_service.validate_provider_config(
-                auth_provider_conn.short_name,
-                obj_in.authentication.provider_config,
+            validated_auth_provider_config = (
+                self._auth_provider_service.validate_provider_config(
+                    auth_provider_conn.short_name,
+                    obj_in.authentication.provider_config,
+                )
             )
 
         validated_config = self._source_validation.validate_config(
@@ -431,7 +482,9 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
         collection_schema: Optional[schemas.CollectionRecord] = None
 
         async with UnitOfWork(db) as uow:
-            collection = await self._get_collection(uow.session, obj_in.readable_collection_id, ctx)
+            collection = await self._get_collection(
+                uow.session, obj_in.readable_collection_id, ctx
+            )
             collection_schema = schemas.CollectionRecord.model_validate(
                 collection, from_attributes=True
             )
@@ -444,14 +497,18 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
                 uow=uow,
             )
             await uow.session.flush()
-            connection_schema = schemas.Connection.model_validate(connection, from_attributes=True)
+            connection_schema = schemas.Connection.model_validate(
+                connection, from_attributes=True
+            )
 
             has_schedule = obj_in.schedule is None or (
                 obj_in.schedule and obj_in.schedule.cron is not None
             )
             sync_result = None
             if bool(obj_in.sync_immediately) or has_schedule:
-                destination_ids = await self._sync_service.resolve_destination_ids(uow.session, ctx)
+                destination_ids = await self._sync_service.resolve_destination_ids(
+                    uow.session, ctx
+                )
                 sync_result = await self._sync_service.create(
                     uow.session,
                     name=obj_in.name or entry.name,
@@ -502,11 +559,18 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
         return response
 
     async def _create_with_oauth_browser(
-        self, db: AsyncSession, *, obj_in: SourceConnectionCreate, entry, ctx: ApiContext
+        self,
+        db: AsyncSession,
+        *,
+        obj_in: SourceConnectionCreate,
+        entry,
+        ctx: ApiContext,
     ) -> SourceConnectionSchema:
         auth = obj_in.authentication
         if auth is not None and not isinstance(auth, OAuthBrowserAuthentication):
-            raise HTTPException(status_code=400, detail="OAuth browser authentication expected")
+            raise HTTPException(
+                status_code=400, detail="OAuth browser authentication expected"
+            )
 
         oauth_auth = auth if auth is not None else OAuthBrowserAuthentication()
         validated_config = self._source_validation.validate_config(
@@ -537,7 +601,9 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
         provider_auth_url = initiation_result.provider_auth_url
 
         async with UnitOfWork(db) as uow:
-            collection = await self._get_collection(uow.session, obj_in.readable_collection_id, ctx)
+            collection = await self._get_collection(
+                uow.session, obj_in.readable_collection_id, ctx
+            )
             source_conn = await self._sc_repo.create(
                 uow.session,
                 obj_in={
@@ -631,7 +697,9 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
         connection_schema: Optional[schemas.Connection] = None
         collection_schema: Optional[schemas.CollectionRecord] = None
         async with UnitOfWork(db) as uow:
-            collection = await self._get_collection(uow.session, obj_in.readable_collection_id, ctx)
+            collection = await self._get_collection(
+                uow.session, obj_in.readable_collection_id, ctx
+            )
             collection_schema = schemas.CollectionRecord.model_validate(
                 collection, from_attributes=True
             )
@@ -642,7 +710,9 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
                 auth_payload=credential_payload,
                 auth_method=auth_method,
                 oauth_type=entry.oauth_type,
-                auth_config_name=entry.auth_config_ref.__name__ if entry.auth_config_ref else None,
+                auth_config_name=(
+                    entry.auth_config_ref.__name__ if entry.auth_config_ref else None
+                ),
                 ctx=ctx,
                 uow=uow,
             )
@@ -656,14 +726,18 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
                 uow=uow,
             )
             await uow.session.flush()
-            connection_schema = schemas.Connection.model_validate(connection, from_attributes=True)
+            connection_schema = schemas.Connection.model_validate(
+                connection, from_attributes=True
+            )
 
             has_schedule = obj_in.schedule is None or (
                 obj_in.schedule and obj_in.schedule.cron is not None
             )
             sync_result = None
             if bool(obj_in.sync_immediately) or has_schedule:
-                destination_ids = await self._sync_service.resolve_destination_ids(uow.session, ctx)
+                destination_ids = await self._sync_service.resolve_destination_ids(
+                    uow.session, ctx
+                )
                 sync_result = await self._sync_service.create(
                     uow.session,
                     name=obj_in.name or entry.name,
@@ -760,9 +834,13 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
             integration_credential_id=credential_id,
             short_name=short_name,
         )
-        return await self._connection_repo.create(db, obj_in=connection_in, ctx=ctx, uow=uow)
+        return await self._connection_repo.create(
+            db, obj_in=connection_in, ctx=ctx, uow=uow
+        )
 
-    async def _get_collection(self, db: AsyncSession, readable_id: str, ctx: ApiContext):
+    async def _get_collection(
+        self, db: AsyncSession, readable_id: str, ctx: ApiContext
+    ):
         collection = await self._collection_repo.get_by_readable_id(
             db, readable_id=readable_id, ctx=ctx
         )
@@ -774,7 +852,9 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
         try:
             return self._source_registry.get(short_name)
         except KeyError as exc:
-            raise HTTPException(status_code=404, detail=f"Source '{short_name}' not found") from exc
+            raise HTTPException(
+                status_code=404, detail=f"Source '{short_name}' not found"
+            ) from exc
 
     @staticmethod
     def _determine_auth_method(obj_in: SourceConnectionCreate) -> AuthenticationMethod:
@@ -795,7 +875,9 @@ class SourceConnectionCreationService(SourceConnectionCreateServiceProtocol):
                     return AuthenticationMethod.OAUTH_BYOC
                 return AuthenticationMethod.OAUTH_BROWSER
             case _:
-                raise HTTPException(status_code=400, detail="Invalid authentication configuration")
+                raise HTTPException(
+                    status_code=400, detail="Invalid authentication configuration"
+                )
 
     @staticmethod
     def _validate_auth_compatibility(

--- a/backend/airweave/domains/source_connections/tests/test_create.py
+++ b/backend/airweave/domains/source_connections/tests/test_create.py
@@ -19,7 +19,9 @@ from airweave.domains.credentials.fakes.service import FakeIntegrationCredential
 from airweave.domains.oauth.fakes.flow_service import FakeOAuthFlowService
 from airweave.domains.oauth.types import OAuthBrowserInitiationResult
 from airweave.domains.source_connections.create import SourceConnectionCreationService
-from airweave.domains.source_connections.fakes.repository import FakeSourceConnectionRepository
+from airweave.domains.source_connections.fakes.repository import (
+    FakeSourceConnectionRepository,
+)
 from airweave.domains.source_connections.fakes.response import FakeResponseBuilder
 from airweave.domains.sources.exceptions import SourceValidationError
 from airweave.domains.sources.fakes.lifecycle import FakeSourceLifecycleService
@@ -42,7 +44,9 @@ NOW = datetime.now(timezone.utc)
 
 
 def _ctx() -> ApiContext:
-    org = Organization(id=str(uuid4()), name="Test Org", created_at=NOW, modified_at=NOW)
+    org = Organization(
+        id=str(uuid4()), name="Test Org", created_at=NOW, modified_at=NOW
+    )
     return ApiContext(
         request_id="test-req",
         organization=org,
@@ -252,7 +256,9 @@ async def test_create_rejects_missing_byoc_for_required_source():
 async def test_create_oauth2_init_session_contract(monkeypatch):
     entry = _entry(oauth_type="access_only")
     svc = _service(entry)
-    svc._source_validation.validate_config = MagicMock(return_value={"instance_url": "acme"})
+    svc._source_validation.validate_config = MagicMock(
+        return_value={"instance_url": "acme"}
+    )
     svc._extract_template_configs = MagicMock(return_value={"instance_url": "acme"})
     svc._collection_repo.seed_readable("col-1", MagicMock(readable_id="col-1"))
     svc._oauth_flow_service.seed_initiate_browser_flow_result(
@@ -265,9 +271,13 @@ async def test_create_oauth2_init_session_contract(monkeypatch):
         )
     )
 
-    shell_sc = MagicMock(id=uuid4(), connection_init_session_id=None, is_authenticated=False)
+    shell_sc = MagicMock(
+        id=uuid4(), connection_init_session_id=None, is_authenticated=False
+    )
     svc._sc_repo.create = AsyncMock(return_value=shell_sc)
-    svc._response_builder.build_response = AsyncMock(return_value=MagicMock(id=shell_sc.id))
+    svc._response_builder.build_response = AsyncMock(
+        return_value=MagicMock(id=shell_sc.id)
+    )
 
     from airweave.domains.source_connections import create as create_module
 
@@ -316,9 +326,13 @@ async def test_create_oauth1_init_session_contract(monkeypatch):
     svc = _service(entry)
     svc._source_validation.validate_config = MagicMock(return_value={})
     svc._collection_repo.seed_readable("col-1", MagicMock(readable_id="col-1"))
-    shell_sc = MagicMock(id=uuid4(), connection_init_session_id=None, is_authenticated=False)
+    shell_sc = MagicMock(
+        id=uuid4(), connection_init_session_id=None, is_authenticated=False
+    )
     svc._sc_repo.create = AsyncMock(return_value=shell_sc)
-    svc._response_builder.build_response = AsyncMock(return_value=MagicMock(id=shell_sc.id))
+    svc._response_builder.build_response = AsyncMock(
+        return_value=MagicMock(id=shell_sc.id)
+    )
     svc._oauth_flow_service.seed_initiate_browser_flow_result(
         OAuthBrowserInitiationResult(
             provider_auth_url="https://provider/oauth1-auth",
@@ -389,7 +403,9 @@ def test_determine_auth_method_rejects_unknown_auth_shape():
 
 def test_determine_auth_method_variants():
     assert (
-        SourceConnectionCreationService._determine_auth_method(SimpleNamespace(authentication=None))
+        SourceConnectionCreationService._determine_auth_method(
+            SimpleNamespace(authentication=None)
+        )
         == AuthenticationMethod.OAUTH_BROWSER
     )
     assert (
@@ -406,14 +422,18 @@ def test_determine_auth_method_variants():
     )
     assert (
         SourceConnectionCreationService._determine_auth_method(
-            SimpleNamespace(authentication=AuthProviderAuthentication(provider_readable_id="p1"))
+            SimpleNamespace(
+                authentication=AuthProviderAuthentication(provider_readable_id="p1")
+            )
         )
         == AuthenticationMethod.AUTH_PROVIDER
     )
     assert (
         SourceConnectionCreationService._determine_auth_method(
             SimpleNamespace(
-                authentication=OAuthBrowserAuthentication(client_id="c", client_secret="s")
+                authentication=OAuthBrowserAuthentication(
+                    client_id="c", client_secret="s"
+                )
             )
         )
         == AuthenticationMethod.OAUTH_BYOC
@@ -454,7 +474,9 @@ async def test_trigger_sync_workflow_returns_early_without_sync_job():
     svc = _service(_entry())
     svc._event_bus.publish = AsyncMock()
     svc._temporal_workflow_service.run_source_connection_workflow = AsyncMock()
-    sync_result = SimpleNamespace(sync_job=None, sync_id=uuid4(), sync=SimpleNamespace(id=uuid4()))
+    sync_result = SimpleNamespace(
+        sync_job=None, sync_id=uuid4(), sync=SimpleNamespace(id=uuid4())
+    )
 
     await svc._trigger_sync_workflow(
         connection=SimpleNamespace(short_name="github"),
@@ -493,7 +515,10 @@ def test_extract_template_configs_maps_validation_error_to_http_422():
 
 def test_extract_template_configs_returns_none_for_missing_config_ref():
     entry = SimpleNamespace(config_ref=None)
-    assert SourceConnectionCreationService._extract_template_configs(entry, {"a": 1}) is None
+    assert (
+        SourceConnectionCreationService._extract_template_configs(entry, {"a": 1})
+        is None
+    )
 
 
 def test_extract_template_configs_returns_none_when_template_fields_empty():
@@ -503,7 +528,10 @@ def test_extract_template_configs_returns_none_when_template_fields_empty():
             return []
 
     entry = SimpleNamespace(config_ref=_Config)
-    assert SourceConnectionCreationService._extract_template_configs(entry, {"a": 1}) is None
+    assert (
+        SourceConnectionCreationService._extract_template_configs(entry, {"a": 1})
+        is None
+    )
 
 
 def test_validate_auth_compatibility_raises_with_supported_methods():
@@ -541,7 +569,9 @@ async def test_create_with_oauth_token_requires_token_auth():
     svc = _service(_entry())
     obj_in = SourceConnectionCreate(short_name="github", readable_collection_id="col-1")
     with pytest.raises(HTTPException, match="requires token"):
-        await svc._create_with_oauth_token(AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx())
+        await svc._create_with_oauth_token(
+            AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx()
+        )
 
 
 async def test_create_with_oauth_token_builds_full_payload_and_delegates():
@@ -560,13 +590,40 @@ async def test_create_with_oauth_token_builds_full_payload_and_delegates():
             expires_at=expires,
         ),
     )
-    await svc._create_with_oauth_token(AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx())
+    await svc._create_with_oauth_token(
+        AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx()
+    )
 
     kwargs = svc._create_authenticated_connection.await_args.kwargs
     assert kwargs["credential_payload"]["access_token"] == "tok"
     assert "refresh_token" not in kwargs["credential_payload"]
     assert kwargs["credential_payload"]["expires_at"] == expires.isoformat()
     assert kwargs["auth_method"] == AuthenticationMethod.OAUTH_TOKEN
+
+
+async def test_create_with_oauth_token_rejects_expired_token_before_validation():
+    svc = _service(_entry())
+    svc._source_validation.validate_config = MagicMock(return_value={"cfg": "x"})
+    svc._source_lifecycle.validate = AsyncMock()
+
+    obj_in = SourceConnectionCreate(
+        short_name="github",
+        readable_collection_id="col-1",
+        authentication=OAuthTokenAuthentication(
+            access_token="tok",
+            refresh_token="rtok",
+            expires_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc._create_with_oauth_token(
+            AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx()
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "expired" in exc_info.value.detail
+    svc._source_lifecycle.validate.assert_not_awaited()
 
 
 async def test_create_with_oauth_token_maps_source_validation_error_to_400():
@@ -582,7 +639,9 @@ async def test_create_with_oauth_token_maps_source_validation_error_to_400():
         authentication=OAuthTokenAuthentication(access_token="invalid_token_12345"),
     )
     with pytest.raises(HTTPException) as exc_info:
-        await svc._create_with_oauth_token(AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx())
+        await svc._create_with_oauth_token(
+            AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx()
+        )
 
     assert exc_info.value.status_code == 400
     detail = str(exc_info.value.detail).lower()
@@ -594,7 +653,9 @@ async def test_create_with_auth_provider_requires_provider_auth():
     svc = _service(_entry())
     obj_in = SourceConnectionCreate(short_name="github", readable_collection_id="col-1")
     with pytest.raises(HTTPException, match="requires provider configuration"):
-        await svc._create_with_auth_provider(AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx())
+        await svc._create_with_auth_provider(
+            AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx()
+        )
 
 
 async def test_create_with_auth_provider_not_found():
@@ -606,7 +667,9 @@ async def test_create_with_auth_provider_not_found():
         authentication=AuthProviderAuthentication(provider_readable_id="missing"),
     )
     with pytest.raises(NotFoundException):
-        await svc._create_with_auth_provider(AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx())
+        await svc._create_with_auth_provider(
+            AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx()
+        )
 
 
 async def test_create_with_auth_provider_rejects_unsupported_provider():
@@ -620,7 +683,9 @@ async def test_create_with_auth_provider_rejects_unsupported_provider():
         authentication=AuthProviderAuthentication(provider_readable_id="provider-1"),
     )
     with pytest.raises(HTTPException, match="does not support"):
-        await svc._create_with_auth_provider(AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx())
+        await svc._create_with_auth_provider(
+            AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx()
+        )
 
 
 async def test_create_with_oauth_browser_rejects_non_oauth_browser_auth():
@@ -631,13 +696,20 @@ async def test_create_with_oauth_browser_rejects_non_oauth_browser_auth():
         authentication=DirectAuthentication(credentials={"k": "v"}),
     )
     with pytest.raises(HTTPException, match="OAuth browser authentication expected"):
-        await svc._create_with_oauth_browser(AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx())
+        await svc._create_with_oauth_browser(
+            AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx()
+        )
 
 
 @pytest.mark.parametrize(
     "oauth_type,error,status_code,detail_match",
     [
-        ("oauth1", HTTPException(status_code=400, detail="Source 'github' is not OAuth1"), 400, "is not OAuth1"),
+        (
+            "oauth1",
+            HTTPException(status_code=400, detail="Source 'github' is not OAuth1"),
+            400,
+            "is not OAuth1",
+        ),
         (
             "access_only",
             HTTPException(status_code=400, detail="Source 'github' is not OAuth2"),
@@ -665,7 +737,9 @@ async def test_create_with_oauth_browser_propagates_initiation_errors(
     svc._oauth_flow_service.seed_initiate_browser_flow_error(error)
     obj_in = SourceConnectionCreate(short_name="github", readable_collection_id="col-1")
     with pytest.raises(HTTPException, match=detail_match) as exc_info:
-        await svc._create_with_oauth_browser(AsyncMock(), obj_in=obj_in, entry=entry, ctx=_ctx())
+        await svc._create_with_oauth_browser(
+            AsyncMock(), obj_in=obj_in, entry=entry, ctx=_ctx()
+        )
     assert exc_info.value.status_code == status_code
 
 
@@ -683,21 +757,31 @@ async def test_create_with_oauth_browser_rejects_missing_collection():
             additional_overrides={"code_verifier": "verifier-123"},
         )
     )
-    obj_in = SourceConnectionCreate(short_name="github", readable_collection_id="missing-col")
+    obj_in = SourceConnectionCreate(
+        short_name="github", readable_collection_id="missing-col"
+    )
     with pytest.raises(NotFoundException, match="Collection not found"):
-        await svc._create_with_oauth_browser(AsyncMock(), obj_in=obj_in, entry=entry, ctx=_ctx())
+        await svc._create_with_oauth_browser(
+            AsyncMock(), obj_in=obj_in, entry=entry, ctx=_ctx()
+        )
 
 
 async def test_create_with_direct_auth_requires_direct_auth():
     svc = _service(_entry())
     obj_in = SourceConnectionCreate(short_name="github", readable_collection_id="col-1")
-    with pytest.raises(HTTPException, match="Direct authentication requires credentials"):
-        await svc._create_with_direct_auth(AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx())
+    with pytest.raises(
+        HTTPException, match="Direct authentication requires credentials"
+    ):
+        await svc._create_with_direct_auth(
+            AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx()
+        )
 
 
 async def test_create_with_direct_auth_delegates_to_authenticated_connection():
     svc = _service(_entry())
-    svc._source_validation.validate_auth_schema = MagicMock(return_value=SimpleNamespace(model_dump=lambda: {"k": "v"}))
+    svc._source_validation.validate_auth_schema = MagicMock(
+        return_value=SimpleNamespace(model_dump=lambda: {"k": "v"})
+    )
     svc._source_validation.validate_config = MagicMock(return_value={"cfg": "x"})
     svc._source_lifecycle.validate = AsyncMock()
     expected = MagicMock(id=uuid4())
@@ -708,7 +792,9 @@ async def test_create_with_direct_auth_delegates_to_authenticated_connection():
         readable_collection_id="col-1",
         authentication=DirectAuthentication(credentials={"k": "v"}),
     )
-    result = await svc._create_with_direct_auth(AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx())
+    result = await svc._create_with_direct_auth(
+        AsyncMock(), obj_in=obj_in, entry=_entry(), ctx=_ctx()
+    )
     assert result is expected
 
 
@@ -716,7 +802,11 @@ async def test_create_redirect_session_returns_created_id():
     svc = _service(_entry())
     redirect_id = uuid4()
     svc._oauth_flow_service.create_proxy_url = AsyncMock(
-        return_value=("https://api.example.com/source-connections/authorize/abcd1234", NOW, redirect_id)
+        return_value=(
+            "https://api.example.com/source-connections/authorize/abcd1234",
+            NOW,
+            redirect_id,
+        )
     )
     result = await svc._create_redirect_session(
         AsyncMock(),
@@ -728,12 +818,16 @@ async def test_create_redirect_session_returns_created_id():
 
 
 async def test_create_with_oauth_browser_rejects_partial_custom_credentials():
-    with pytest.raises(ValidationError, match="requires both client_id and client_secret"):
+    with pytest.raises(
+        ValidationError, match="requires both client_id and client_secret"
+    ):
         OAuthBrowserAuthentication(client_id="only-id")
 
 
 async def test_create_with_oauth_browser_rejects_empty_client_secret():
-    with pytest.raises(ValidationError, match="requires both client_id and client_secret"):
+    with pytest.raises(
+        ValidationError, match="requires both client_id and client_secret"
+    ):
         OAuthBrowserAuthentication(client_id="id", client_secret="")
 
 
@@ -751,7 +845,9 @@ async def test_create_with_oauth_browser_sets_platform_default_overrides(monkeyp
         )
     )
     svc._sc_repo.create = AsyncMock(
-        return_value=MagicMock(id=uuid4(), connection_init_session_id=None, is_authenticated=False)
+        return_value=MagicMock(
+            id=uuid4(), connection_init_session_id=None, is_authenticated=False
+        )
     )
     svc._response_builder.build_response = AsyncMock(return_value=MagicMock(id=uuid4()))
 
@@ -803,7 +899,9 @@ async def test_create_with_oauth_browser_sets_byoc_nested_for_oauth1(monkeypatch
         )
     )
     svc._sc_repo.create = AsyncMock(
-        return_value=MagicMock(id=uuid4(), connection_init_session_id=None, is_authenticated=False)
+        return_value=MagicMock(
+            id=uuid4(), connection_init_session_id=None, is_authenticated=False
+        )
     )
     svc._response_builder.build_response = AsyncMock(return_value=MagicMock(id=uuid4()))
 
@@ -831,14 +929,19 @@ async def test_create_with_oauth_browser_sets_byoc_nested_for_oauth1(monkeypatch
     obj_in = SourceConnectionCreate(
         short_name="github",
         readable_collection_id="col-1",
-        authentication=OAuthBrowserAuthentication(consumer_key="ck", consumer_secret="cs"),
+        authentication=OAuthBrowserAuthentication(
+            consumer_key="ck", consumer_secret="cs"
+        ),
     )
-    await svc._create_with_oauth_browser(db, obj_in=obj_in, entry=_entry(oauth_type="oauth1"), ctx=_ctx())
+    await svc._create_with_oauth_browser(
+        db, obj_in=obj_in, entry=_entry(oauth_type="oauth1"), ctx=_ctx()
+    )
 
     kwargs = svc._oauth_flow_service._last_create_init_session_kwargs
     assert kwargs["oauth_client_mode"] == "byoc_nested"
     assert kwargs["client_id"] == "ck"
     assert kwargs["client_secret"] == "cs"
+
 
 async def test_trigger_sync_workflow_publishes_event_before_workflow():
     svc = _service(_entry())
@@ -1065,7 +1168,10 @@ async def test_reinitiate_oauth_preserves_byoc_credentials(monkeypatch):
     svc._sc_repo.seed(sc_id, sc)
 
     # Seed old init session with BYOC credentials
-    from airweave.models.connection_init_session import ConnectionInitSession, ConnectionInitStatus
+    from airweave.models.connection_init_session import (
+        ConnectionInitSession,
+        ConnectionInitStatus,
+    )
 
     old_init = MagicMock(spec=ConnectionInitSession)
     old_init.status = ConnectionInitStatus.PENDING

--- a/backend/airweave/schemas/source_connection.py
+++ b/backend/airweave/schemas/source_connection.py
@@ -6,12 +6,19 @@ This module provides a clean schema hierarchy for source connections:
 - Builder classes with type-safe construction and validation
 """
 
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 
 from airweave.core.shared_models import (
     SourceConnectionErrorCategory,
@@ -89,13 +96,6 @@ class OAuthTokenAuthentication(BaseModel):
             raise ValueError("access_token cannot be empty or whitespace only")
         return v
 
-    @model_validator(mode="after")
-    def validate_token(self):
-        """Validate token is not expired."""
-        if self.expires_at and self.expires_at < datetime.now(timezone.utc):
-            raise ValueError("Token has already expired")
-        return self
-
 
 class OAuthBrowserAuthentication(BaseModel):
     """OAuth authentication via browser flow.
@@ -110,11 +110,17 @@ class OAuthBrowserAuthentication(BaseModel):
     redirect_uri: Optional[str] = Field(None, description="OAuth redirect URI")
 
     # OAuth2 BYOC fields
-    client_id: Optional[str] = Field(None, description="OAuth2 client ID (for custom apps)")
-    client_secret: Optional[str] = Field(None, description="OAuth2 client secret (for custom apps)")
+    client_id: Optional[str] = Field(
+        None, description="OAuth2 client ID (for custom apps)"
+    )
+    client_secret: Optional[str] = Field(
+        None, description="OAuth2 client secret (for custom apps)"
+    )
 
     # OAuth1 BYOC fields
-    consumer_key: Optional[str] = Field(None, description="OAuth1 consumer key (for custom apps)")
+    consumer_key: Optional[str] = Field(
+        None, description="OAuth1 consumer key (for custom apps)"
+    )
     consumer_secret: Optional[str] = Field(
         None, description="OAuth1 consumer secret (for custom apps)"
     )
@@ -132,7 +138,9 @@ class OAuthBrowserAuthentication(BaseModel):
 
         # Validate OAuth2 BYOC
         if bool(self.client_id) != bool(self.client_secret):
-            raise ValueError("OAuth2 BYOC requires both client_id and client_secret or neither")
+            raise ValueError(
+                "OAuth2 BYOC requires both client_id and client_secret or neither"
+            )
 
         # Validate OAuth1 BYOC
         if bool(self.consumer_key) != bool(self.consumer_secret):
@@ -211,7 +219,9 @@ class SourceConnectionCreate(BaseModel):
     config: Optional[Dict[str, Any]] = Field(
         None,
         description="Source-specific configuration (e.g., repository name, filters)",
-        json_schema_extra={"example": {"repo_name": "airweave-ai/airweave", "branch": "main"}},
+        json_schema_extra={
+            "example": {"repo_name": "airweave-ai/airweave", "branch": "main"}
+        },
     )
     schedule: Optional[ScheduleConfig] = Field(
         None,
@@ -310,7 +320,9 @@ class SourceConnectionUpdate(BaseModel):
     config: Optional[Dict[str, Any]] = Field(
         None,
         description="Updated source-specific configuration",
-        json_schema_extra={"example": {"repo_name": "company/new-repo", "branch": "develop"}},
+        json_schema_extra={
+            "example": {"repo_name": "company/new-repo", "branch": "develop"}
+        },
     )
     schedule: Optional[ScheduleConfig] = Field(
         None,
@@ -334,7 +346,9 @@ class SourceConnectionUpdate(BaseModel):
     @model_validator(mode="after")
     def validate_direct_auth(self):
         """Ensure only direct auth can be updated with authentication."""
-        if self.authentication and not isinstance(self.authentication, DirectAuthentication):
+        if self.authentication and not isinstance(
+            self.authentication, DirectAuthentication
+        ):
             raise ValueError("Direct auth can only be updated with authentication")
         return self
 
@@ -347,7 +361,9 @@ class SourceConnectionUpdate(BaseModel):
                 },
                 {
                     "summary": "Update config",
-                    "value": {"config": {"repo_name": "company/new-repo", "branch": "main"}},
+                    "value": {
+                        "config": {"repo_name": "company/new-repo", "branch": "main"}
+                    },
                 },
                 {
                     "summary": "Update schedule",
@@ -749,7 +765,10 @@ class SourceConnection(BaseModel):
                         "entities_updated": 12,
                     },
                 },
-                "entities": {"total_entities": 1250, "by_type": {"file": {"count": 1250}}},
+                "entities": {
+                    "total_entities": 1250,
+                    "by_type": {"file": {"count": 1250}},
+                },
                 "federated_search": False,
             }
         }
@@ -864,7 +883,10 @@ def determine_auth_method(source_conn: Any) -> AuthenticationMethod:
     Determine authentication method from database fields.
     """
     # Auth provider takes precedence
-    if hasattr(source_conn, "readable_auth_provider_id") and source_conn.readable_auth_provider_id:
+    if (
+        hasattr(source_conn, "readable_auth_provider_id")
+        and source_conn.readable_auth_provider_id
+    ):
         return AuthenticationMethod.AUTH_PROVIDER
 
     # Check for pending OAuth

--- a/backend/tests/unit/schemas/test_source_connection_schemas.py
+++ b/backend/tests/unit/schemas/test_source_connection_schemas.py
@@ -1,0 +1,19 @@
+"""Unit tests for source connection schemas."""
+
+from datetime import datetime, timedelta, timezone
+
+from airweave.schemas.source_connection import OAuthTokenAuthentication
+
+
+def test_oauth_token_authentication_accepts_expired_tokens_for_stored_credentials():
+    """Expired stored OAuth tokens must deserialize so refresh logic can run."""
+    expired = datetime.now(timezone.utc) - timedelta(minutes=10)
+
+    auth = OAuthTokenAuthentication(
+        access_token="stored-access-token",
+        refresh_token="stored-refresh-token",
+        expires_at=expired,
+    )
+
+    assert auth.expires_at == expired
+    assert auth.refresh_token == "stored-refresh-token"


### PR DESCRIPTION
## Summary
- Allow OAuthTokenAuthentication to deserialize expired stored tokens so refresh code can inspect and refresh them
- Keep the user-facing creation guard by rejecting expired OAuth-token submissions in SourceConnectionCreationService
- Add regression coverage for stored-token deserialization and OAuth-token connection creation

## Why
Issue #1785 describes a refresh deadlock: once an OAuth access token expires, the Pydantic schema raises before the sync/refresh path can load the credential and call the refresh endpoint. Expiry is still important for brand-new token submissions, but persisted credentials need to be loadable so the refresh path can do its job.

## Verification
- PYTHONPATH=/tmp/airweave-ritwij-contrib/backend /tmp/airweave-backend-venv/bin/python -m pytest backend/tests/unit/schemas/test_source_connection_schemas.py -q
- PYTHONPATH=/tmp/airweave-ritwij-contrib/backend /tmp/airweave-backend-venv/bin/python -m pytest backend/airweave/domains/source_connections/tests/test_create.py -q
- /tmp/airweave-backend-venv/bin/python -m compileall backend/airweave/schemas/source_connection.py backend/airweave/domains/source_connections/create.py backend/tests/unit/schemas/test_source_connection_schemas.py backend/airweave/domains/source_connections/tests/test_create.py
- /tmp/airweave-backend-venv/bin/python -m black --check backend/airweave/schemas/source_connection.py backend/airweave/domains/source_connections/create.py backend/airweave/domains/source_connections/tests/test_create.py backend/tests/unit/schemas/test_source_connection_schemas.py
- git diff --check

Closes #1785

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1785 by allowing expired OAuth tokens to deserialize so the refresh path can run, while still rejecting expired tokens on new connection creation.

- **Bug Fixes**
  - Removed expiry check from `OAuthTokenAuthentication` so stored (expired) tokens load for refresh.
  - Added `_is_expired` and a 400 guard in `SourceConnectionCreationService._create_with_oauth_token` to block creating connections with expired tokens.
  - Added unit tests for expired-token deserialization and create-time rejection.

<sup>Written for commit f4a06f85dc08ba4d449ddf816d0985ec52ec3635. Summary will update on new commits. <a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1797?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

