### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/airweave-ai-airweave)
+
 <p align="center">
   <a href="https://app.airweave.ai" target="_blank" rel="noopener noreferrer">
     <picture>


### PR DESCRIPTION
Hi! 👋 **airweave** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/airweave-ai-airweave

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building airweave! 🙏

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Listed on TakoAPI" badge at the top of the README, linking to the project's TakoAPI directory listing. Improves discoverability via the open agent directory.

<sup>Written for commit 644d2619f71b1bfb1e0158678349dbea76c6783d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

