### PR TITLE
Capture replayable sync failure artifacts

### DIFF
--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -125,6 +125,7 @@ from airweave.domains.sources.service import SourceService
 from airweave.domains.sources.validation import SourceValidationService
 from airweave.domains.storage.sync_file_manager import SyncFileManager
 from airweave.domains.sync_pipeline.factory import SyncFactory
+from airweave.domains.sync_pipeline.failure_capture import SyncFailureCapture
 from airweave.domains.sync_pipeline.processors.chunk_embed import ChunkEmbedProcessor
 from airweave.domains.sync_pipeline.subscribers.progress_relay import SyncProgressRelay
 from airweave.domains.syncs.cursors.repository import SyncCursorRepository
@@ -356,16 +357,18 @@ def create_container(settings: Settings) -> Container:
     acl_membership_repo = AccessControlMembershipRepository()
     access_broker = AccessBroker(acl_repo=acl_membership_repo)
     converter_registry = ConverterRegistry(ocr_provider=ocr_provider)
-    chunk_embed_processor = ChunkEmbedProcessor(
-        converter_registry=converter_registry,
-        dense_embedder=dense_embedder,
-        sparse_embedder=sparse_embedder,
-    )
 
     # Storage domain
     # -----------------------------------------------------------------
     storage_backend = _create_storage_backend(settings)
     sync_file_manager = SyncFileManager(backend=storage_backend)
+    failure_capture = SyncFailureCapture(storage=storage_backend)
+    chunk_embed_processor = ChunkEmbedProcessor(
+        converter_registry=converter_registry,
+        dense_embedder=dense_embedder,
+        sparse_embedder=sparse_embedder,
+        failure_capture=failure_capture,
+    )
 
     # ARF domain service (raw entity capture / replay)
     # -----------------------------------------------------------------

--- a/backend/airweave/domains/storage/paths.py
+++ b/backend/airweave/domains/storage/paths.py
@@ -67,6 +67,31 @@ class StoragePaths:
         return f"{cls.arf_sync_path(sync_id)}/entities"
 
     @classmethod
+    def sync_failure_artifact_path(
+        cls,
+        sync_id: Union[str, UUID],
+        sync_job_id: Union[str, UUID],
+        stage: str,
+        artifact_id: str,
+    ) -> str:
+        """Failure artifact path: raw/{sync_id}/failures/{sync_job_id}/{stage}/{id}.json."""
+        safe_stage = cls.safe_filename(stage)
+        safe_id = cls.safe_filename(artifact_id)
+        return f"{cls.arf_sync_path(sync_id)}/failures/{sync_job_id}/{safe_stage}/{safe_id}.json"
+
+    @classmethod
+    def sync_failure_artifacts_dir(
+        cls,
+        sync_id: Union[str, UUID],
+        sync_job_id: Optional[Union[str, UUID]] = None,
+    ) -> str:
+        """Failure artifact directory for a sync or one sync job."""
+        base = f"{cls.arf_sync_path(sync_id)}/failures"
+        if sync_job_id is None:
+            return base
+        return f"{base}/{sync_job_id}"
+
+    @classmethod
     def arf_files_dir(cls, sync_id: Union[str, UUID]) -> str:
         """Files directory: raw/{sync_id}/files/."""
         return f"{cls.arf_sync_path(sync_id)}/files"

--- a/backend/airweave/domains/sync_pipeline/config/base.py
+++ b/backend/airweave/domains/sync_pipeline/config/base.py
@@ -49,6 +49,15 @@ class BehaviorConfig(BaseModel):
     skip_guardrails: bool = Field(False, description="Skip usage guardrails (entity count checks)")
 
 
