### PR TITLE
feat(mistral): make Mistral SDK base URL configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,11 @@ SPARSE_EMBEDDER=fastembed_bm25
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 MISTRAL_API_KEY=
+# Optional — override the base URL used by every Mistral client (embedder,
+# OCR, LLM). Unset to fall back to the in-code default
+# (MISTRAL_DEFAULT_BASE_URL = https://api.mistral.ai). Set this to point at a
+# self-hosted Mistral endpoint or a corporate proxy.
+# MISTRAL_BASE_URL=
 
 # Development Settings
 LOCAL_DEVELOPMENT=false

--- a/backend/airweave/adapters/llm/mistral.py
+++ b/backend/airweave/adapters/llm/mistral.py
@@ -25,7 +25,7 @@ from airweave.adapters.llm.base import BaseLLM
 from airweave.adapters.llm.exceptions import LLMTransientError
 from airweave.adapters.llm.registry import LLMModelSpec
 from airweave.adapters.llm.tool_response import LLMResponse, LLMToolCall
-from airweave.core.config import settings
+from airweave.core.config import MISTRAL_DEFAULT_BASE_URL, settings
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -48,7 +48,10 @@ class MistralLLM(BaseLLM):
             )
 
         try:
-            self._client = Mistral(api_key=api_key)
+            self._client = Mistral(
+                api_key=api_key,
+                server_url=settings.MISTRAL_BASE_URL or MISTRAL_DEFAULT_BASE_URL,
+            )
         except Exception as e:
             raise RuntimeError(f"Failed to initialize Mistral client: {e}") from e
 

--- a/backend/airweave/core/config/__init__.py
+++ b/backend/airweave/core/config/__init__.py
@@ -15,13 +15,14 @@ Usage:
 """
 
 from airweave.core.config.enums import Environment, StorageBackendType
-from airweave.core.config.settings import Settings
+from airweave.core.config.settings import MISTRAL_DEFAULT_BASE_URL, Settings
 
 __all__ = [
     "Settings",
     "StorageBackendType",
     "Environment",
     "settings",
+    "MISTRAL_DEFAULT_BASE_URL",
 ]
 
 # Singleton settings instance

--- a/backend/airweave/core/config/settings.py
+++ b/backend/airweave/core/config/settings.py
@@ -36,6 +36,9 @@ _BANNED_SUPERUSER_EMAILS: frozenset[str] = frozenset(
     }
 )
 
+# Fallback base URL used by every Mistral SDK client when MISTRAL_BASE_URL is unset.
+MISTRAL_DEFAULT_BASE_URL: str = "https://api.mistral.ai"
+
 
 class Settings(BaseSettings):
     """Pydantic settings class.
@@ -74,6 +77,8 @@ class Settings(BaseSettings):
         TEXT2VEC_INFERENCE_URL (str): The URL for text2vec-transformers inference service.
         OPENAI_API_KEY (Optional[str]): The OpenAI API key.
         MISTRAL_API_KEY (Optional[str]): The Mistral AI API key.
+        MISTRAL_BASE_URL (Optional[str]): Override base URL for all Mistral SDK
+            clients (embedder, OCR, LLM). Unset → ``MISTRAL_DEFAULT_BASE_URL``.
         EMBEDDING_DIMENSIONS (int): Embedding dimensions for the stack (provider, Vespa).
         FIRECRAWL_API_KEY (Optional[str]): The FireCrawl API key.
         TEMPORAL_HOST (str): The host of the Temporal server.
@@ -200,6 +205,7 @@ class Settings(BaseSettings):
     OPENAI_API_KEY: Optional[str] = None
     ANTHROPIC_API_KEY: Optional[str] = None
     MISTRAL_API_KEY: Optional[str] = None
+    MISTRAL_BASE_URL: Optional[str] = None
     FIRECRAWL_API_KEY: Optional[str] = None
     GROQ_API_KEY: Optional[str] = None
     COHERE_API_KEY: Optional[str] = None

--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -809,6 +809,7 @@ def _create_dense_embedder(
             api_key=settings.MISTRAL_API_KEY,
             model=spec.api_model_name,
             dimensions=EMBEDDING_DIMENSIONS,
+            server_url=settings.MISTRAL_BASE_URL,
         )
 
     if spec.embedder_class_ref is LocalDenseEmbedder:

--- a/backend/airweave/domains/embedders/dense/mistral.py
+++ b/backend/airweave/domains/embedders/dense/mistral.py
@@ -9,6 +9,7 @@ import asyncio
 
 from mistralai import Mistral
 
