### PR TITLE
fix: update Composio dashboard URL

### DIFF
--- a/backend/airweave/domains/auth_provider/providers/composio.py
+++ b/backend/airweave/domains/auth_provider/providers/composio.py
@@ -30,7 +30,7 @@ from airweave.platform.decorators import auth_provider
 class ComposioAuthProvider(BaseAuthProvider):
     """Composio authentication provider."""
 
-    SETTINGS_URL = "https://platform.composio.dev/"
+    SETTINGS_URL = "https://dashboard.composio.dev/"
 
     # Sources that Composio does not support
     BLOCKED_SOURCES = [

--- a/backend/airweave/domains/auth_provider/tests/test_registry_settings_url.py
+++ b/backend/airweave/domains/auth_provider/tests/test_registry_settings_url.py
@@ -25,8 +25,8 @@ def _stub_entry(short_name: str, settings_url: str = "") -> AuthProviderRegistry
 
 def test_get_settings_url_returns_url():
     reg = AuthProviderRegistry()
-    reg._entries["composio"] = _stub_entry("composio", "https://platform.composio.dev/")
-    assert reg.get_settings_url("composio") == "https://platform.composio.dev/"
+    reg._entries["composio"] = _stub_entry("composio", "https://dashboard.composio.dev/")
+    assert reg.get_settings_url("composio") == "https://dashboard.composio.dev/"
 
 
 def test_get_settings_url_empty_returns_none():

--- a/backend/airweave/domains/source_connections/tests/test_response.py
+++ b/backend/airweave/domains/source_connections/tests/test_response.py
@@ -1502,7 +1502,7 @@ async def test_resolve_provider_info_returns_url_and_short_name():
     from unittest.mock import AsyncMock, MagicMock
 
     registry = MagicMock()
-    registry.get_settings_url.return_value = "https://platform.composio.dev/"
+    registry.get_settings_url.return_value = "https://dashboard.composio.dev/"
 
     conn = SimpleNamespace(short_name="composio")
     conn_repo = FakeConnectionRepository()
@@ -1519,7 +1519,7 @@ async def test_resolve_provider_info_returns_url_and_short_name():
     )
     sc = _make_source_conn(readable_auth_provider_id="my-composio")
     result = await builder._resolve_provider_info(AsyncMock(), sc, _make_ctx())
-    assert result.settings_url == "https://platform.composio.dev/"
+    assert result.settings_url == "https://dashboard.composio.dev/"
     assert result.short_name == "composio"
     registry.get_settings_url.assert_called_once_with("composio")
 

--- a/fern/docs/pages/auth-providers/composio.mdx
+++ b/fern/docs/pages/auth-providers/composio.mdx
@@ -28,7 +28,7 @@ Composio enables Airweave to access credentials from integrated applications. Wh
 <Steps>
 
   <Step title="Get your Composio API Key" toc={true}>
-    1. Log in to your [Composio dashboard](https://platform.composio.dev) and navigate to your Project.
+    1. Log in to your [Composio dashboard](https://dashboard.composio.dev) and navigate to your Project.
     2. Go to your Project settings.
     3. Copy your API key from the Project API Keys.
 

--- a/frontend/src/components/auth-providers/ConfigureAuthProviderView.tsx
+++ b/frontend/src/components/auth-providers/ConfigureAuthProviderView.tsx
@@ -576,7 +576,7 @@ export const ConfigureAuthProviderView: React.FC<ConfigureAuthProviderViewProps>
                                                         <button
                                                             onClick={() => {
                                                                 const url = authProviderShortName === 'composio'
-                                                                    ? 'https://platform.composio.dev/'
+                                                                    ? 'https://dashboard.composio.dev/'
                                                                     : 'https://pipedream.com/settings/api';
                                                                 window.open(url, '_blank');
                                                             }}

--- a/frontend/src/components/creation-views/AuthProviderSelector.tsx
+++ b/frontend/src/components/creation-views/AuthProviderSelector.tsx
@@ -193,7 +193,7 @@ export const AuthProviderSelector: React.FC<AuthProviderSelectorProps> = ({
                     <button
                       onClick={() => {
                         const url = selectedProviderConnection.short_name === 'composio'
-                          ? 'https://platform.composio.dev/'
+                          ? 'https://dashboard.composio.dev/'
                           : 'https://pipedream.com/';
                         window.open(url, '_blank');
                       }}


### PR DESCRIPTION
## Summary
- replace deprecated platform.composio.dev links with dashboard.composio.dev
- update Composio auth provider settings URL, frontend fallbacks, docs, and tests

## Verification
- git diff --check
- targeted pytest not run: poetry is not installed in this environment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the deprecated Composio URL with the new dashboard URL to prevent broken links and keep the app and docs current.

- **Bug Fixes**
  - Updated `ComposioAuthProvider.SETTINGS_URL` to `https://dashboard.composio.dev/`.
  - Updated Composio links in `ConfigureAuthProviderView` and `AuthProviderSelector`.
  - Updated docs and tests to reference `https://dashboard.composio.dev`.

<sup>Written for commit 3f46f6e002e3de384d5ac7c402752147654b04cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