+class FailureCaptureConfig(BaseModel):
+    """Controls sync failure artifact capture for replay/debugging."""
+
+    enabled: bool = Field(False, description="Store redacted failure artifacts for sync debugging")
+    capture_entity_snapshots: bool = Field(
+        True, description="Include redacted entity snapshots in failure artifacts"
+    )
+
+
 class SyncConfig(BaseSettings):
     """Sync configuration with automatic env var loading.
 
@@ -66,6 +75,7 @@ class SyncConfig(BaseSettings):
     handlers: HandlerConfig = Field(default_factory=HandlerConfig)
     cursor: CursorConfig = Field(default_factory=CursorConfig)
     behavior: BehaviorConfig = Field(default_factory=BehaviorConfig)
+    failure_capture: FailureCaptureConfig = Field(default_factory=FailureCaptureConfig)
 
     @model_validator(mode="after")
     def validate_config_logic(self):

--- a/backend/airweave/domains/sync_pipeline/entity/dispatcher_builder.py
+++ b/backend/airweave/domains/sync_pipeline/entity/dispatcher_builder.py
@@ -11,6 +11,7 @@ from airweave.domains.sync_pipeline.entity.handlers.arf import ArfHandler
 from airweave.domains.sync_pipeline.entity.handlers.destination import DestinationHandler
 from airweave.domains.sync_pipeline.entity.handlers.postgres import EntityPostgresHandler
 from airweave.domains.sync_pipeline.entity.handlers.protocol import EntityActionHandler
+from airweave.domains.sync_pipeline.failure_capture import SyncFailureCapture
 from airweave.domains.sync_pipeline.protocols import ChunkEmbedProcessorProtocol
 from airweave.platform.destinations._base import BaseDestination
 
@@ -23,11 +24,13 @@ class EntityDispatcherBuilder:
         processor: ChunkEmbedProcessorProtocol,
         entity_repo: EntityRepositoryProtocol,
         arf_service: Optional[ArfServiceProtocol] = None,
+        failure_capture: Optional[SyncFailureCapture] = None,
     ) -> None:
         """Initialize with processor and entity repository."""
         self._processor = processor
         self._entity_repo = entity_repo
         self._arf_service = arf_service
+        self._failure_capture = failure_capture
 
     def build(
         self,
@@ -90,7 +93,11 @@ class EntityDispatcherBuilder:
 
         if enabled:
             handlers.append(
-                DestinationHandler(destinations=destinations, processor=self._processor)
+                DestinationHandler(
+                    destinations=destinations,
+                    processor=self._processor,
+                    failure_capture=self._failure_capture,
+                )
             )
             if logger:
                 dest_names = [d.__class__.__name__ for d in destinations]

--- a/backend/airweave/domains/sync_pipeline/entity/handlers/destination.py
+++ b/backend/airweave/domains/sync_pipeline/entity/handlers/destination.py
@@ -18,6 +18,7 @@ from airweave.domains.sync_pipeline.entity.actions import (
 )
 from airweave.domains.sync_pipeline.entity.handlers.protocol import EntityActionHandler
 from airweave.domains.sync_pipeline.exceptions import SyncFailureError
+from airweave.domains.sync_pipeline.failure_capture import SyncFailureCapture
 from airweave.domains.sync_pipeline.protocols import ChunkEmbedProcessorProtocol
 from airweave.platform.destinations._base import BaseDestination
 
@@ -44,10 +45,12 @@ class DestinationHandler(EntityActionHandler):
         self,
         destinations: List[BaseDestination],
         processor: ChunkEmbedProcessorProtocol,
+        failure_capture: SyncFailureCapture | None = None,
     ) -> None:
         """Initialize with destination list and chunk/embed processor."""
         self._destinations = destinations
         self._processor = processor
+        self._failure_capture = failure_capture
 
     @property
     def name(self) -> str:
@@ -172,6 +175,7 @@ class DestinationHandler(EntityActionHandler):
                 operation_name=f"insert_{dest.__class__.__name__}",
                 destination=dest,
                 sync_context=sync_context,
+                entities=processed,
             )
 
     async def _do_delete_by_ids(
@@ -201,6 +205,7 @@ class DestinationHandler(EntityActionHandler):
         operation_name: str,
         destination: BaseDestination,
         sync_context: "SyncContext",
+        entities: List["BaseEntity"] | None = None,
         max_retries: int = 4,
     ) -> None:
         """Execute operation with exponential backoff retry for network issues."""
@@ -233,6 +238,13 @@ class DestinationHandler(EntityActionHandler):
                             exc_info=True,
                         )
                         return
+                    await self._capture_batch_failure(
+                        entities=entities or [],
+                        stage=operation_name,
+                        error=e,
+                        sync_context=sync_context,
+                        destination=destination,
+                    )
                     raise SyncFailureError(
                         f"Destination unavailable: {type(e).__name__}: {error_msg}"
                     ) from e
@@ -250,6 +262,48 @@ class DestinationHandler(EntityActionHandler):
                     f"[{self.name}] {operation_name} failed: {type(e).__name__}: {error_msg}",
                     exc_info=True,
                 )
+                await self._capture_batch_failure(
+                    entities=entities or [],
+                    stage=operation_name,
+                    error=e,
+                    sync_context=sync_context,
+                    destination=destination,
+                )
                 raise SyncFailureError(
                     f"Destination failed: {type(e).__name__}: {error_msg}"
                 ) from e
+
+    async def _capture_batch_failure(
+        self,
+        *,
+        entities: List["BaseEntity"],
+        stage: str,
+        error: Exception,
+        sync_context: "SyncContext",
+        destination: BaseDestination,
+    ) -> None:
+        """Best-effort capture for destination batch failures."""
+        config = getattr(sync_context, "execution_config", None)
+        capture_config = getattr(config, "failure_capture", None)
+        if not self._failure_capture or not capture_config or not capture_config.enabled:
+            return
+
+        try:
+            artifact_path = await self._failure_capture.capture_batch_failure(
+                entities=entities,
+                stage=stage,
+                error=error,
+                sync_context=sync_context,
+                extra={"destination": destination.__class__.__name__},
+            )
+            sync_context.logger.warning(
+                "[%s] Captured destination failure artifact at %s",
+                self.name,
+                artifact_path,
+            )
+        except Exception as capture_error:
+            sync_context.logger.warning(
+                "[%s] Failed to capture destination failure artifact: %s",
+                self.name,
+                capture_error,
+            )

--- a/backend/airweave/domains/sync_pipeline/factory.py
+++ b/backend/airweave/domains/sync_pipeline/factory.py
@@ -47,6 +47,7 @@ from airweave.domains.sync_pipeline.config import SyncConfig
 from airweave.domains.sync_pipeline.contexts.runtime import SyncRuntime
 from airweave.domains.sync_pipeline.contexts.sync import SyncContext
 from airweave.domains.sync_pipeline.entity.dispatcher_builder import EntityDispatcherBuilder
+from airweave.domains.sync_pipeline.failure_capture import SyncFailureCapture
 from airweave.domains.sync_pipeline.orchestrator import SyncOrchestrator
 from airweave.domains.sync_pipeline.pipeline.entity_tracker import EntityTracker
 from airweave.domains.sync_pipeline.protocols import (
@@ -132,6 +133,7 @@ class SyncFactory(SyncFactoryProtocol):
         self._usage_checker = usage_checker
         self._usage_ledger = usage_ledger
         self._storage_backend = storage_backend
+        self._failure_capture = SyncFailureCapture(storage=storage_backend)
         self._state_machine = state_machine
 
     async def create_orchestrator(
@@ -278,6 +280,7 @@ class SyncFactory(SyncFactoryProtocol):
             processor=self._processor,
             entity_repo=self._entity_repo,
             arf_service=self._arf_service,
+            failure_capture=self._failure_capture,
         )
         dispatcher = dispatcher_builder.build(
             destinations=destinations,

--- a/backend/airweave/domains/sync_pipeline/failure_capture.py
+++ b/backend/airweave/domains/sync_pipeline/failure_capture.py
@@ -37,6 +37,13 @@ _SENSITIVE_KEYWORDS = (
     "secret",
     "token",
 )
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b("
+    r"access_token|authorization|api_key|apikey|bearer|client_secret|credential|"
+    r"password|private_key|refresh_token|secret|token"
+    r")\b\s*[:=]\s*(?:bearer\s+)?([^\s,;]+)"
+)
+_BEARER_TOKEN_RE = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+")
 
 
 @dataclass(frozen=True)
@@ -138,7 +145,7 @@ class SyncFailureCapture:
             },
             "error": {
                 "type": type(error).__name__,
-                "message": self._clean_string(str(error) or "(empty error message)"),
+                "message": self._redact_string(str(error) or "(empty error message)"),
             },
         }
 
@@ -211,7 +218,7 @@ class SyncFailureCapture:
             return self._redact(list(value))
 
         if isinstance(value, str):
-            return self._clean_string(value)
+            return self._redact_string(value)
 
         return value
 
@@ -225,6 +232,12 @@ class SyncFailureCapture:
                 f"...[truncated {truncated_chars} chars]"
             )
         return clean
+
+    def _redact_string(self, value: str) -> str:
+        """Redact inline credentials from a string, then clean and trim it."""
+        redacted = _SECRET_ASSIGNMENT_RE.sub(r"\1=[REDACTED]", value)
+        redacted = _BEARER_TOKEN_RE.sub("Bearer [REDACTED]", redacted)
+        return self._clean_string(redacted)
 
     @staticmethod
     def _is_sensitive_key(key: str) -> bool:

--- a/backend/airweave/domains/sync_pipeline/failure_capture.py
+++ b/backend/airweave/domains/sync_pipeline/failure_capture.py
@@ -1,0 +1,233 @@
+"""Failure artifact capture for sync replay/debugging.
+
+The capture layer stores small, redacted JSON artifacts for failures that are
+otherwise hard to reproduce from logs alone. It is intentionally storage-backed
+and side-effect-light so callers can use it best-effort without changing normal
+sync semantics.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Mapping, Optional
+
+from airweave.domains.storage.paths import StoragePaths
+from airweave.domains.storage.protocols import StorageBackend
+
+if TYPE_CHECKING:
+    from airweave.domains.sync_pipeline.contexts import SyncContext
+    from airweave.platform.entities._base import BaseEntity
+
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_SENSITIVE_KEYWORDS = (
+    "access_token",
+    "authorization",
+    "api_key",
+    "apikey",
+    "bearer",
+    "client_secret",
+    "credential",
+    "password",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "token",
+)
+
+
+@dataclass(frozen=True)
+class FailureCaptureLimits:
+    """Limits applied to failure artifacts to avoid large/sensitive dumps."""
+
+    max_string_chars: int = 1_000
+    max_list_items: int = 20
+    max_dict_items: int = 40
+
+
+class SyncFailureCapture:
+    """Stores redacted sync failure artifacts in the raw sync storage tree."""
+
+    def __init__(
+        self,
+        storage: StorageBackend,
+        limits: Optional[FailureCaptureLimits] = None,
+    ) -> None:
+        """Initialize with a storage backend."""
+        self._storage = storage
+        self._limits = limits or FailureCaptureLimits()
+
+    async def capture_entity_failure(
+        self,
+        *,
+        entity: "BaseEntity",
+        stage: str,
+        error: Exception,
+        sync_context: "SyncContext",
+        include_snapshot: bool = True,
+        extra: Optional[Mapping[str, Any]] = None,
+    ) -> str:
+        """Capture an entity-scoped failure and return the artifact path."""
+        artifact = self._base_artifact(stage=stage, error=error, sync_context=sync_context)
+        artifact["entity"] = (
+            self._entity_snapshot(entity) if include_snapshot else self._entity_ref(entity)
+        )
+        if extra:
+            artifact["extra"] = self._redact(extra)
+
+        return await self._write_artifact(
+            artifact=artifact,
+            stage=stage,
+            sync_context=sync_context,
+            artifact_id=str(getattr(entity, "entity_id", "unknown")),
+        )
+
+    async def capture_batch_failure(
+        self,
+        *,
+        entities: list["BaseEntity"],
+        stage: str,
+        error: Exception,
+        sync_context: "SyncContext",
+        extra: Optional[Mapping[str, Any]] = None,
+    ) -> str:
+        """Capture a batch-scoped failure and return the artifact path."""
+        artifact = self._base_artifact(stage=stage, error=error, sync_context=sync_context)
+        entity_refs = [
+            self._entity_ref(entity) for entity in entities[: self._limits.max_list_items]
+        ]
+        artifact["batch"] = {
+            "entity_count": len(entities),
+            "entities": entity_refs,
+            "truncated": len(entities) > self._limits.max_list_items,
+        }
+        if extra:
+            artifact["extra"] = self._redact(extra)
+
+        raw_id = "|".join(str(getattr(entity, "entity_id", "")) for entity in entities)
+        digest = hashlib.sha256(raw_id.encode("utf-8", errors="ignore")).hexdigest()[:16]
+        return await self._write_artifact(
+            artifact=artifact,
+            stage=stage,
+            sync_context=sync_context,
+            artifact_id=f"batch-{digest}",
+        )
+
+    def _base_artifact(
+        self,
+        *,
+        stage: str,
+        error: Exception,
+        sync_context: "SyncContext",
+    ) -> dict[str, Any]:
+        """Build the shared artifact envelope."""
+        return {
+            "version": 1,
+            "captured_at": datetime.now(timezone.utc).isoformat(),
+            "stage": stage,
+            "sync": {
+                "sync_id": str(sync_context.sync.id),
+                "sync_job_id": str(sync_context.sync_job.id),
+                "collection_id": str(sync_context.collection.id),
+                "source_connection_id": str(sync_context.source_connection_id),
+                "source_type": sync_context.source_short_name,
+                "organization_id": str(sync_context.organization_id),
+            },
+            "error": {
+                "type": type(error).__name__,
+                "message": self._clean_string(str(error) or "(empty error message)"),
+            },
+        }
+
+    async def _write_artifact(
+        self,
+        *,
+        artifact: dict[str, Any],
+        stage: str,
+        sync_context: "SyncContext",
+        artifact_id: str,
+    ) -> str:
+        """Persist an artifact under the sync's raw storage tree."""
+        path = StoragePaths.sync_failure_artifact_path(
+            sync_id=sync_context.sync.id,
+            sync_job_id=sync_context.sync_job.id,
+            stage=stage,
+            artifact_id=artifact_id,
+        )
+        await self._storage.write_json(path, artifact)
+        return path
+
+    def _entity_snapshot(self, entity: "BaseEntity") -> dict[str, Any]:
+        """Return a redacted entity snapshot useful for replay/debugging."""
+        snapshot = self._entity_ref(entity)
+        textual_representation = getattr(entity, "textual_representation", None)
+        if textual_representation is not None:
+            snapshot["textual_representation"] = {
+                "chars": len(textual_representation),
+                "preview": self._clean_string(textual_representation),
+            }
+
+        if hasattr(entity, "model_dump"):
+            raw = entity.model_dump(mode="json", exclude={"airweave_system_metadata"})
+            snapshot["fields"] = self._redact(raw)
+        return snapshot
+
+    def _entity_ref(self, entity: "BaseEntity") -> dict[str, Any]:
+        """Return stable identifying fields for an entity."""
+        metadata = getattr(entity, "airweave_system_metadata", None)
+        return {
+            "entity_id": str(getattr(entity, "entity_id", "")),
+            "entity_type": entity.__class__.__name__,
+            "original_entity_id": str(getattr(metadata, "original_entity_id", "") or ""),
+            "chunk_index": getattr(metadata, "chunk_index", None),
+        }
+
+    def _redact(self, value: Any) -> Any:
+        """Recursively redact sensitive values and trim large structures."""
+        if isinstance(value, Mapping):
+            redacted: dict[str, Any] = {}
+            items = list(value.items())
+            for key, item_value in items[: self._limits.max_dict_items]:
+                key_str = str(key)
+                if self._is_sensitive_key(key_str):
+                    redacted[key_str] = "[REDACTED]"
+                else:
+                    redacted[key_str] = self._redact(item_value)
+            if len(items) > self._limits.max_dict_items:
+                redacted["_truncated_keys"] = len(items) - self._limits.max_dict_items
+            return redacted
+
+        if isinstance(value, list):
+            redacted_items = [self._redact(item) for item in value[: self._limits.max_list_items]]
+            if len(value) > self._limits.max_list_items:
+                truncated_items = len(value) - self._limits.max_list_items
+                redacted_items.append({"_truncated_items": truncated_items})
+            return redacted_items
+
+        if isinstance(value, tuple):
+            return self._redact(list(value))
+
+        if isinstance(value, str):
+            return self._clean_string(value)
+
+        return value
+
+    def _clean_string(self, value: str) -> str:
+        """Remove control characters and trim long strings."""
+        clean = _CONTROL_CHARS_RE.sub(r"\\uFFFD", value)
+        if len(clean) > self._limits.max_string_chars:
+            truncated_chars = len(clean) - self._limits.max_string_chars
+            return (
+                f"{clean[: self._limits.max_string_chars]}"
+                f"...[truncated {truncated_chars} chars]"
+            )
+        return clean
+
+    @staticmethod
+    def _is_sensitive_key(key: str) -> bool:
+        """Return true if a field name looks credential-bearing."""
+        key_lower = key.lower()
+        return any(keyword in key_lower for keyword in _SENSITIVE_KEYWORDS)