+from airweave.core.config import MISTRAL_DEFAULT_BASE_URL
 from airweave.domains.embedders.exceptions import (
     EmbedderAuthError,
     EmbedderConnectionError,
@@ -45,6 +46,7 @@ class MistralDenseEmbedder(DenseEmbedderProtocol):
         api_key: str,
         model: str,
         dimensions: int,
+        server_url: str | None = None,
     ) -> None:
         """Initialize the Mistral dense embedder.
 
@@ -52,10 +54,15 @@ class MistralDenseEmbedder(DenseEmbedderProtocol):
             api_key: Mistral API key.
             model: Model name (e.g. "mistral-embed").
             dimensions: Expected output dimensions (validated on response only).
+            server_url: Override the Mistral API base URL. Unset →
+                ``MISTRAL_DEFAULT_BASE_URL``.
         """
         self._model = model
         self._dimensions = dimensions
-        self._client = Mistral(api_key=api_key)
+        self._client = Mistral(
+            api_key=api_key,
+            server_url=server_url or MISTRAL_DEFAULT_BASE_URL,
+        )
         self._tokenizer = get_tokenizer(model)
         self._semaphore = asyncio.Semaphore(self._MAX_CONCURRENT_REQUESTS)
 

--- a/backend/airweave/domains/ocr/mistral/ocr_client.py
+++ b/backend/airweave/domains/ocr/mistral/ocr_client.py
@@ -18,7 +18,7 @@ import aiofiles
 from httpx import HTTPStatusError
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
-from airweave.core.config import settings
+from airweave.core.config import MISTRAL_DEFAULT_BASE_URL, settings
 from airweave.core.logging import logger
 from airweave.domains.ocr.mistral.models import (
     FileChunk,
@@ -86,6 +86,7 @@ class MistralOcrClient:
 
             self._client = Mistral(
                 api_key=settings.MISTRAL_API_KEY,
+                server_url=settings.MISTRAL_BASE_URL or MISTRAL_DEFAULT_BASE_URL,
                 timeout_ms=120_000,  # 2 minutes per OCR call
             )
             self._initialized = True

--- a/backend/tests/unit/core/test_dense_embedder_factory.py
+++ b/backend/tests/unit/core/test_dense_embedder_factory.py
@@ -18,6 +18,7 @@ def _make_settings(**overrides):
     defaults = dict(
         OPENAI_API_KEY="sk-test-openai",
         MISTRAL_API_KEY="test-mistral-key",
+        MISTRAL_BASE_URL=None,
         TEXT2VEC_INFERENCE_URL="http://localhost:9878",
     )
     defaults.update(overrides)


### PR DESCRIPTION
## What

Adds a single optional `MISTRAL_BASE_URL` setting that overrides the `server_url` passed to every `mistralai.Mistral(...)` client constructed by the backend:

| # | Call site | File |
|---|-----------|------|
| 1 | Dense embedder | `backend/airweave/domains/embedders/dense/mistral.py` |
| 2 | OCR client | `backend/airweave/domains/ocr/mistral/ocr_client.py` |
| 3 | Chat LLM adapter | `backend/airweave/adapters/llm/mistral.py` |

Wired through `_create_dense_embedder` in `backend/airweave/core/container/factory.py` for the embedder; the OCR and LLM clients already read `settings` directly.

When `MISTRAL_BASE_URL` is unset, every adapter explicitly falls back to a new module-level constant `MISTRAL_DEFAULT_BASE_URL = "https://api.mistral.ai"` defined in `backend/airweave/core/config/settings.py` (re-exported from `airweave.core.config`). This keeps the production endpoint visible in the source rather than depending on the SDK's internal default, and gives us a single seam to layer per-adapter version overrides on later if needed.

## Why

We want to route Mistral SDK calls (embeddings, OCR, chat) to a self-hosted Mistral endpoint or a corporate proxy without forking the codebase. The existing `MISTRAL_API_KEY` setting covers credentials but the base URL was hardcoded by the SDK default (`https://api.mistral.ai`).

## Behavior

- **Unset (default):** identical to today — every Mistral client is constructed with `server_url=MISTRAL_DEFAULT_BASE_URL`, which matches what the SDK was using implicitly. No deployment changes required.
- **Set:** every Mistral client is constructed with `server_url=settings.MISTRAL_BASE_URL`, including the OCR pipeline, the dense embedder pool, and the chat LLM provider.

## Naming

`MISTRAL_BASE_URL` mirrors the existing `DOCLING_BASE_URL` convention in `settings.py`. The `MistralDenseEmbedder` constructor exposes it as `server_url` to match the underlying SDK kwarg.

## Tests

- `backend/tests/unit/core/test_dense_embedder_factory.py` — added `MISTRAL_BASE_URL=None` to the test settings fixture so the new factory wiring is exercised.
- All Mistral-touching unit tests pass locally (66 passed):
  - `backend/airweave/domains/embedders/dense/tests/test_mistral.py`
  - `backend/airweave/adapters/llm/tests/test_mistral.py`
  - `backend/airweave/domains/ocr/tests/test_retry_predicate.py`
  - `backend/tests/unit/core/test_dense_embedder_factory.py`
  - `backend/tests/unit/core/test_embedding_validation.py`

## Docs

- `.env.example` updated with the new (commented-out) option.
- `Settings` docstring in `backend/airweave/core/config/settings.py` documents the new field.