### PR TITLE
fix(webhooks): require privileged org role for webhook management

### DIFF
--- a/backend/airweave/api/v1/endpoints/webhooks.py
+++ b/backend/airweave/api/v1/endpoints/webhooks.py
@@ -18,6 +18,7 @@ from airweave.api import deps
 from airweave.api.context import ApiContext
 from airweave.api.deps import Inject
 from airweave.core.protocols import WebhookServiceProtocol
+from airweave.domains.organizations import logic
 from airweave.domains.webhooks import WebhooksError
 from airweave.domains.webhooks.types import compute_health_status
 from airweave.schemas.webhooks import (
@@ -57,7 +58,7 @@ such as `sync.completed` or `sync.failed`.""",
     },
 )
 async def get_messages(
-    ctx: ApiContext = Depends(deps.get_context),
+    ctx: ApiContext = deps.require_org_role(logic.can_manage_webhooks, block_api_key_auth=True),
     webhook_service: WebhookServiceProtocol = Inject(WebhookServiceProtocol),
     event_types: List[str] | None = Query(
         default=None,
@@ -106,7 +107,7 @@ async def get_message(
         description="Include delivery attempts for this message. Each attempt includes "
         "the HTTP response code, response body, and timestamp.",
     ),
-    ctx: ApiContext = Depends(deps.get_context),
+    ctx: ApiContext = deps.require_org_role(logic.can_manage_webhooks, block_api_key_auth=True),
     webhook_service: WebhookServiceProtocol = Inject(WebhookServiceProtocol),
 ) -> WebhookMessageWithAttempts:
     """Retrieve a specific event message by ID."""
@@ -141,7 +142,7 @@ your webhook configuration or find a specific subscription.""",
     },
 )
 async def get_subscriptions(
-    ctx: ApiContext = Depends(deps.get_context),
+    ctx: ApiContext = deps.require_org_role(logic.can_manage_webhooks, block_api_key_auth=True),
     webhook_service: WebhookServiceProtocol = Inject(WebhookServiceProtocol),
 ) -> List[WebhookSubscription]:
     """List all webhook subscriptions for the organization."""
@@ -188,7 +189,7 @@ async def get_subscription(
         description="Include the signing secret for webhook signature verification. "
         "Keep this secret secure and use it to verify the 'svix-signature' header.",
     ),
-    ctx: ApiContext = Depends(deps.get_context),
+    ctx: ApiContext = deps.require_org_role(logic.can_manage_webhooks, block_api_key_auth=True),
     webhook_service: WebhookServiceProtocol = Inject(WebhookServiceProtocol),
 ) -> WebhookSubscriptionDetail:
     """Retrieve a specific webhook subscription with delivery attempts."""
@@ -231,7 +232,7 @@ matching events occur. Each request includes a signature header for verification
 )
 async def create_subscription(
     request: CreateSubscriptionRequest,
-    ctx: ApiContext = Depends(deps.get_context),
+    ctx: ApiContext = deps.require_org_role(logic.can_manage_webhooks, block_api_key_auth=True),
     webhook_service: WebhookServiceProtocol = Inject(WebhookServiceProtocol),
 ) -> WebhookSubscription:
     """Create a new webhook subscription."""
@@ -282,7 +283,7 @@ async def delete_subscription(
         description="The unique identifier of the subscription to delete (UUID).",
         json_schema_extra={"example": "550e8400-e29b-41d4-a716-446655440000"},
     ),
-    ctx: ApiContext = Depends(deps.get_context),
+    ctx: ApiContext = deps.require_org_role(logic.can_manage_webhooks, block_api_key_auth=True),
     webhook_service: WebhookServiceProtocol = Inject(WebhookServiceProtocol),
 ) -> WebhookSubscription:
     """Delete a webhook subscription permanently."""
@@ -332,7 +333,7 @@ async def patch_subscription(
         json_schema_extra={"example": "550e8400-e29b-41d4-a716-446655440000"},
     ),
     request: PatchSubscriptionRequest = ...,
-    ctx: ApiContext = Depends(deps.get_context),
+    ctx: ApiContext = deps.require_org_role(logic.can_manage_webhooks, block_api_key_auth=True),
     webhook_service: WebhookServiceProtocol = Inject(WebhookServiceProtocol),
 ) -> WebhookSubscription:
     """Update an existing webhook subscription."""
@@ -392,7 +393,7 @@ async def recover_failed_messages(
         json_schema_extra={"example": "550e8400-e29b-41d4-a716-446655440000"},
     ),
     request: RecoverMessagesRequest = ...,
-    ctx: ApiContext = Depends(deps.get_context),
+    ctx: ApiContext = deps.require_org_role(logic.can_manage_webhooks, block_api_key_auth=True),
     webhook_service: WebhookServiceProtocol = Inject(WebhookServiceProtocol),
 ) -> RecoveryTask:
     """Retry failed message deliveries for a subscription."""

