### PR TITLE
feat(search-llm): support Claude via AWS Bedrock (opt-in)

### DIFF
--- a/backend/airweave/adapters/llm/anthropic.py
+++ b/backend/airweave/adapters/llm/anthropic.py
@@ -13,7 +13,7 @@ import json
 import time
 from typing import Any, TypeVar
 
-from anthropic import AsyncAnthropic
+from anthropic import AsyncAnthropic, AsyncAnthropicBedrock
 from pydantic import BaseModel
 
 from airweave.adapters.llm.base import BaseLLM
@@ -36,26 +36,54 @@ class AnthropicLLM(BaseLLM):
         model_spec: LLMModelSpec,
         max_retries: int | None = None,
     ) -> None:
-        """Initialize the Anthropic LLM client with API key validation."""
+        """Initialize the Anthropic LLM client (direct API or AWS Bedrock)."""
         super().__init__(model_spec, max_retries=max_retries)
 
-        api_key = settings.ANTHROPIC_API_KEY
-        if not api_key:
-            raise ValueError(
-                "ANTHROPIC_API_KEY not configured. Set it in your environment or .env file."
-            )
-
-        try:
-            self._client = AsyncAnthropic(api_key=api_key, timeout=self.DEFAULT_TIMEOUT)
-        except Exception as e:
-            raise RuntimeError(f"Failed to initialize Anthropic client: {e}") from e
+        # Bedrock mode: talk to Claude through AWS Bedrock instead of the direct
+        # Anthropic API. AWS credentials come from the botocore default chain;
+        # the model id is overridden with the Bedrock inference-profile id.
+        if settings.ANTHROPIC_USE_BEDROCK:
+            model = settings.AWS_BEDROCK_MODEL
+            if not model:
+                raise ValueError(
+                    "ANTHROPIC_USE_BEDROCK is true but AWS_BEDROCK_MODEL is not set. "
+                    "Set it to the Bedrock model / inference-profile id "
+                    "(e.g. 'us.anthropic.claude-sonnet-4-6')."
+                )
+            self._model_name = model
+            region = settings.BEDROCK_AWS_REGION or settings.STORAGE_AWS_REGION
+            # Prefer explicit static IAM keys when configured; otherwise let the
+            # SDK resolve credentials via the botocore chain (AWS_PROFILE / SSO).
+            bedrock_kwargs: dict[str, Any] = {
+                "aws_region": region,
+                "timeout": self.DEFAULT_TIMEOUT,
+            }
+            if settings.AWS_BEDROCK_ACCESS_ID and settings.AWS_BEDROCK_SECRET:
+                bedrock_kwargs["aws_access_key"] = settings.AWS_BEDROCK_ACCESS_ID
+                bedrock_kwargs["aws_secret_key"] = settings.AWS_BEDROCK_SECRET
+            try:
+                self._client = AsyncAnthropicBedrock(**bedrock_kwargs)
+            except Exception as e:
+                raise RuntimeError(f"Failed to initialize Anthropic Bedrock client: {e}") from e
+        else:
+            api_key = settings.ANTHROPIC_API_KEY
+            if not api_key:
+                raise ValueError(
+                    "ANTHROPIC_API_KEY not configured. Set it in your environment or .env file."
+                )
+            self._model_name = model_spec.api_model_name
+            try:
+                self._client = AsyncAnthropic(api_key=api_key, timeout=self.DEFAULT_TIMEOUT)
+            except Exception as e:
+                raise RuntimeError(f"Failed to initialize Anthropic client: {e}") from e
 
         self._effort = model_spec.thinking_config.effort  # e.g., "high"
 
         thinking_mode = f"adaptive (effort={self._effort})" if self._effort else "on-demand"
 
         self._logger.debug(
-            f"[AnthropicLLM] Initialized model={model_spec.api_model_name}, "
+            f"[AnthropicLLM] Initialized model={self._model_name}, "
+            f"bedrock={settings.ANTHROPIC_USE_BEDROCK}, "
             f"context={model_spec.context_window}, "
             f"max_output={model_spec.max_output_tokens}, "
             f"thinking={thinking_mode}"
@@ -81,7 +109,7 @@ class AnthropicLLM(BaseLLM):
 
         api_start = time.monotonic()
         response = await self._client.messages.create(  # type: ignore[call-overload]
-            model=self._model_spec.api_model_name,
+            model=self._model_name,
             max_tokens=self._model_spec.max_output_tokens,
             system=system_prompt,
             messages=[{"role": "user", "content": prompt}],
@@ -153,7 +181,7 @@ class AnthropicLLM(BaseLLM):
 
         # Build API kwargs
         kwargs: dict[str, Any] = {
-            "model": self._model_spec.api_model_name,
+            "model": self._model_name,
             "max_tokens": max_tokens or self._model_spec.max_output_tokens,
             "system": cached_system,
             "messages": anthropic_messages,

--- a/backend/airweave/core/config/settings.py
+++ b/backend/airweave/core/config/settings.py
@@ -204,6 +204,23 @@ class Settings(BaseSettings):
 
     OPENAI_API_KEY: Optional[str] = None
     ANTHROPIC_API_KEY: Optional[str] = None
+    # When true, the Anthropic search adapter talks to AWS Bedrock via
+    # AsyncAnthropicBedrock instead of the direct Anthropic API. AWS credentials
+    # are resolved by the standard botocore chain (AWS_ACCESS_KEY_ID /
+    # AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN, SSO, or instance profile).
+    ANTHROPIC_USE_BEDROCK: bool = False
+    # Bedrock model / inference-profile id used when ANTHROPIC_USE_BEDROCK is
+    # true (e.g. "us.anthropic.claude-sonnet-4-6"). Overrides the registry's
+    # api_model_name for the Anthropic provider.
+    AWS_BEDROCK_MODEL: Optional[str] = None
+    # AWS region for Bedrock (e.g. "us-east-1"). Falls back to STORAGE_AWS_REGION
+    # and then the botocore default when unset.
+    BEDROCK_AWS_REGION: Optional[str] = None
+    # Optional static IAM credentials for Bedrock. When both are set they are
+    # passed explicitly to the Bedrock client; otherwise the standard botocore
+    # chain is used (AWS_PROFILE / SSO / instance profile).
+    AWS_BEDROCK_ACCESS_ID: Optional[str] = None
+    AWS_BEDROCK_SECRET: Optional[str] = None
     MISTRAL_API_KEY: Optional[str] = None
     MISTRAL_BASE_URL: Optional[str] = None
     FIRECRAWL_API_KEY: Optional[str] = None

--- a/backend/airweave/core/container/factory.py
+++ b/backend/airweave/core/container/factory.py
@@ -1215,7 +1215,10 @@ def _build_llm_chain(
     available = []
     for provider, model in config.LLM_FALLBACK_CHAIN:
         api_key_attr = PROVIDER_API_KEY_SETTINGS.get(provider)
-        if api_key_attr and not getattr(settings, api_key_attr, None):
+        # Anthropic via Bedrock authenticates with AWS credentials, not
+        # ANTHROPIC_API_KEY — treat it as configured when Bedrock is enabled.
+        bedrock_ok = provider == LLMProvider.ANTHROPIC and settings.ANTHROPIC_USE_BEDROCK
+        if api_key_attr and not getattr(settings, api_key_attr, None) and not bedrock_ok:
             logger.debug(f"[SearchFactory] Skipping {provider.value}: no API key")
             continue
 


### PR DESCRIPTION
## Summary
Adds an **opt-in** path for the search LLM to reach Claude through **AWS Bedrock** instead of the direct Anthropic API, for deployments standardized on Bedrock. Disabled by default — direct-API behavior is unchanged when `ANTHROPIC_USE_BEDROCK` is off.

## Changes
- **settings**: `ANTHROPIC_USE_BEDROCK`, `AWS_BEDROCK_MODEL` (e.g. `us.anthropic.claude-sonnet-4-6`), `BEDROCK_AWS_REGION`, and optional static `AWS_BEDROCK_ACCESS_ID`/`AWS_BEDROCK_SECRET`.
- **AnthropicLLM adapter**: when enabled, uses `AsyncAnthropicBedrock` (already provided by `anthropic>=0.86`, and `aioboto3` is already a dependency) with either explicit static IAM keys or the standard botocore credential chain (`AWS_PROFILE`/SSO/instance profile); the Bedrock inference-profile id overrides the registry model name. Falls back to `AsyncAnthropic` when Bedrock is off.
- **container factory**: `_build_llm_chain` treats the Anthropic provider as available under Bedrock even without `ANTHROPIC_API_KEY`.

## Test plan
- With `ANTHROPIC_USE_BEDROCK=true` + valid AWS creds, `classic`/`agentic` search returns answers via Bedrock (verified end-to-end against `us.anthropic.claude-sonnet-4-6` in us-west-2).
- With the flag off, the adapter uses the direct Anthropic API exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in path for the search LLM to use Claude via AWS Bedrock. Default behavior stays the same; direct Anthropic API is used unless enabled.

- New Features
  - Routes Claude requests through `AWS Bedrock` via `AsyncAnthropicBedrock` when `ANTHROPIC_USE_BEDROCK=true`; model set by `AWS_BEDROCK_MODEL`.
  - Uses the default AWS credential chain or static `AWS_BEDROCK_ACCESS_ID`/`AWS_BEDROCK_SECRET`; supports `BEDROCK_AWS_REGION`.
  - Treats Anthropic as available under Bedrock without `ANTHROPIC_API_KEY`; falls back to `AsyncAnthropic` when disabled.

<sup>Written for commit 42150834465280c4e6acf3c9680216166b1c16dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