--- a/backend/airweave/domains/sync_pipeline/processors/chunk_embed.py
+++ b/backend/airweave/domains/sync_pipeline/processors/chunk_embed.py
@@ -18,6 +18,7 @@ from airweave.domains.converters.protocols import ConverterRegistryProtocol
 from airweave.domains.embedders.exceptions import EmbedderProviderError
 from airweave.domains.embedders.protocols import DenseEmbedderProtocol, SparseEmbedderProtocol
 from airweave.domains.sync_pipeline.exceptions import EntityProcessingError, SyncFailureError
+from airweave.domains.sync_pipeline.failure_capture import SyncFailureCapture
 from airweave.domains.sync_pipeline.pipeline.text_builder import TextualRepresentationBuilder
 from airweave.domains.sync_pipeline.processors.utils import filter_empty_representations
 from airweave.platform.entities._base import BaseEntity, CodeFileEntity
@@ -35,11 +36,13 @@ class ChunkEmbedProcessor:
         converter_registry: ConverterRegistryProtocol,
         dense_embedder: DenseEmbedderProtocol,
         sparse_embedder: SparseEmbedderProtocol,
+        failure_capture: SyncFailureCapture | None = None,
     ) -> None:
         """Initialize with converter registry and embedding providers."""
         self._text_builder = TextualRepresentationBuilder(converter_registry)
         self._dense_embedder = dense_embedder
         self._sparse_embedder = sparse_embedder