--- a/backend/tests/integration/api/test_webhooks_api.py
+++ b/backend/tests/integration/api/test_webhooks_api.py
@@ -11,10 +11,50 @@ Fixtures used:
 """
 
 from datetime import datetime, timezone
+from uuid import uuid4
 
 import pytest
 
+from airweave import schemas
+from airweave.api.context import ApiContext
+from airweave.api.deps import get_context
+from airweave.core.logging import logger
+from airweave.core.shared_models import AuthMethod
 from airweave.domains.webhooks.types import EventMessage
+from airweave.main import app
+from airweave.schemas.organization import Organization
+
+
+def _override_context(role: str) -> None:
+    now = datetime.now(timezone.utc)
+    org_id = uuid4()
+    org = Organization(id=org_id, name="Test Organization", created_at=now, modified_at=now)
+    user = schemas.User(
+        id=uuid4(),
+        email=f"{role}@example.com",
+        full_name=f"{role.title()} User",
+        primary_organization_id=org_id,
+        user_organizations=[
+            schemas.UserOrganization(
+                role=role,
+                is_primary=True,
+                user_id=uuid4(),
+                organization_id=org_id,
+                organization=org,
+            )
+        ],
+        is_admin=(role == "admin"),
+        is_superuser=False,
+    )
+    ctx = ApiContext(
+        request_id=f"webhooks-{role}",
+        organization=org,
+        user=user,
+        auth_method=AuthMethod.AUTH0,
+        auth_metadata={"test": True},
+        logger=logger.with_context(request_id=f"webhooks-{role}"),
+    )
+    app.dependency_overrides[get_context] = lambda: ctx
 
 
 class TestWebhookSubscriptionsAPI:
@@ -26,12 +66,14 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_list_subscriptions_empty(self, client):
+        _override_context("admin")
         response = await client.get("/webhooks/subscriptions")
         assert response.status_code == 200
         assert response.json() == []
 
     @pytest.mark.asyncio
     async def test_list_subscriptions_after_create(self, client, fake_webhook_service):
+        _override_context("admin")
         payload = {
             "url": "https://example.com/hook",
             "event_types": ["sync.completed"],
@@ -55,6 +97,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_create_subscription(self, client, fake_webhook_service):
+        _override_context("admin")
         payload = {
             "url": "https://example.com/webhook",
             "event_types": ["sync.completed", "sync.failed"],
@@ -75,6 +118,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_create_subscription_with_custom_secret(self, client):
+        _override_context("admin")
         payload = {
             "url": "https://example.com/webhook",
             "event_types": ["sync.completed"],
@@ -85,6 +129,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_create_subscription_invalid_event_type(self, client):
+        _override_context("admin")
         payload = {
             "url": "https://example.com/webhook",
             "event_types": ["invalid.event.type"],
@@ -94,6 +139,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_create_subscription_empty_event_types(self, client):
+        _override_context("admin")
         payload = {
             "url": "https://example.com/webhook",
             "event_types": [],
@@ -103,6 +149,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_create_subscription_short_secret(self, client):
+        _override_context("admin")
         payload = {
             "url": "https://example.com/webhook",
             "event_types": ["sync.completed"],
@@ -113,6 +160,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_create_subscription_invalid_url(self, client):
+        _override_context("admin")
         payload = {
             "url": "not-a-url",
             "event_types": ["sync.completed"],
@@ -126,6 +174,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_get_subscription_by_id(self, client, fake_webhook_service):
+        _override_context("admin")
         # Create first
         create_resp = await client.post(
             "/webhooks/subscriptions",
@@ -152,6 +201,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_get_subscription_with_secret(self, client, fake_webhook_service):
+        _override_context("admin")
         create_resp = await client.post(
             "/webhooks/subscriptions",
             json={
@@ -168,6 +218,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_get_nonexistent_subscription(self, client):
+        _override_context("admin")
         response = await client.get("/webhooks/subscriptions/nonexistent-id")
         assert response.status_code == 500  # KeyError from fake
 
@@ -177,6 +228,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_delete_subscription(self, client, fake_webhook_service):
+        _override_context("admin")
         # Create
         create_resp = await client.post(
             "/webhooks/subscriptions",
@@ -203,6 +255,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_update_subscription_url(self, client, fake_webhook_service):
+        _override_context("admin")
         create_resp = await client.post(
             "/webhooks/subscriptions",
             json={
@@ -221,6 +274,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_disable_subscription(self, client, fake_webhook_service):
+        _override_context("admin")
         create_resp = await client.post(
             "/webhooks/subscriptions",
             json={
@@ -239,6 +293,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_reenable_subscription(self, client, fake_webhook_service):
+        _override_context("admin")
         create_resp = await client.post(
             "/webhooks/subscriptions",
             json={
@@ -264,6 +319,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_update_event_types(self, client, fake_webhook_service):
+        _override_context("admin")
         create_resp = await client.post(
             "/webhooks/subscriptions",
             json={
@@ -290,6 +346,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_recover_messages(self, client, fake_webhook_service):
+        _override_context("admin")
         create_resp = await client.post(
             "/webhooks/subscriptions",
             json={
@@ -310,6 +367,7 @@ class TestWebhookSubscriptionsAPI:
 
     @pytest.mark.asyncio
     async def test_recover_messages_with_until(self, client, fake_webhook_service):
+        _override_context("admin")
         create_resp = await client.post(
             "/webhooks/subscriptions",
             json={
@@ -329,17 +387,44 @@ class TestWebhookSubscriptionsAPI:
         assert response.status_code == 200
 
 
+    @pytest.mark.asyncio
+    async def test_member_cannot_create_subscription(self, client):
+        _override_context("member")
+        response = await client.post(
+            "/webhooks/subscriptions",
+            json={"url": "https://example.com/webhook", "event_types": ["sync.completed"]},
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Insufficient permissions for this operation"
+
+    @pytest.mark.asyncio
+    async def test_member_cannot_get_subscription_secret(self, client):
+        _override_context("admin")
+        create_resp = await client.post(
+            "/webhooks/subscriptions",
+            json={"url": "https://example.com/hook", "event_types": ["sync.completed"]},
+        )
+        sub_id = create_resp.json()["id"]
+
+        _override_context("member")
+        response = await client.get(f"/webhooks/subscriptions/{sub_id}?include_secret=true")
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Insufficient permissions for this operation"
+
+
 class TestWebhookMessagesAPI:
     """Tests for /webhooks/messages endpoints."""
 
     @pytest.mark.asyncio
     async def test_list_messages_empty(self, client):
+        _override_context("admin")
         response = await client.get("/webhooks/messages")
         assert response.status_code == 200
         assert response.json() == []
 
     @pytest.mark.asyncio
     async def test_list_messages_with_data(self, client, fake_webhook_service):
+        _override_context("admin")
         now = datetime.now(timezone.utc)
         fake_webhook_service._admin.messages.append(
             EventMessage(
@@ -367,6 +452,7 @@ class TestWebhookMessagesAPI:
 
     @pytest.mark.asyncio
     async def test_list_messages_filtered_by_event_type(self, client, fake_webhook_service):
+        _override_context("admin")
         now = datetime.now(timezone.utc)
         fake_webhook_service._admin.messages.extend(
             [
@@ -393,6 +479,7 @@ class TestWebhookMessagesAPI:
 
     @pytest.mark.asyncio
     async def test_get_message_by_id(self, client, fake_webhook_service):
+        _override_context("admin")
         now = datetime.now(timezone.utc)
         fake_webhook_service._admin.messages.append(
             EventMessage(
@@ -412,6 +499,7 @@ class TestWebhookMessagesAPI:
 
     @pytest.mark.asyncio
     async def test_get_message_with_attempts(self, client, fake_webhook_service):
+        _override_context("admin")
         now = datetime.now(timezone.utc)
         fake_webhook_service._admin.messages.append(
             EventMessage(
@@ -430,5 +518,6 @@ class TestWebhookMessagesAPI:
 
     @pytest.mark.asyncio
     async def test_get_nonexistent_message(self, client):
+        _override_context("admin")
         response = await client.get("/webhooks/messages/nonexistent-id")
         assert response.status_code == 500  # KeyError from fake


### PR DESCRIPTION
## Problem

Webhook management routes were wired directly to `deps.get_context` even though the repo already defines `logic.can_manage_webhooks(role)` for privileged users. Pre-patch, any authenticated organization member could create, update, or delete webhook subscriptions and call `include_secret=true` to retrieve the signing secret.

That lets low-privilege users redirect deliveries to attacker-controlled endpoints, disable legitimate subscriptions, or exfiltrate the shared secret used by downstream consumers to verify events.

## Fix

Apply the existing privileged-role policy at the API boundary:

- replace plain `get_context` dependencies in webhook routes with `deps.require_org_role(logic.can_manage_webhooks, block_api_key_auth=True)`
- add regression coverage for member-denied webhook creation and secret retrieval

## Test Plan
- [ ] Admin users can still create/read/update/delete webhook subscriptions
- [ ] Member users now receive 403 on webhook management routes
- [ ] Member users cannot retrieve signing secrets with `include_secret=true`
- [ ] Webhook message visibility remains aligned with the privileged role policy

## Security Note

Severity: **Medium**.

`SECURITY.md` asks for private reporting and says not to disclose publicly. This PR body is prepared for operator approval only and should not be submitted automatically without a conscious disclosure decision.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a privileged org role for all webhook management and message endpoints, and block API key auth. This closes a gap that let members create/modify subscriptions or read signing secrets.

- **Bug Fixes**
  - Gate all webhook routes with `deps.require_org_role(logic.can_manage_webhooks, block_api_key_auth=True)`.
  - Add tests to ensure members get 403 on management routes and `include_secret=true`, while admins still succeed.

<sup>Written for commit 2c17bbfec9e5a63d5dcc24d8ea5f53ee2adcbfcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

