### PR TITLE
feat(llm): upgrade MiniMax model on Together AI from M2.5 to M2.7

### DIFF
--- a/backend/airweave/adapters/llm/registry.py
+++ b/backend/airweave/adapters/llm/registry.py
@@ -45,7 +45,7 @@ class LLMModel(str, Enum):
     QWEN_3_5 = "qwen-3.5"
     QWEN_3_5_DEDICATED = "qwen-3.5-dedicated"
     ZAI_GLM_5_DEDICATED = "zai-glm-5-dedicated"
-    MINIMAX_M2_5 = "minimax-m2.5"
+    MINIMAX_M2_7 = "minimax-m2.7"
     MISTRAL_LARGE = "mistral-large"
     MISTRAL_SMALL = "mistral-small"
     MAGISTRAL_SMALL = "magistral-small"
@@ -197,10 +197,10 @@ MODEL_REGISTRY: dict[LLMProvider, dict[LLMModel, LLMModelSpec]] = {
             input_price_factor=0.6,
             output_price_factor=3.6,
         ),
-        # ── MiniMax M2.5 ──────────────────────────────────────────
-        LLMModel.MINIMAX_M2_5: LLMModelSpec(
-            api_model_name="MiniMaxAI/MiniMax-M2.5",
-            context_window=192_000,
+        # ── MiniMax M2.7 ──────────────────────────────────────────
+        LLMModel.MINIMAX_M2_7: LLMModelSpec(
+            api_model_name="MiniMaxAI/MiniMax-M2.7",
+            context_window=200_000,
             max_output_tokens=64_000,
             required_tokenizer_type=TokenizerType.TIKTOKEN,
             required_tokenizer_encoding=TokenizerEncoding.O200K_HARMONY,


### PR DESCRIPTION
## Summary

Together AI removed `MiniMaxAI/MiniMax-M2.5` from its serverless catalog and now hosts [`MiniMaxAI/MiniMax-M2.7`](https://www.together.ai/models/minimax-m2-7) instead. Update `MODEL_REGISTRY` so anyone selecting the MiniMax option in `LLM_FALLBACK_CHAIN` continues to hit a live model.

## Changes

- `backend/airweave/adapters/llm/registry.py`
  - Replace `LLMModel.MINIMAX_M2_5` enum (`minimax-m2.5`) with `LLMModel.MINIMAX_M2_7` (`minimax-m2.7`).
  - Repoint the `LLMProvider.TOGETHER` registry entry to `MiniMaxAI/MiniMax-M2.7`, bump `context_window` from 192,000 to 200,000 to match Together's listed M2.7 context window. Pricing factors stay at `$0.30 / $1.20` per 1M input/output tokens (unchanged on Together for M2.7).
  - Thinking configuration unchanged (`reasoning={\"enabled\": ...}` via the existing Together adapter).

## Why

- M2.5 has been delisted from [Together's serverless model catalog](https://docs.together.ai/docs/serverless/models); calls to `MiniMaxAI/MiniMax-M2.5` now fail.
- M2.7 is the current GA MiniMax model on Together (200K context, function-calling, JSON mode, prompt caching at $0.06/1M cached input).
- M3 is announced as ["coming soon to Together's Serverless API"](https://www.together.ai/models/minimax-m3); a follow-up PR can register it once Together makes it generally available.

## Migration

Anyone deploying with `LLM_FALLBACK_CHAIN=together:minimax-m2.5` should update to `together:minimax-m2.7`. The default fallback chain (`together:zai-glm-5,anthropic:claude-sonnet-4.6`) is unaffected.

## Testing

- `python -m py_compile backend/airweave/adapters/llm/registry.py`
- `ruff check backend/airweave/adapters/llm/registry.py`
- `ruff format --check backend/airweave/adapters/llm/registry.py`
- Loaded the registry in isolation and confirmed `get_model_spec(LLMProvider.TOGETHER, LLMModel.MINIMAX_M2_7)` returns the expected `MiniMaxAI/MiniMax-M2.7` spec.
- Existing fallback-chain parser tests remain valid: only the deprecated M2.5 enum is removed, no other model identifiers change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Together MiniMax from M2.5 to M2.7 in the LLM registry to match Together’s catalog and prevent failed requests. Context window increases to 200K; pricing stays the same.

- **Refactors**
  - Replace `LLMModel.MINIMAX_M2_5` with `LLMModel.MINIMAX_M2_7`.
  - Point `LLMProvider.TOGETHER` to `MiniMaxAI/MiniMax-M2.7` with `context_window=200_000`; keep pricing factors unchanged.

- **Migration**
  - If `LLM_FALLBACK_CHAIN` includes `together:minimax-m2.5`, update to `together:minimax-m2.7`.

<sup>Written for commit 44308da3ba16e62da7ae0afb48b9f3ff1cba65c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

