### PR TITLE
fix(oauth1): support custom (BYOC) credentials for OAuth1 sources on self-hosted

### DIFF
--- a/backend/airweave/domains/oauth/flow_service.py
+++ b/backend/airweave/domains/oauth/flow_service.py
@@ -272,7 +272,15 @@ class OAuthFlowService:
         """Exchange OAuth1 verifier for access token."""
         ctx.logger.info(f"Exchanging OAuth1 verifier for access token: {short_name}")
 
-        if not oauth_settings.consumer_secret:
+        # Prefer the consumer credentials captured at init time (BYOC / custom
+        # OAuth), which are persisted in the init-session overrides. The request-
+        # token step was signed with these, so the access-token step must use the
+        # same pair or the OAuth1 signature won't match ("Invalid Signature").
+        # Fall back to the platform-default settings for non-BYOC flows.
+        consumer_key = overrides.get("consumer_key") or oauth_settings.consumer_key
+        consumer_secret = overrides.get("consumer_secret") or oauth_settings.consumer_secret
+
+        if not consumer_secret:
             raise HTTPException(
                 status_code=400,
                 detail=f"Missing consumer_secret for OAuth1 source: {short_name}",
@@ -280,8 +288,8 @@ class OAuthFlowService:
 
         return await self._oauth1_service.exchange_token(
             access_token_url=oauth_settings.access_token_url,
-            consumer_key=oauth_settings.consumer_key,
-            consumer_secret=oauth_settings.consumer_secret,
+            consumer_key=consumer_key,
+            consumer_secret=consumer_secret,
             oauth_token=overrides.get("oauth_token", ""),
             oauth_token_secret=overrides.get("oauth_token_secret", ""),
             oauth_verifier=verifier,

--- a/backend/airweave/platform/configs/auth.py
+++ b/backend/airweave/platform/configs/auth.py
@@ -978,6 +978,10 @@ class TrelloAuthConfig(AuthConfig):
     """Trello authentication credentials schema.
 
     Trello uses OAuth1, which requires both a token and token secret.
+    The consumer key/secret (the OAuth1 client identity used to sign every API
+    request) are persisted here too — the OAuth browser flow fills them in.
+    Without them, request signing falls back to a placeholder and Trello
+    rejects every call with 401 "invalid key".
     """
 
     oauth_token: str = Field(
@@ -987,6 +991,16 @@ class TrelloAuthConfig(AuthConfig):
     oauth_token_secret: str = Field(
         title="OAuth Token Secret",
         description="The OAuth1 access token secret for Trello",
+    )
+    consumer_key: Optional[str] = Field(
+        default=None,
+        title="Consumer Key",
+        description="The OAuth1 consumer key (Trello API key) used to sign requests",
+    )
+    consumer_secret: Optional[str] = Field(
+        default=None,
+        title="Consumer Secret",
+        description="The OAuth1 consumer secret used to sign requests",
     )
 
 


### PR DESCRIPTION
## Summary
Fixes two bugs that break OAuth1 custom-credential (BYOC) sources — e.g. **Trello** — on self-hosted deployments.

**Bug 1 — access-token exchange signed with the wrong consumer secret.** `OAuthFlowService.complete_oauth1_callback` signed step 3 with the platform-default consumer credentials from the integration YAML, ignoring the BYOC `consumer_key`/`consumer_secret` captured at init. Step 1 (request token) *was* signed with the BYOC creds → signatures mismatch → **"Invalid Signature"**. Fixed by preferring the consumer credentials stored in the init-session `overrides`, falling back to platform defaults for non-BYOC flows.

**Bug 2 — TrelloAuthConfig drops the consumer key/secret.** `TrelloAuthConfig` only declared `oauth_token`/`oauth_token_secret`; validating the stored credential silently dropped `consumer_key`/`consumer_secret`, so at sync time the connector signed with a placeholder consumer key → **401 "invalid key"**. Fixed by declaring them (optional) on `TrelloAuthConfig`.

## Repro
Self-hosted, connect Trello via **Custom OAuth** (own API key/secret): before, the callback fails with "Invalid Signature"; adding the consumer key/secret then surfaces 401 "invalid key" at sync. Both fixes together make it sync.

## Test plan
- Trello Custom OAuth connect + sync succeeds end-to-end on self-hosted.
- Non-BYOC OAuth1 flows unaffected (exchange falls back to platform settings when overrides are absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth1 BYOC on self-hosted so sources like Trello can connect and sync. The access-token exchange now uses the user's consumer key/secret, and Trello credentials keep the consumer key/secret for signing.

- Bug Fixes
  - Use `consumer_key`/`consumer_secret` from init-session overrides for the OAuth1 access-token exchange, falling back to platform defaults when absent (prevents "Invalid Signature").
  - Add optional `consumer_key` and `consumer_secret` to `TrelloAuthConfig` so they persist and requests are signed with the correct key (avoids 401 "invalid key").

<sup>Written for commit 0267e89cc1e7bca30ebca54027d4a8c5afedfaa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/airweave-ai/airweave/pull/1816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