+        self._failure_capture = failure_capture
 
     async def process(
         self,
@@ -343,6 +346,12 @@ class ChunkEmbedProcessor:
                 successful_results.append(results[0])
                 successful_entities.append(entity)
             except Exception as exc:
+                await self._capture_entity_failure(
+                    entity=entity,
+                    stage="dense_embedding",
+                    error=exc,
+                    sync_context=sync_context,
+                )
                 sync_context.logger.warning(
                     "[ChunkEmbedProcessor] Skipping entity %s — dense embedding failed: %s",
                     entity.entity_id,
@@ -358,3 +367,39 @@ class ChunkEmbedProcessor:
             )
 
         return successful_results, successful_entities
+
+    async def _capture_entity_failure(
+        self,
+        *,
+        entity: BaseEntity,
+        stage: str,
+        error: Exception,
+        sync_context: "SyncContext",
+    ) -> None:
+        """Best-effort failure capture for entity-scoped recoverable failures."""
+        config = getattr(sync_context, "execution_config", None)
+        capture_config = getattr(config, "failure_capture", None)
+        if not self._failure_capture or not capture_config or not capture_config.enabled:
+            return
+
+        try:
+            artifact_path = await self._failure_capture.capture_entity_failure(
+                entity=entity,
+                stage=stage,
+                error=error,
+                sync_context=sync_context,
+                include_snapshot=capture_config.capture_entity_snapshots,
+            )
+            sync_context.logger.warning(
+                "[ChunkEmbedProcessor] Captured %s failure artifact for %s at %s",
+                stage,
+                entity.entity_id,
+                artifact_path,
+            )
+        except Exception as capture_error:
+            sync_context.logger.warning(
+                "[ChunkEmbedProcessor] Failed to capture %s failure artifact for %s: %s",
+                stage,
+                entity.entity_id,
+                capture_error,
+            )

--- a/backend/airweave/domains/sync_pipeline/tests/test_chunk_embed.py
+++ b/backend/airweave/domains/sync_pipeline/tests/test_chunk_embed.py
@@ -6,6 +6,9 @@ import pytest
 
 from airweave.domains.converters.fakes.registry import FakeConverterRegistry
 from airweave.domains.embedders.exceptions import EmbedderProviderError
+from airweave.domains.storage.fakes.backend import FakeStorageBackend
+from airweave.domains.sync_pipeline.config.base import FailureCaptureConfig, SyncConfig
+from airweave.domains.sync_pipeline.failure_capture import SyncFailureCapture
 from airweave.domains.sync_pipeline.processors.chunk_embed import ChunkEmbedProcessor
 
 _TEXT_BUILDER_CLS = (
@@ -392,6 +395,60 @@ class TestChunkEmbedProcessor:
 
         with pytest.raises(EntityProcessingError, match="no textual_representation"):
             await processor._embed_entities([entity], mock_sync_context)
+
+    @pytest.mark.asyncio
+    async def test_nonretryable_dense_fallback_captures_failed_entity(
+        self, mock_dense_embedder, mock_sparse_embedder, mock_sync_context
+    ):
+        """Failed single-entity fallback writes a replay artifact when enabled."""
+        storage = FakeStorageBackend()
+        processor = ChunkEmbedProcessor(
+            converter_registry=FakeConverterRegistry(),
+            dense_embedder=mock_dense_embedder,
+            sparse_embedder=mock_sparse_embedder,
+            failure_capture=SyncFailureCapture(storage=storage),
+        )
+        mock_sync_context.execution_config = SyncConfig(
+            failure_capture=FailureCaptureConfig(enabled=True)
+        )
+        mock_sync_context.sync = MagicMock(id="sync-1")
+        mock_sync_context.sync_job = MagicMock(id="job-1")
+        mock_sync_context.collection = MagicMock(id="collection-1")
+        mock_sync_context.source_connection_id = "source-connection-1"
+        mock_sync_context.source_short_name = "gmail"
+        mock_sync_context.organization_id = "org-1"
+
+        ok_entity = MagicMock()
+        ok_entity.entity_id = "ok"
+        ok_entity.textual_representation = "ok text"
+        ok_entity.airweave_system_metadata = MagicMock()
+        ok_entity.model_dump.return_value = {"entity_id": "ok"}
+
+        bad_entity = MagicMock()
+        bad_entity.entity_id = "bad"
+        bad_entity.textual_representation = "bad text"
+        bad_entity.airweave_system_metadata = MagicMock()
+        bad_entity.model_dump.return_value = {"entity_id": "bad", "api_key": "secret"}
+
+        dense_result = MagicMock()
+        dense_result.vector = [0.1] * 3072
+        mock_dense_embedder.embed_many = AsyncMock(
+            side_effect=[
+                EmbedderProviderError("input too long", retryable=False),
+                [dense_result],
+                RuntimeError("provider rejected entity"),
+            ]
+        )
+        mock_sparse_embedder.embed_many = AsyncMock(return_value=[MagicMock()])
+
+        result = await processor._embed_entities([ok_entity, bad_entity], mock_sync_context)
+
+        assert result == [ok_entity]
+        files = await storage.list_files("raw/sync-1/failures/job-1")
+        assert len(files) == 1
+        artifact = await storage.read_json(files[0])
+        assert artifact["stage"] == "dense_embedding"
+        assert artifact["entity"]["fields"]["api_key"] == "[REDACTED]"
 
     @pytest.mark.asyncio
     async def test_handles_empty_chunks_from_chunker(

--- a/backend/airweave/domains/sync_pipeline/tests/test_config_base.py
+++ b/backend/airweave/domains/sync_pipeline/tests/test_config_base.py
@@ -10,6 +10,7 @@ from airweave.domains.sync_pipeline.config.base import (
     BehaviorConfig,
     CursorConfig,
     DestinationConfig,
+    FailureCaptureConfig,
     HandlerConfig,
     SyncConfig,
     _deep_merge,
@@ -89,6 +90,22 @@ class TestBehaviorConfig:
         assert config.replay_from_arf is True
 
 
+class TestFailureCaptureConfig:
+    """Test FailureCaptureConfig defaults and behavior."""
+
+    def test_defaults(self):
+        """Test default failure capture config values."""
+        config = FailureCaptureConfig()
+        assert config.enabled is False
+        assert config.capture_entity_snapshots is True
+
+    def test_with_custom_values(self):
+        """Test failure capture config with custom values."""
+        config = FailureCaptureConfig(enabled=True, capture_entity_snapshots=False)
+        assert config.enabled is True
+        assert config.capture_entity_snapshots is False
+
+
 class TestSyncConfig:
     """Test SyncConfig composite configuration."""
 
@@ -103,6 +120,7 @@ class TestSyncConfig:
                 assert config.handlers.enable_vector_handlers is True
                 assert config.cursor.skip_load is False
                 assert config.behavior.replay_from_arf is False
+                assert config.failure_capture.enabled is False
 
     def test_with_nested_configs(self):
         """Test SyncConfig with nested sub-configs."""
@@ -134,6 +152,16 @@ class TestSyncConfig:
         ):
             config = SyncConfig()
             assert config.behavior.replay_from_arf is True
+
+    def test_env_var_failure_capture(self):
+        """Test that failure capture can be enabled through env vars."""
+        with patch.dict(
+            os.environ,
+            {"SYNC_CONFIG__FAILURE_CAPTURE__ENABLED": "true"},
+            clear=False,
+        ):
+            config = SyncConfig()
+            assert config.failure_capture.enabled is True
 
 
 class TestSyncConfigValidation:

--- a/backend/airweave/domains/sync_pipeline/tests/test_destination_handler.py
+++ b/backend/airweave/domains/sync_pipeline/tests/test_destination_handler.py
@@ -12,8 +12,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from airweave.domains.sync_pipeline.exceptions import SyncFailureError
+from airweave.domains.storage.fakes.backend import FakeStorageBackend
+from airweave.domains.sync_pipeline.config.base import FailureCaptureConfig, SyncConfig
 from airweave.domains.sync_pipeline.entity.handlers.destination import DestinationHandler
+from airweave.domains.sync_pipeline.exceptions import SyncFailureError
+from airweave.domains.sync_pipeline.failure_capture import SyncFailureCapture
 
 _ASYNC_SLEEP = "airweave.domains.sync_pipeline.entity.handlers.destination.asyncio.sleep"
 
@@ -37,6 +40,13 @@ def _make_mock_sync_context():
     ctx.logger.debug = MagicMock()
     ctx.sync = MagicMock()
     ctx.sync.id = "test-sync-id"
+    ctx.sync_job = MagicMock()
+    ctx.sync_job.id = "test-job-id"
+    ctx.collection = MagicMock()
+    ctx.collection.id = "test-collection-id"
+    ctx.source_connection_id = "test-source-connection-id"
+    ctx.source_short_name = "stub"
+    ctx.organization_id = "test-org-id"
     return ctx
 
 
@@ -185,6 +195,41 @@ class TestExecuteWithRetryTimeout:
 
         # Should NOT retry - fails on first attempt
         assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_exception_captures_batch_failure_when_enabled(self):
+        """Destination failures write a redacted batch artifact when enabled."""
+        storage = FakeStorageBackend()
+        dest = _make_mock_destination()
+        handler = DestinationHandler(
+            [dest],
+            processor=MagicMock(),
+            failure_capture=SyncFailureCapture(storage=storage),
+        )
+        ctx = _make_mock_sync_context()
+        ctx.execution_config = SyncConfig(failure_capture=FailureCaptureConfig(enabled=True))
+        entity = MagicMock()
+        entity.entity_id = "entity-1"
+        entity.airweave_system_metadata = MagicMock()
+
+        async def failing_operation():
+            raise ValueError("bad payload")
+
+        with pytest.raises(SyncFailureError, match="Destination failed"):
+            await handler._execute_with_retry(
+                operation=failing_operation,
+                operation_name="insert_MockDestination",
+                destination=dest,
+                sync_context=ctx,
+                entities=[entity],
+                max_retries=4,
+            )
+
+        files = await storage.list_files("raw/test-sync-id/failures/test-job-id")
+        assert len(files) == 1
+        artifact = await storage.read_json(files[0])
+        assert artifact["stage"] == "insert_MockDestination"
+        assert artifact["batch"]["entities"][0]["entity_id"] == "entity-1"
 
 
 class TestTimingLogs:

--- a/backend/airweave/domains/sync_pipeline/tests/test_failure_capture.py
+++ b/backend/airweave/domains/sync_pipeline/tests/test_failure_capture.py
@@ -1,0 +1,81 @@
+"""Tests for sync failure artifact capture."""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from airweave.domains.storage.fakes.backend import FakeStorageBackend
+from airweave.domains.sync_pipeline.failure_capture import SyncFailureCapture
+
+
+def _make_sync_context():
+    ctx = MagicMock()
+    ctx.sync = MagicMock(id=uuid4())
+    ctx.sync_job = MagicMock(id=uuid4())
+    ctx.collection = MagicMock(id=uuid4())
+    ctx.source_connection_id = uuid4()
+    ctx.source_short_name = "teams"
+    ctx.organization_id = uuid4()
+    return ctx
+
+
+def _make_entity():
+    entity = MagicMock()
+    entity.entity_id = "message/with:unsafe"
+    entity.textual_representation = "hello\x1bworld"
+    entity.airweave_system_metadata = MagicMock()
+    entity.airweave_system_metadata.original_entity_id = "message-1"
+    entity.airweave_system_metadata.chunk_index = 3
+    entity.model_dump.return_value = {
+        "entity_id": "message/with:unsafe",
+        "access_token": "should-not-leak",
+        "nested": {"client_secret": "also-redacted", "safe": "kept"},
+    }
+    return entity
+
+
+@pytest.mark.asyncio
+async def test_capture_entity_failure_redacts_and_cleans_snapshot():
+    """Entity artifacts redact credentials and replace control characters."""
+    storage = FakeStorageBackend()
+    capture = SyncFailureCapture(storage=storage)
+    ctx = _make_sync_context()
+    entity = _make_entity()
+
+    path = await capture.capture_entity_failure(
+        entity=entity,
+        stage="dense_embedding",
+        error=ValueError("bad token\x1b"),
+        sync_context=ctx,
+    )
+
+    artifact = await storage.read_json(path)
+    assert artifact["stage"] == "dense_embedding"
+    assert artifact["error"]["message"] == "bad token\\uFFFD"
+    assert artifact["entity"]["textual_representation"]["preview"] == "hello\\uFFFDworld"
+    assert artifact["entity"]["fields"]["access_token"] == "[REDACTED]"
+    assert artifact["entity"]["fields"]["nested"]["client_secret"] == "[REDACTED]"
+    assert artifact["entity"]["fields"]["nested"]["safe"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_capture_batch_failure_lists_entity_refs():
+    """Batch artifacts include bounded entity refs and destination metadata."""
+    storage = FakeStorageBackend()
+    capture = SyncFailureCapture(storage=storage)
+    ctx = _make_sync_context()
+    entities = [_make_entity(), _make_entity()]
+
+    path = await capture.capture_batch_failure(
+        entities=entities,
+        stage="insert_VespaDestination",
+        error=RuntimeError("vespa rejected payload"),
+        sync_context=ctx,
+        extra={"destination": "VespaDestination"},
+    )
+
+    artifact = await storage.read_json(path)
+    assert artifact["batch"]["entity_count"] == 2
+    assert artifact["batch"]["entities"][0]["entity_id"] == "message/with:unsafe"
+    assert artifact["extra"]["destination"] == "VespaDestination"

--- a/backend/airweave/domains/sync_pipeline/tests/test_failure_capture.py
+++ b/backend/airweave/domains/sync_pipeline/tests/test_failure_capture.py
@@ -60,6 +60,26 @@ async def test_capture_entity_failure_redacts_and_cleans_snapshot():
 
 
 @pytest.mark.asyncio
+async def test_capture_entity_failure_redacts_inline_secret_error_messages():
+    """Error strings are redacted too, not only structured entity fields."""
+    storage = FakeStorageBackend()
+    capture = SyncFailureCapture(storage=storage)
+    ctx = _make_sync_context()
+
+    path = await capture.capture_entity_failure(
+        entity=_make_entity(),
+        stage="dense_embedding",
+        error=ValueError("request failed access_token=abc123 Authorization: Bearer sk-live"),
+        sync_context=ctx,
+    )
+
+    artifact = await storage.read_json(path)
+    assert artifact["error"]["message"] == (
+        "request failed access_token=[REDACTED] Authorization=[REDACTED]"
+    )
+
+
+@pytest.mark.asyncio
 async def test_capture_batch_failure_lists_entity_refs():
     """Batch artifacts include bounded entity refs and destination metadata."""
     storage = FakeStorageBackend()


### PR DESCRIPTION
## Summary

Adds opt-in sync failure artifact capture for failures that are hard to debug from logs alone:

- new `FailureCaptureConfig` under `SyncConfig`
- storage paths for `raw/{sync_id}/failures/{sync_job_id}/{stage}/...`
- `SyncFailureCapture` for redacted entity and batch failure artifacts
- entity-level capture for dense embedding fallback failures
- batch-level capture for destination insert failures after retry exhaustion or non-retryable errors
- wiring through the container, sync factory, dispatcher builder, processor, and destination handler
- tests for redaction, control-character cleanup, config/env behavior, embedding fallback capture, and destination failure capture

## Why

When a source emits one malformed payload, an embedding provider rejects one chunk, or Vespa rejects a bulk insert, the current failure context can be too transient: logs show the exception, but not a small replay/debug artifact tied to the sync job, stage, entity IDs, and sanitized entity context.

This gives Airweave a storage-backed failure trail without changing default sync behavior. Capture is disabled by default and best-effort when enabled.

## Verification

- `PYTHONPATH=/tmp/airweave-test-deps:backend /Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest backend/airweave/domains/sync_pipeline/tests/test_failure_capture.py backend/airweave/domains/sync_pipeline/tests/test_config_base.py -q`
- `/Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile backend/airweave/domains/sync_pipeline/failure_capture.py backend/airweave/domains/sync_pipeline/processors/chunk_embed.py backend/airweave/domains/sync_pipeline/entity/handlers/destination.py backend/airweave/domains/sync_pipeline/entity/dispatcher_builder.py backend/airweave/domains/sync_pipeline/factory.py backend/airweave/core/container/factory.py backend/airweave/domains/sync_pipeline/config/base.py backend/airweave/domains/storage/paths.py backend/airweave/domains/sync_pipeline/tests/test_failure_capture.py backend/airweave/domains/sync_pipeline/tests/test_chunk_embed.py backend/airweave/domains/sync_pipeline/tests/test_destination_handler.py backend/airweave/domains/sync_pipeline/tests/test_config_base.py`
- `git diff --check`
- `cd backend && PYTHONPATH=/tmp/airweave-test-deps:. /Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check --select E,I airweave/domains/sync_pipeline/failure_capture.py airweave/domains/sync_pipeline/tests/test_destination_handler.py`

I used a temporary local dependency target because this checkout does not have the project Poetry environment installed. CI should run the broader backend suite.

## AI disclosure

I used an AI coding assistant to help draft and verify this contribution. I reviewed the patch before opening the PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in failure artifact capture for sync runs, storing redacted, replayable JSON to debug embedding and destination insert failures without changing defaults. Capture is disabled by default and writes artifacts under the sync’s raw storage tree.

- **New Features**
  - Opt-in via `SyncConfig.failure_capture` (flags: `enabled`, `capture_entity_snapshots`).
  - Stores artifacts at `raw/{sync_id}/failures/{sync_job_id}/{stage}/{id}.json`.
  - Captures entity failures in `ChunkEmbedProcessor` (dense embedding fallback) and batch failures in `DestinationHandler` (non-retryable or after retries).
  - Redacts inline secrets in error messages and text (e.g., Bearer tokens, `api_key=`), and cleans control characters.
  - Wired through container and factory; tests cover redaction (including inline), env config, and capture flows.

- **Migration**
  - Disabled by default. Enable with `SyncConfig.failure_capture.enabled=true` or env `SYNC_CONFIG__FAILURE_CAPTURE__ENABLED=true`.

<sup>Written for commit 4ad80949fae6a878d226d13d899f77abd9a8a0f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

