### PR TITLE
fix(embeddings): probe weaviate transformers readiness at /.well-known/ready

### DIFF
--- a/backend/airweave/domains/embedders/config.py
+++ b/backend/airweave/domains/embedders/config.py
@@ -148,7 +148,7 @@ def _validate_credentials(
 def _validate_local_reachability(dense_spec: DenseEmbedderEntry) -> None:
     """Probe the text2vec inference service when using the local dense embedder.
 
-    Only runs for local_minilm. Performs a synchronous HTTP GET to the health
+    Only runs for local_minilm. Performs a synchronous HTTP GET to the readiness
     endpoint with a short timeout. Raises EmbeddingConfigError with actionable
     instructions if the service is unreachable.
     """
@@ -158,11 +158,13 @@ def _validate_local_reachability(dense_spec: DenseEmbedderEntry) -> None:
         return
 
     inference_url = settings.TEXT2VEC_INFERENCE_URL
-    health_url = f"{inference_url}/health"
+    # The text2vec-transformers (Weaviate) image exposes readiness at
+    # /.well-known/ready (HTTP 204), not /health.
+    readiness_url = f"{inference_url}/.well-known/ready"
 
     try:
         with httpx.Client(timeout=httpx.Timeout(5.0)) as client:
-            response = client.get(health_url)
+            response = client.get(readiness_url)
             response.raise_for_status()
     except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError) as exc:
         raise EmbeddingConfigError(

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -157,7 +157,9 @@ services:
       ENABLE_CUDA: 0
       WORKERS_PER_NODE: 1
     healthcheck:
-      test: [ "CMD", "wget", "--spider", "-q", "http://localhost:8080/health" ]
+      # Weaviate transformers-inference exposes readiness at /.well-known/ready (204), not /health.
+      # This image ships no curl/wget, so probe with python3 (urllib raises on non-2xx).
+      test: [ "CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/.well-known/ready')" ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
The `text2vec-transformers` (Weaviate) image exposes readiness at **`/.well-known/ready`** (HTTP 204), not `/health`, and ships **no curl/wget**. Both the startup credential probe for the local dense embedder and the compose healthcheck were hitting `/health`, which never succeeds — so the local embedder was reported unreachable on a clean local stack.

## Changes
- `domains/embedders/config.py`: probe `/.well-known/ready` instead of `/health`.
- `docker/docker-compose.yml`: healthcheck uses `python3` + `urllib` against the readiness endpoint (the image has no curl/wget).

## Test plan
`./start.sh` with `DENSE_EMBEDDER=local_minilm` — the text2vec service becomes healthy and the backend passes the embedder reachability check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `/.well-known/ready` (204) for the Weaviate `text2vec-transformers` readiness probe instead of `/health`, so the local dense embedder is detected as reachable. The docker healthcheck now uses `python3` + `urllib` since the image ships without curl/wget.

<sup>Written for commit eb39e1b696dc9d44339fa234f87dddcdf6b18492. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

